### PR TITLE
1120 First Load

### DIFF
--- a/res/Sectors/M1120/1120_Spin.sec
+++ b/res/Sectors/M1120/1120_Spin.sec
@@ -1,0 +1,442 @@
+Hex  Name                 UWP       Remarks                                     {Ix}   (Ex)    [Cx]   N      B  Z PBG W  A    Stellar       
+---- -------------------- --------- ------------------------------------------- ------ ------- ------ ------ -- - --- -- ---- --------------
+0101 Zeycude              C430698-9 De Ni Na Po                                 { 0 }  (C53-1) [6659] -      KV - 613 8  ZhIN K9 V          
+0102 Reno                 C4207B9-A De He Na Pi Po Pz                           { 1 }  (C6A+2) [886B] -      -  A 603 12 ZhIN G8 V M1 V     
+0103 Errere               B563664-B Ni Ri O:0304                                { 2 }  (957+1) [4839] -      KM - 910 9  ZhIN M1 V M4 V     
+0104 Cantrel              C566243-9 Lo                                          { -1 } (611-4) [1126] -      -  - 520 12 ZhIN F1 V          
+0108 Gyomar               C8B2889-8 Fl He Ph (Tethmari)                         { -1 } (G77+1) [9769] -      -  - 824 14 NaHu A8 V          
+0202 Thengo               C868586-5 Ni Ag Pr                                    { -1 } (743-2) [4444] -      -  - 801 12 ZhIN G5 V M3 V     
+0301 Rio                  C686648-8 Ga Ni Ag Ri                                 { 0 }  (954+1) [6658] -      -  - 201 8  NaHu M0 V M1 V     
+0303 Gesentown            B31169B-C Ic Ni Na Da                                 { 1 }  (956+4) [877E] -      KM A 801 12 ZhIN M2 V M9 V     
+0304 Chronor              A6369A5-D Hi Cp                                       { 3 }  (C8G+2) [7C3B] -      KM - 810 5  ZhIN F8 V          
+0307 Atsa                 B4337CA-A Na Po Fo An                                 { 2 }  (A6C+5) [997C] -      KM R 810 8  ZhIN F7 V M3 V     
+0503 Whenge               D648500-8 Ni Ag                                       { -2 } (842-5) [1313] -      -  - 610 13 NaHu F8 V          
+0601 Enlas-du             E975776-6 Ag Pi                                       { -1 } (966-2) [6645] -      -  - 323 14 NaHu F1 V          
+0605 Algebaster           C665658-9 Ga Ni Ag Ri                                 { 1 }  (955+1) [6759] -      -  - 410 10 NaHu M0 V M1 V     
+0607 Rasatt               E883401-7 Ni                                          { -3 } (631-5) [1113] -      -  - 910 6  NaHu F0 V          
+0608 Ninjar               A311666-C Ic Ni Na Mr                                 { 1 }  (956+1) [574B] -      KM - 410 6  ZhIN A4 V          
+0610 Sheyou               B756779-A Ga Ag                                       { 3 }  (B6D+5) [8A6B] -      KM - 111 13 ZhIN F4 V M0 V     
+0703 Indo                 E434662-6 Ni Cy O:0605                                { -3 } (851-5) [2312] -      -  - 320 11 NaHu F6 V          
+0704 Nerewhon             E738475-7 Ni                                          { -3 } (631-5) [2135] -      -  - 820 10 NaHu K5 V          
+0705 Cipango              A886865-C Ga Ph Pa Ri O:0304                          { 3 }  (D7E+2) [6B3A] -      KM - 121 10 ZhIN G2 V          
+0710 Stave                E7667A8-2 Ga Ag Ri (Obeyery)                          { 0 }  (965+1) [7752] -      -  - 801 8  NaHu K9 V M2 V     
+0805 Narval               D525688-7 Ni Px                                       { -3 } (851-3) [6357] -      M  - 603 10 CsZh G4 V M6 V     
+0807 Plaven               E845300-5 Lo                                          { -3 } (521-5) [1111] -      -  - 910 6  NaHu G8 V M7 V     
+0808 Quar                 B532720-B Na Po                                       { 2 }  (A6C-2) [2916] -      N  - 401 9  ImDd M2 V          
+0810 Frond                E9C3300-9 Fl Lo                                       { -2 } (821-5) [1114] -      -  - 103 12 CsIm F8 V          
+0901 Condyole             E7A1522-8 Fl He Ni (Vexx)                             { -3 } (C41-5) [1214] -      -  - 923 10 NaHu F8 V          
+0902 Puparkin             C7B3386-9 Fl Lo Px Varg8                              { -1 } (721-2) [2248] -      -  - 502 6  NaHu K8 V M4 V     
+0904 Chwistyoch           B766766-A Ga Ag Ri Mr                                 { 4 }  (F6E+4) [6B49] -      KM - 424 15 ZhIN M2 V          
+0909 Gougeste             C572510-A He Ni                                       { 0 }  (944-4) [1515] -      -  - 420 10 CsIm K2 V          
+1004 Esalin               C565673-8 Ni Ag Ri                                    { 0 }  (D54-3) [3625] -      -  - 223 9  CsIm F3 V M2 V     
+1005 Ruby                 B400445-B Ni                                          { 1 }  (734-1) [2539] B      S  - 201 9  ImDd M1 V M3 V     
+1006 Emerald              B766555-B Ga Ni Ag Pr                                 { 2 }  (E46+1) [3739] BcC    S  - 534 12 ImDd M1 V          
+1010 Zenopit              D430546-7 De Ni Po                                    { -3 } (741-4) [4246] -      -  - 622 7  FdAr M3 V          
+1102 Riverland            C566A99-9 Hi                                          { 1 }  (H9B+2) [BB6A] -      -  - 214 14 ZhIN M2 V          
+1103 Clan                 B672899-A He Ph Pi                                    { 2 }  (B7C+4) [9A6B] -      KM - 901 12 ZhIN K8 V          
+1106 Jewell               A777999-C Hi In Cp                                    { 5 }  (G8G+5) [AE6D] BEf    NS - 623 10 ImDd G7 V          
+1110 Zircon               C792668-8 He Ni O:1011                                { -2 } (E52-2) [6458] -      M  - 624 12 FdAr F0 V          
+1201 Ao-dai               E410644-7 Ni Na                                       { -3 } (851-5) [4335] -      -  - 312 10 ZhIN K2 V M3 V     
+1204 Mongo                A568685-A Ni Ag Ri                                    { 4 }  (B58+2) [4A38] BCf    NS - 603 7  ImDd M6 III M0 V   
+1209 Utoland              C573464-7 Ni Re O:1011                                { -2 } (631-4) [2235] -      -  - 410 8  FdAr M0 V          
+1210 Pequan               E5656B9-4 Ni Ag Ri Da                                 { -1 } (853+1) [7565] -      -  A 710 5  FdAr K5 V          
+1305 Nakege               D591314-5 He Lo (minor)                               { -3 } (521-5) [1133] B      -  - 501 14 ImDd K2 V M0 V     
+1307 Lysen                B592655-A He Ni                                       { 1 }  (D55-1) [4738] B      S  - 623 12 ImDd M3 V          
+1401 Foelen               B638665-8 Ni (Chokari)4 Dolp2 O:1103                  { -1 } (953-3) [4536] -      -  - 910 14 ZhIN K0 V          
+1402 Farreach             A200400-B Ni                                          { 1 }  (C35-2) [1516] -      KM - 415 10 ZhIN M3 III M0 V   
+1510 871-438              E722000-0 He Ba Po                                    { -3 } (200-5) [0000] -      -  - 801 7  NaXX M3 V M8 V     
+1604 Louzy                D422A88-8 He Hi Na In Po                              { 0 }  (D99+1) [AA58] BE     -  - 110 7  ImDd M2 V          
+1607 Grant                X664100-3 Lo                                          { -3 } (301-5) [1111] -      -  R 222 13 ImDd K6 V          
+1705 Efate                A646930-D Hi In An                                    { 5 }  (B8H+1) [4E18] BEf    NW - 800 8  ImDd K4 V          
+1706 Alell                B56789C-A Ph Pa Ri Pz                                 { 3 }  (B7C+5) [BB8D] BcCe   -  A 410 6  ImDd M1 V M7 V     
+1802 Yres                 BAC6773-9 Fl                                          { 1 }  (H6A-2) [4826] B      -  - 335 13 ImDd G5 V          
+1803 Menorb               C652998-7 Hi Po                                       { 0 }  (B89+1) [9957] BE     -  - 310 7  ImDd K2 V          
+1805 Uakye                B439598-D Ni                                          { 1 }  (945+1) [565D] B      -  - 320 12 ImDd M3 V          
+1806 Whanga               E676126-7 Lo                                          { -3 } (301-4) [1146] B      -  - 224 14 ImDd G1 V M1 V     
+1807 Knorbes              E888765-2 Ag Ri An                                    { 0 }  (965-2) [5731] BC     -  - 834 15 ImDd G3 V          
+1808 Forboldn             D893614-5 Ni                                          { -3 } (851-5) [4333] B      -  - 312 14 ImDd G0 V          
+1809 Ruie                 C776977-7 Hi In Di (Daccamites)                       { 1 }  (B8A+1) [9A57] -      -  - 701 9  NaHu G5 V          
+1810 Jenghe               C799663-9 Ni Cy O:1910                                { -1 } (D53-4) [3526] B      S  - 323 11 ImDd M0 V          
+1903 Pixie                A100103-D Lo An                                       { 1 }  (401-2) [122A] B      N  - 901 15 ImDd K1 V M0 V     
+1904 Boughene             A8B3531-D Fl Ni An                                    { 1 }  (845-3) [1619] B      S  - 601 13 ImDd M1 V          
+1909 Hefry                C200423-7 Ni                                          { -2 } (631-5) [1224] B      S  - 320 13 ImDd K6 II M2 V    
+1910 Regina               A788899-C Ph Pa Ri Cp Sa Ab An (Amindii)2 Varg0 Asla0 { 4 }  (D7E+5) [9C6D] BcCeFG NS - 703 8  ImDd F7 V BD M3 V  
+2005 Feri                 B584879-B Ph Pa Ri                                    { 3 }  (C7D+4) [9B6C] BcCe   S  - 620 14 ImDd G4 V M3 V     
+2007 Roup                 C77A9A9-7 Wa Hi In                                    { 1 }  (B8A+2) [AA68] BE     S  - 323 14 ImDd F9 V          
+2106 Pscias               X555423-2 Ni Pa                                       { -3 } (631-5) [1121] -      -  R 501 15 ImDd K5 V          
+2110 Yori                 C560757-A De Ri An (Zhurphani)6 RsB                   { 2 }  (D6B+2) [795A] BC     -  - 713 15 ImDd F1 V          
+2201 Dentus               C979500-A Ni                                          { 0 }  (944-4) [1515] -      C  - 920 10 NaVa M2 V          
+2202 Kinorb               A663659-8 Ni Ri                                       { 0 }  (C54+1) [7669] -      -  - 622 7  NaVa G7 V          
+2204 Beck's World         D88349D-4 Ni Fo An                                    { -3 } (631+1) [8198] B      -  R 701 10 ImDd K0 V M2 V     
+2205 Enope                C411988-7 Ic Hi Na In                                 { 1 }  (B8A+1) [9A57] BE     -  - 600 8  ImDd K6 V M5 V     
+2207 Wochiers             EAC28CC-9 Fl He Ph Fo                                 { -1 } (D78+2) [B78C] Be     -  R 703 17 ImDd F0 V          
+2303 Yorbund              C7C6503-9 Fl Ni                                       { -1 } (943-4) [2426] -      -  - 220 9  NaVa M3 V          
+2306 Shionthy             C000742-8 As Na Pi An                                 { -1 } (E67-5) [3614] -      -  - 714 14 ImDd F6 V          
+2308 Algine               X766977-4 Ga Hi Pr                                    { -1 } (B86-1) [9854] -      -  R 723 11 ImDd G9 V          
+2309 Yurst                E7B4643-8 Fl Ni (Ursty)                               { -3 } (E51-5) [3325] B      -  - 824 13 ImDd K9 V          
+2402 Heya                 B687745-5 Ga Ag Ri                                    { 2 }  (969+1) [5933] -      -  - 734 16 NaVa K6 III M3 V   
+2405 Keng                 E5718CA-5 He Ph Pi Fo                                 { -2 } (A75+1) [A677] BDe    -  R 812 6  ImDd G5 V M9 V     
+2406 Moughas              CA5A588-B Oc Ni                                       { 0 }  (844+1) [555B] B      -  - 801 13 ImDd K9 V M9 V     
+2408 Rethe                E430AA8-8 De Hi Na Po                                 { -1 } (H98-1) [A958] BE     -  - 323 11 ImDd G7 V          
+2410 Inthe                B575776-9 Ag Pi An                                    { 3 }  (E6C+2) [6A48] BCD    NS - 423 8  ImDd F8 V          
+2509 Paya                 A655241-9 Ga Lo                                       { 0 }  (711-4) [1215] B      N  - 603 14 ImDd F3 V          
+2510 Dhian                C9A769D-8 Fl Ni Fo                                    { -2 } (A52+2) [A49C] B      -  R 202 13 ImDd K5 V          
+2602 Corfu                X895674-8 Ni Ag An                                    { -2 } (C53-3) [4436] -      -  R 222 7  NaVa M0 V          
+2607 Focaline             EA88544-7 Ni Ag Pr                                    { -2 } (742-4) [3335] -      -  - 724 11 NaVa F3 V          
+2701 Lablon               B646589-A Ni Ag                                       { 2 }  (A46+3) [676B] -      -  - 503 14 NaVa M2 III M4 V   
+2706 Heguz                E66A224-9 Wa Lo                                       { -2 } (511-4) [1137] -      -  - 510 10 NaVa K2 V M7 V     
+2708 Violante             C669452-A Ni                                          { 0 }  (833-4) [1416] -      -  - 420 10 NaVa G2 V          
+2905 Pavanne              C310425-A Ni                                          { 0 }  (934-5) [445A] -      -  - 425 12 NaVa M0 V          
+2906 Carsten              C427402-B Ni                                          { 0 }  (A33-4) [1417] -      -  - 804 15 NaVa M1 V          
+2908 Zila                 E556727-7 Ag                                          { -1 } (967-1) [7657] BC     -  - 701 8  ImDd K6 V M3 V     
+3001 Jesedipere           C775300-7 Lo Varg3                                    { -2 } (521-5) [1112] -      -  - 411 12 NaVa F4 V          
+3002 Yebab                C9A489A-8 Fl Ph (Ebokin)                              { -1 } (D77+1) [A77A] -      -  - 712 10 NaVa G9 V          
+3003 Nasemin              B98A422-B Wa Ni                                       { 1 }  (934-3) [1517] -      C  - 612 10 NaVa F5 V          
+3004 Zykoca               X994542-6 Ni Ag                                       { -2 } (742-5) [1312] -      -  R 320 12 NaVa K9 V          
+3005 Aramanx              B657974-7 Ga Hi                                       { 1 }  (B8A-1) [7A35] -      -  - 210 13 NaVa G0 V          
+3008 Pysadi               C5766D8-5 Ni Ag Da                                    { -1 } (853-1) [6555] -      -  A 201 8  NaVa F9 V M1 V     
+3010 L'oeul d'Dieu        B98A510-B Wa Ni Pr                                    { 1 }  (945-3) [1616] Bc     N  - 502 6  ImDd G1 V M9 V     
+3102 Rugbird              BAC5634-A Fl Ni                                       { 1 }  (A55-1) [4738] -      -  - 811 14 NaVa M1 V          
+3103 Towers               B544448-A Ni Pa                                       { 1 }  (E34+1) [455A] -      C  - 735 11 NaVa G8 V K6 V     
+3104 Feneteman            C422200-C He Lo Po                                    { 0 }  (511-4) [1217] -      -  - 910 4  NaVa G4 V M7 V     
+3107 Lewis                D427402-7 Ni                                          { -3 } (631-5) [1113] -      -  - 701 9  ImDd F8 V          
+3110 Aramis               A5A0556-B He Ni                                       { 2 }  (846+1) [474A] B      NS - 710 9  ImDd M2 V          
+3202 Junidy               B434ABD-B Hi Fo (Llellewyloly)5                       { 3 }  (D9F+5) [ED9F] -      C  R 310 17 NaVa F7 V M2 V     
+3207 Patinir              C000632-9 As Ni Na An                                 { -1 } (C53-5) [2515] B      -  - 223 15 ImDd F3 V          
+3209 Natoko               B582211-8 Lo                                          { -1 } (511-5) [1114] B      N  - 801 18 ImDd M2 V M6 V     
+3210 Reacher              C9A8542-8 Fl Ni                                       { -2 } (D42-5) [1314] B      -  - 233 12 ImDd G4 V          
+0111 Atson                B310598-8 Ni                                          { -1 } (D43-1) [5458] -      -  - 933 10 NaHu K8 V          
+0114 Yiktor               C6B6431-A Fl Ni                                       { 0 }  (B33-4) [1416] -      -  - 123 12 NaHu G4 V M4 V     
+0115 Xhosa                EA95124-5 Lo                                          { -3 } (301-5) [1133] -      -  - 910 8  NaHu M0 V          
+0212 Prinx                C436635-6 Ni                                          { -2 } (852-4) [4434] -      -  - 720 9  NaHu A9 V K8 V     
+0215 Rushu                E766674-4 Ga Ni Ag Ri VargW                           { -1 } (853-3) [4532] -      -  - 903 8  CsZh G0 V M3 V     
+0218 Bael                 E200100-8 Lo                                          { -3 } (601-5) [1113] -      -  - 812 9  NaHu K2 V          
+0311 Mizan-fel            B56258A-8 Ni Pr                                       { -1 } (C43+1) [747A] -      -  - 323 13 NaHu F3 V          
+0412 Sansibar             B200310-A Lo Droy4                                    { 1 }  (621-2) [1415] -      KM - 701 12 ZhIN M3 V M3 V     
+0414 Attica               C400546-8 Ni                                          { -2 } (842-3) [4347] -      -  - 810 8  NaHu K1 V M6 V     
+0416 Retinae              E8C69AA-9 Fl Hi In Pz (Tashaki) RsD                   { 1 }  (C8B+3) [BA7B] -      -  A 910 11 CsIm M1 V          
+0511 Terra Nova           C786342-9 Ga Lo                                       { -1 } (821-5) [1215] -      -  - 812 8  ZhIN K2 V          
+0512 Asmodeus             E596400-5 Ni Pa                                       { -3 } (631-5) [1111] -      -  - 205 11 ZhIN K8 V          
+0518 Faisal               D545436-5 Ni Pa                                       { -3 } (631-4) [3144] -      -  - 810 9  CsIm K9 V M7 V     
+0613 Lebeau               B869554-C Ni Pr                                       { 1 }  (845-1) [363A] -      -  - 901 10 ZhIN G8 V M5 V     
+0614 Querion              B554788-9 Ag Cp (Sheol)                               { 2 }  (D6C+3) [7959] -      KM - 804 13 ZhIN G6 V          
+0618 Dekalb               EA8A799-6 Oc Ri                                       { -1 } (966+1) [8667] -      -  - 320 13 CsIm M1 V          
+0620 Winston              E887573-6 Ga Ni Ag Pr                                 { -2 } (742-5) [2323] -      -  - 501 6  DaCf K5 V M9 V     
+0712 Rapp's World         C592320-8 He Lo                                       { -2 } (721-5) [1113] -      K  - 402 9  ZhIN K5 V M8 V     
+0717 Thanber              B543653-C Ni Po                                       { 1 }  (955-2) [3729] -      -  - 210 9  CsIm M0 V M1 V     
+0720 Entrope              E436AAA-B Hi Pz                                       { 1 }  (D9C+3) [CB7D] -      -  A 110 10 DaCf G6 V M1 V     
+0820 Anselhome            C310588-8 Ni                                          { -2 } (842-2) [5358] -      -  - 601 7  DaCf M0 V M1 V     
+0911 Caloran              C796746-5 Ag Pi                                       { 0 }  (967-1) [6744] -      -  - 510 6  NaHu G2 V M4 V     
+0912 899-076              E201300-8 Ic Lo                                       { -3 } (721-5) [1113] -      -  - 520 8  NaHu F7 V          
+0915 Quare                B200545-9 Ni                                          { 0 }  (B44-2) [3537] -      -  - 204 10 FdAr M3 V          
+0919 Zeta 2               X6B0000-0 He Ba (Viji)                                { -3 } (200-5) [0000] -      -  R 020 13 NaXX M0 V          
+1011 Arden                B5549CB-9 Hi Fo                                       { 2 }  (C8C+4) [BB7B] -      -  R 810 12 FdAr G4 V M5 V     
+1018 Choleosti            C200100-9 Lo                                          { -1 } (401-5) [1114] B      -  - 101 5  ImDd K9 V M4 V     
+1020 Margesi              C575677-6 Ni Ag                                       { -1 } (853-1) [6556] BC     -  - 910 10 ImDd K4 V M7 V     
+1116 Frenzie              A200436-A Ni Cp                                       { 1 }  (734+1) [3549] B      N  - 110 5  ImDd M3 III M2 V   
+1118 Garda-Vilis          B978868-A Ph Pa Pi O:1119                             { 2 }  (D7B+2) [8A5A] BcDe   S  - 912 14 ImDd M3 V          
+1119 Vilis                A593943-A Hi In                                       { 4 }  (D8E+1) [6D27] BEf    -  - 820 9  ImDd G5 V M8 V     
+1212 Digitis              E53668A-6 Ni                                          { -3 } (851-1) [8378] -      -  - 920 8  NaHu M3 V          
+1213 Edinina              E400220-7 Lo                                          { -3 } (411-5) [1112] -      -  - 401 6  CsIm K6 V M0 V     
+1214 728-907              E955000-0 Ba                                          { -3 } (200-5) [0000] -      -  - 610 10 ImDd F1 V M2 V     
+1216 Stellatio            D5A4420-8 Fl Ni                                       { -3 } (731-5) [1113] B      -  - 210 16 ImDd M3 V          
+1217 Arkadia              E546845-6 Ph Pa Pi                                    { -2 } (A75-4) [6634] BcDe   -  - 402 7  ImDd G8 V          
+1311 Tremous Dex          B511411-C Ic Ni                                       { 1 }  (734-3) [1518] -      -  - 201 8  FdAr K8 V M5 V     
+1315 Mirriam              E572300-8 He Lo                                       { -3 } (621-5) [1113] B      N  - 110 11 ImDd F5 V          
+1320 Saurus               D888588-7 Ni Ag Pr (Saurians)                         { -2 } (742-2) [5357] BcC    -  - 820 13 ImDd G8 V M1 V     
+1411 Rangent              E67A612-7 Wa Ni                                       { -3 } (851-5) [2313] -      -  - 503 14 NaHu K8 V          
+1413 Denotam              B739573-A Ni                                          { 1 }  (D45-2) [2627] B      N  - 324 9  ImDd M2 V          
+1417 Ficant               E567353-5 Lo                                          { -3 } (521-5) [1122] B      -  - 910 13 ImDd M0 V M1 V     
+1511 Tionale              C674321-8 Lo (minor)                                  { -2 } (621-5) [1114] -      -  - 210 11 CsIm M2 V M5 V     
+1515 Calit                C434887-7 Ph                                          { -1 } (A77-1) [8757] Be     -  - 501 4  ImDd K9 V M1 V     
+1519 Asgard               X5437C7-5 Pi Po                                       { -2 } (965-2) [7555] -      -  R 520 13 ImDd F5 V M1 V     
+1520 Tavonni              E567000-0 Ba                                          { -3 } (200-5) [0000] -      -  - 434 10 ImDd G6 V          
+1611 Phlume               C887624-8 Ga Ni Ag Ri                                 { 0 }  (954-2) [4636] BC     -  - 710 5  ImDd G5 V M8 V     
+1711 Extolay              B55589A-A Ph Pa Varg2                                 { 2 }  (B7B+4) [AA7C] Bce    N  - 110 8  ImDd M2 V M4 V     
+1719 Lanth                A879533-B Ni Cp                                       { 2 }  (846-1) [2728] B      NS - 710 14 ImDd F5 IV M1 V    
+1811 Dinom                D300535-A Ni Sa                                       { -1 } (843-3) [3438] B      -  - 201 16 ImDd A4 V          
+1815 Ghandi               B311455-A Ic Ni                                       { 1 }  (934-1) [2538] B      N  - 303 13 ImDd F8 V M3 V     
+1817 Victoria             D6D7772-2 An                                          { -2 } (963-5) [3511] -      -  - 112 8  ImDd K6 V          
+1912 Dinomn               B674632-9 Ni Ag                                       { 1 }  (C55-3) [2715] BC     S  - 204 11 ImDd G8 V          
+1916 Ylaven               X587552-4 Ni Ag Pr                                    { -2 } (742-5) [1311] -      -  R 922 11 ImDd F9 V          
+1918 Sonthert             D6266AB-7 Ni Da                                       { -3 } (851-1) [8379] B      -  A 314 8  ImDd K6 V M0 V     
+1920 D'Ganzio             B420410-D De He Ni Po                                 { 1 }  (934-3) [1518] B      N  - 312 6  ImDd M0 V M3 V     
+2011 Wypoc                E9C4547-9 Fl Ni                                       { -2 } (B42-2) [5359] B      -  - 922 9  ImDd M3 V          
+2111 Djinni               X559000-0 Ba                                          { -3 } (200-5) [0000] -      -  R 822 11 ImDd K5 V          
+2112 Rech                 D9957AA-6 Ag Pi Pz                                    { -1 } (966+1) [9678] BCD    -  A 501 15 ImDd M0 V          
+2212 K'Kirka              CAA5345-8 Fl Lo                                       { -2 } (721-4) [1136] B      -  - 102 7  ImDd M2 V          
+2215 Quopist              B551679-A Ni Po                                       { 1 }  (B55+2) [776B] B      -  - 721 8  ImDd M3 V          
+2311 Treece               D432866-8 Ph Na Po O:2410                             { -2 } (B76-3) [7647] Be     -  - 610 9  ImDd M1 V          
+2313 Echiste              C53A313-A Wa Lo                                       { 0 }  (721-3) [1327] B      -  - 720 10 ImDd G4 V          
+2314 Pirema               D691142-5 He Lo                                       { -3 } (301-5) [1111] B      -  - 802 7  ImDd M2 V          
+2317 Rhise                C100576-A Ni                                          { 0 }  (844-1) [4549] B      -  - 710 8  ImDd K7 V          
+2319 Ivendo               B424659-A Ni Px                                       { 2 }  (B56+3) [786B] B      NS - 112 11 ImDd A9 V          
+2411 Keanou               C792348-7 He Lo                                       { -2 } (521-2) [3157] B      S  - 213 12 ImDd M3 III M2 V   
+2414 Tureded              C565540-9 Ni Ag Pr                                    { 0 }  (C44-4) [1514] BcC    -  - 614 11 ImDd M3 V          
+2415 Vreibefger           E581542-3 Ni Pr RsE                                   { -3 } (741-5) [1211] Bc     -  - 901 8  ImDd K9 V          
+2416 La'Belle             C564112-4 Lo                                          { -2 } (301-5) [1111] B      -  - 701 11 ImDd F2 V M3 V     
+2417 Equus                B55A858-B Wa Ph Dolp1                                 { 2 }  (C7C+2) [8A5B] Be     S  - 202 12 ImDd F6 V M1 V     
+2418 Icetina              B5245A9-7 Ni Px                                       { -1 } (743+1) [6468] B      N  - 301 13 ImDd K9 V M8 V     
+2419 Cogri                CA6A643-9 Oc Ni Ri                                    { 0 }  (D54-3) [3626] BC     -  - 432 8  ImDd M1 V          
+2420 Skull                C4237C7-9 Na Pi Po                                    { 0 }  (A69+1) [7759] BD     N  - 601 12 ImDd M0 V M1 V     
+2512 Kinorb               C549433-9 Ni                                          { -1 } (832-4) [1326] B      -  - 502 14 ImDd F0 V K9 V     
+2514 Gileden              C583103-6 Lo                                          { -2 } (301-5) [1123] B      -  - 203 13 ImDd M1 V          
+2519 Pannet               E9C5677-9 Fl Ni                                       { -2 } (E52-2) [6459] B      -  - 224 11 ImDd K5 V          
+2520 Garrincski           B632520-7 Ni Po                                       { -1 } (743-5) [1412] B      S  - 410 9  ImDd M0 V M7 V     
+2612 Macene               B000453-E As Ni                                       { 1 }  (734-2) [152B] B      N  - 911 11 ImDd G8 V M8 V     
+2613 Fulacin              A674210-D Lo An                                       { 1 }  (511-3) [1318] B      -  - 810 12 ImDd G3 V          
+2620 Natoko               C8879AB-9 Ga Hi Pr Pz An                              { 1 }  (F8B+3) [BA7B] BcE    -  A 204 9  ImDd F4 V          
+2712 Risek                A425579-A Ni Px                                       { 1 }  (845+2) [666B] B      N  - 401 11 ImDd M2 V M3 V     
+2715 Porozlo              A867A74-B Ga Hi                                       { 3 }  (D9E+1) [8D39] BE     -  - 201 11 ImDd M1 V M9 V     
+2716 Rhylanor             A434934-F Hi Cp                                       { 4 }  (C8G+2) [7D3D] BEF    NS - 810 12 ImDd M2 V          
+2720 Loneseda             C86A215-7 Wa Lo                                       { -2 } (411-4) [1135] B      -  - 705 14 ImDd K9 V          
+2811 Valhalla             E565432-5 Ni Pa                                       { -3 } (631-5) [1111] Bc     -  - 622 9  ImDd G4 V          
+2812 Zivije               C6B199C-B Fl He Hi In Pz                              { 3 }  (E8E+5) [CC8E] BE     -  A 421 11 ImDd G6 V          
+2814 Jae Tellona          A560565-8 De Ni Pr Mr                                 { -1 } (B43-3) [3436] Bc     N  - 913 9  ImDd F9 V          
+2818 Gerome               X573000-0 Ba                                          { -3 } (200-5) [0000] -      -  R 701 11 ImDd K2 V          
+2912 Henoz                A545543-B Ni Ag                                       { 2 }  (D46-1) [2728] BC     -  - 824 11 ImDd F3 V          
+2913 Celepina             B434456-9 Ni Px                                       { 1 }  (734+1) [3548] B      NS - 201 13 ImDd M2 V          
+2918 Gitosy               B000676-9 As Ni Na                                    { 0 }  (954-1) [5648] B      -  - 620 6  ImDd G6 V M3 V     
+3015 Belizo               B895646-5 Ni Ag Asla3                                 { 0 }  (854-1) [5644] BC     -  - 923 11 ImDd K1 V          
+3016 Kegena               E869569-3 Ni Pr O:2716                                { -3 } (741-2) [6264] Bc     -  - 224 12 ImDd F6 V          
+3017 Heroni               E7A0614-8 He Ni                                       { -3 } (A51-5) [4336] B      -  - 820 8  ImDd G5 V          
+3019 457-973              X572776-5 He Pi (minor)                               { -2 } (965-3) [6544] -      -  R 534 10 ImDd G9 V          
+3020 Somem                C301340-B Ic Lo                                       { 0 }  (621-4) [1316] B      -  - 201 14 ImDd M2 V M7 V     
+3111 Vinorian             B879610-9 Ni                                          { 0 }  (954-4) [1614] B      -  - 610 13 ImDd M3 V M4 V     
+3112 Nutema               B864310-8 Lo                                          { -1 } (921-5) [1213] B      N  - 822 7  ImDd M3 V          
+3114 Huderu               X575000-0 Ba                                          { -3 } (200-5) [0000] -      -  R 920 10 ImDd M0 V          
+3118 Cipatwe              B55879A-6 Ag                                          { 1 }  (968+3) [9878] BC     -  - 623 12 ImDd M1 V          
+3119 Vanejen              C686854-5 Ga Ph Pa Ri Chir1 RsG                       { 0 }  (A77-2) [6833] BcCe   -  - 520 11 ImDd G1 V M0 V     
+3212 Margesi              A576257-C Lo                                          { 2 }  (611+2) [245C] B      NS - 920 12 ImDd F0 V          
+3216 Bevey                D4209CC-A De He Hi Na In Po Fo                        { 2 }  (H8C+5) [CB8D] BE     S  R 224 9  ImDd F4 V          
+3218 Tacaxeb              C430411-B De Ni Po                                    { 0 }  (733-4) [1417] B      -  - 801 10 ImDd A5 V M2 V     
+3220 Powaza               C787566-5 Ga Ni Ag Pr O:3124                          { -1 } (743-2) [4444] BcC    -  - 332 13 ImDd K4 V M2 V     
+0122 Junction             D550441-4 De Ni Po                                    { -3 } (631-5) [1111] -      -  - 210 10 NaHu M2 V M3 V     
+0129 Uniqua               E62556B-7 Ni O:0130                                   { -3 } (741-1) [7279] -      -  - 210 8  NaHu K9 V M9 V     
+0130 Garoo                A2008CB-A Ph Na Pi Fo (Garoo)                         { 2 }  (B7B+4) [AA7C] -      -  R 210 9  NaHu M1 V M5 V     
+0223 Stern-Stern          B421558-B He Ni Px Po DaryW                           { 1 }  (845+1) [565B] -      -  - 701 9  DaCf M0 V M3 V     
+0230 886-945              E833000-0 Ba Po                                       { -3 } (200-5) [0000] -      -  - 504 16 NaXX F8 V          
+0321 Nonym                C433898-A Ph Na Po                                    { 1 }  (F7A+1) [895A] -      M  - 623 14 NaHu G0 V          
+0325 Laberv               B554443-7 Ni Pa DaryW                                 { -1 } (632-4) [1324] -      M  - 834 12 DaCf G0 V          
+0326 Ektron               C432652-9 Ni Na Po Asla1 Dary8                        { -1 } (D53-5) [2515] -      -  - 423 14 DaCf M1 V          
+0421 Zamine               C897977-A Hi In Dary9                                 { 3 }  (G8D+3) [9C5A] -      -  - 223 12 DaCf M3 V          
+0425 Engrange             C554769-8 Ag Asla1 Dary8 O:0426                       { 0 }  (A68+1) [8769] -      -  - 701 10 DaCf M1 V M3 V     
+0426 Ilium                B544831-9 Ph Pa Pi DaryW                              { 1 }  (B7B-2) [4915] -      KM - 401 6  DaCf G3 V M8 V     
+0427 Roget                B566777-9 Ag Ri Asla6 Dary3                           { 3 }  (B6C+3) [7A59] -      -  - 420 7  DaCf F8 V M3 V     
+0429 Kardin               E553123-6 Lo Po An                                    { -3 } (301-5) [1123] -      -  - 410 10 NaHu F7 V          
+0430 Bularia              C774622-5 Ni Ag                                       { -1 } (853-5) [2511] -      -  - 310 8  CsIm K5 V M3 V     
+0526 Rorre                D765657-3 Ga Ni Ag Ri DaryW                           { -1 } (853-1) [6553] -      -  - 103 13 DaCf F4 V M2 V     
+0527 Mire                 A665A95-C Ga Hi Cx Dary8 Asla1                        { 3 }  (D9F+2) [8D3A] -      KM - 110 10 DaCf K6 V          
+0528 Condaria             E54779B-5 Ag Pi Pz                                    { -1 } (966+1) [9677] -      -  A 901 12 NaHu K3 V M0 V     
+0530 Dorannia             E42158A-8 He Ni Po                                    { -3 } (841-1) [727A] -      -  - 510 9  NaHu K4 V          
+0622 Terant 340           D5405A7-9 De He Ni Po DaryW                           { -2 } (C42-2) [5359] -      -  - 523 8  DaCf G0 V M5 V     
+0624 Jacent               A433744-D Na Po DaryW                                 { 2 }  (A6D+1) [593B] -      -  - 710 7  DaCf M0 V          
+0625 494-908              X893000-0 Ba                                          { -3 } (200-5) [0000] -      -  R 710 6  DaCf M1 V          
+0627 Darrian              A463955-G Hi Pr An (Daryen)8 Asla0                    { 4 }  (J8F+1) [7D3E] -      -  - 225 10 DaCf G1 V D        
+0721 Torment              X433268-6 Lo Px Po DaryW                              { -3 } (411-3) [2156] -      -  R 620 12 DaCf M0 V          
+0723 Trifuge              C546556-9 Ni Ag (Dphone) Dary9                        { 0 }  (844-1) [4548] -      -  - 210 10 DaCf F0 V          
+0724 Nosea                B4326BB-C Ni Na Po Fo DaryW                           { 1 }  (A55+3) [877E] -      K  R 620 13 DaCf M2 V          
+0727 Spume                C540200-A DeHe Lo Po DaryW                            { 0 }  (B11-4) [1215] -      M  - 434 12 DaCf M2 V          
+0729 Ator                 D426258-7 Lo An                                       { -3 } (411-3) [2157] -      -  - 821 6  NaHu F7 V M2 V     
+0822 Cunnonic             E65767A-3 Ga Ni Ag Asla0 Dary9                        { -2 } (852+1) [8475] -      -  - 502 8  DaCf K0 V          
+0830 Debarre              B854123-9 Lo                                          { 0 }  (701-3) [1126] -      -  - 822 15 CsIm M2 V          
+0921 Hrunting             B563747-9 Ri                                          { 2 }  (D6C+3) [7959] -      KM - 313 10 SwCf M2 V          
+0922 Tizon                B586887-A Ph Pa Ri                                    { 3 }  (F7D+4) [8B5A] -      KM - 323 15 SwCf K2 IV M3 V    
+0927 Narsil               B574A55-A Hi In                                       { 4 }  (J9F+3) [8E38] -      KM - 224 10 SwCf G6 IV M0 V    
+0930 Flammarion           A623514-B Ni Po                                       { 2 }  (846+1) [3739] B      NW - 710 11 ImDd F8 V          
+1022 Colada               B564685-B Ni Ag Ri                                    { 3 }  (A58+2) [4939] -      KM - 211 10 SwCf K2 V M8 V     
+1026 Anduril              B985855-B Ph Pa Ri                                    { 3 }  (E7E+2) [6B39] -      KM - 222 11 SwCf F2 V          
+1121 Mjolnir              B530544-A De Ni Po                                    { 1 }  (B46+1) [3638] -      KM - 522 12 SwCf A5 V G0 V     
+1123 Joyeuse              B564778-A Ag Ri                                       { 4 }  (A6E+5) [7B5A] -      KM - 201 13 SwCf M3 V M9 V     
+1126 Orcrist              B8A6733-A Fl Lk Lk                                    { 2 }  (A6C+1) [4927] -      KM - 401 8  SwCf K7 V M7 V     
+1130 Enos                 E35059B-4 De Ni Po Da                                 { -3 } (741-1) [7276] -      M  A 710 8  SwCf M1 V          
+1221 Gungnir              B544779-8 Ag Pi                                       { 1 }  (E69+2) [8869] -      M  - 432 13 SwCf G3 IV M4 V    
+1223 Gram                 A895957-C Hi In Cx                                    { 4 }  (E8G+5) [9D5C] -      KM - 603 10 SwCf F2 V M2 V     
+1225 Excalibur            B424755-A Pi                                          { 2 }  (B6C+1) [5938] -      KM - 402 10 SwCf K5 V          
+1324 Tyrfing              B637735-A                                             { 2 }  (A6C+1) [5938] -      M  - 701 6  BoWo M2 V          
+1325 Sacnoth              A775956-C Hi In                                       { 4 }  (C8G+4) [8D4B] -      KM - 801 7  SwCf F9 V M3 V     
+1329 Caladbolg            B565776-A Ag Ri                                       { 4 }  (A6D+3) [6B49] BCf    S  - 710 9  ImDd F7 V M0 V M4 V
+1424 Beater               B685686-A Ga Ni Ag Ri                                 { 3 }  (958+3) [5949] -      KM - 610 11 SwCf K4 V          
+1429 Gunn                 E544110-8 Lo                                          { -3 } (501-5) [1113] B      -  - 602 9  ImDd M3 V          
+1430 Caliburn             E000514-A As Ni                                       { -1 } (C43-3) [3438] B      -  - 924 13 ImDd M2 V          
+1522 Dyrnwyn              B958812-A Ph Pa                                       { 2 }  (B7C-1) [4A16] -      M  - 201 7  BoWo K4 V M8 V     
+1523 Durendal             B687734-B Ga Ag Ri                                    { 4 }  (E6F+3) [5B39] -      M  - 714 11 BoWo M1 V          
+1524 Hofud                B666853-A Ga Ph Pa Ri                                 { 3 }  (B7D+1) [5B27] -      KM - 501 8  SwCf G6 V M9 V     
+1525 Sting                B645796-A Ag Pi                                       { 3 }  (B6D+3) [6A49] -      M  - 302 9  BoWo M0 V          
+1526 Biter                B354623-A Ni Ag                                       { 2 }  (957+1) [3827] -      KM - 301 8  SwCf G7 V M1 V     
+1529 Steel                E655000-0 Ga Ba                                       { -3 } (200-5) [0000] -      -  - 324 15 SwCf K8 V          
+1626 Iron                 E529000-0 Ba                                          { -3 } (200-5) [0000] -      -  - 714 9  BoWo F0 V          
+1627 Bronze               E201000-0 Ic Ba                                       { -3 } (200-5) [0000] -      -  - 510 5  BoWo M3 V          
+1628 Mithril              E568000-0 Ba                                          { -3 } (200-5) [0000] -      -  - 301 8  SwCf F4 V          
+1721 Arba                 C200200-C Lo                                          { 0 }  (511-4) [1217] B      -  - 610 11 ImDd M2 V          
+1727 Wardn                B756486-B Ga Ni Pa                                    { 1 }  (834+1) [354A] Bc     S  - 502 7  ImDd K2 V          
+1728 Olympia              C428342-7 Lo                                          { -2 } (521-5) [1113] B      -  - 120 6  ImDd M3 V          
+1729 Smoug                C54078A-9 De He Pi Po                                 { 0 }  (B69+2) [977B] BD     -  - 902 7  ImDd M1 V M7 V     
+1822 Rabwhar              D5448BA-6 Ph Pa Pi Pz                                 { -2 } (A75+1) [A678] BcDe   S  A 313 12 ImDd K5 V          
+1824 Adabicci             A57189B-B He Ph Pi Pz                                 { 2 }  (B7C+4) [AA7D] BDe    N  A 801 6  ImDd K8 V M8 V     
+1825 Zaibon               B000544-B As Ni                                       { 1 }  (945-1) [3639] B      -  - 512 9  ImDd M6 III M3 V   
+1826 Tenalphi             A774722-E Ag Pi An                                    { 3 }  (A6E-1) [3A1A] BCD    -  - 610 12 ImDd F7 V          
+1924 Ianic                E560697-5 De Ni Ri                                    { -2 } (852-2) [6455] BC     -  - 924 9  ImDd M3 V M7 V     
+1927 Spirelle             C766846-8 Ga Ph Pa Ri                                 { 0 }  (G78-1) [7847] BcCe   S  - 715 14 ImDd G7 V          
+2024 Derchon              C512799-8 Ic Na Pi                                    { -1 } (A67+1) [8669] BD     S  - 901 5  ImDd M0 V M7 V     
+2124 Lunion               A995984-D Hi In Cp                                    { 5 }  (C8H+3) [7E3B] BEF    NS - 810 11 ImDd G5 V          
+2125 Shirene              B984510-B Ni Ag Pr                                    { 2 }  (C46-2) [1716] BcC    S  - 723 12 ImDd G4 V M1 V M1 V
+2128 Penkwhar             D978310-5 Lo                                          { -3 } (521-5) [1111] B      -  - 320 9  ImDd M0 V          
+2129 Harvosette           C430737-9 De Na Po                                    { 0 }  (A69+1) [7759] B      -  - 910 11 ImDd M0 V M5 V     
+2224 Carse                C563325-9 Lo                                          { -1 } (621-3) [1237] B      -  - 601 13 ImDd M3 V M6 V     
+2228 Persephone           B775833-A Ph Pa Pi                                    { 3 }  (E7C+1) [5B27] BcDe   W  - 922 10 ImDd M2 V          
+2321 Quiru                B565300-8 Lo                                          { -1 } (A21-5) [1213] B      -  - 323 9  ImDd M3 V          
+2322 Gorram               X554220-2 Lo                                          { -3 } (411-5) [1111] -      -  R 801 9  ImDd K8 V M6 V     
+2323 Resten               B310100-B Lo                                          { 1 }  (401-3) [1216] B      S  - 501 10 ImDd K5 V M8 V     
+2324 Capon                B747748-A Ag Pi                                       { 3 }  (A6C+3) [7A5A] BCD    N  - 610 10 ImDd F9 V          
+2325 Sharrip              C575101-A Lo                                          { 0 }  (601-4) [1116] B      -  - 503 16 ImDd K5 V          
+2327 Strouden             A745988-D Hi In                                       { 4 }  (D8G+4) [9D5D] BEf    N  - 920 8  ImDd G5 V M4 V     
+2425 Gandr                E000347-8 As Lo                                       { -3 } (821-3) [3158] B      -  - 813 9  ImDd M1 V          
+2426 Drolraw              EAB6311-8 Fl Lo                                       { -3 } (921-5) [1114] B      -  - 904 12 ImDd F1 V          
+2521 Heroni               B6449B9-8 Hi In Pz                                    { 2 }  (E8B+3) [AB69] BE     -  A 721 14 ImDd F3 V          
+2523 Byret                B585697-6 Ni Ag Ri (Larianz)                          { 1 }  (855+1) [6756] BC     -  - 812 7  ImDd G9 V          
+2527 Pimane               E500343-7 Lo                                          { -3 } (521-5) [1124] B      -  - 903 10 ImDd K0 V          
+2621 Fosey                A633656-A Ni Na Px Po                                 { 1 }  (A55+1) [5749] B      -  - 620 11 ImDd M3 V          
+2624 Mercury              B658663-8 Ni Ag Mr Cy                                 { 1 }  (C55-2) [3725] BC     NS - 304 13 ImDd F7 V          
+2627 Tivid                C534477-8 Ni Px                                       { -2 } (731-2) [4258] B      -  - 401 11 ImDd M3 V          
+2726 Carey                C579221-9 Lo                                          { -1 } (511-5) [1115] B      -  - 910 4  ImDd M2 V M2 V     
+2728 Duale                A5437BF-B Pi Po Fo RsA                                { 2 }  (A6C+5) [C9AG] BD     -  R 401 5  ImDd M0 V M2 V     
+2824 Catuz                C42048C-9 De He Ni Po Da                              { -1 } (732+2) [738C] B      -  A 510 5  ImDd K8 V M6 V     
+2827 Meleto               C675100-5 Lo                                          { -2 } (301-5) [1111] B      S  - 724 9  ImDd F9 V          
+2828 Hexos                B534420-8 Ni                                          { -1 } (B32-5) [1313] B      N  - 123 10 ImDd K1 V M2 V     
+2830 Pedase               C415346-7 Ic Lo                                       { -2 } (521-3) [2146] B      S  - 101 11 ImDd M2 V M7 V     
+2924 Moran                C567300-8 Lo                                          { -2 } (621-5) [1113] B      N  - 201 10 ImDd M3 V M7 V     
+2927 Maitz                A201511-B Ic Ni                                       { 1 }  (B45-3) [1617] B      -  - 122 11 ImDd F1 V          
+2930 Mainz                C553352-A Lo Po                                       { 0 }  (821-4) [1316] B      S  - 803 11 ImDd K2 V M7 V     
+3021 Brodie               C410468-7 Ni O:3124                                   { -2 } (631-2) [4257] B      -  - 114 15 ImDd M1 III M7 V   
+3022 Rorise               C994100-A Lo                                          { 0 }  (501-4) [1115] B      -  - 502 8  ImDd M1 V          
+3024 Jokotre              B6548D9-7 Ph Pa Fo                                    { 0 }  (A78+1) [9868] Bce    -  R 810 9  ImDd K6 V          
+3025 Fornice              A554A87-C Hi                                          { 3 }  (E9E+3) [AD5C] BE     -  - 202 13 ImDd M0 V          
+3026 Grille               E410335-7 Lo                                          { -3 } (521-5) [1135] B      -  - 701 12 ImDd M2 V M2 V     
+3029 Palique              A511965-E Ic Hi Na In O:3025                          { 4 }  (D8G+2) [7D3C] BEf    -  - 320 5  ImDd M0 V M1 V     
+3030 Nexine               C97A443-8 Wa Ni (Nexxies)                             { -2 } (731-5) [1225] B      S  - 801 12 ImDd G9 V M2 V     
+3123 Nadrin               D420203-7 DeHe Lo Po                                  { -3 } (411-5) [1124] B      S  - 920 16 ImDd K5 V M1 V     
+3124 Mora                 AA99AC7-F Hi In Cs                                    { 5 }  (F9H+5) [AF5F] BEF    NS - 112 9  ImDd F0 V          
+3223 Dojodo               C512311-7 Ic Lo                                       { -2 } (521-5) [1113] B      S  - 710 14 ImDd M0 V          
+3228 Fenl's Gren          C647346-9 Lo                                          { -1 } (A21-2) [2248] B      -  - 423 12 ImDd K7 V          
+0133 Emape                B564500-B Ni Ag Pr                                    { 2 }  (A46-2) [1716] BcC    N  - 503 6  ImDd M0 V          
+0139 Raweh                B430300-B DeLo Po                                     { 1 }  (721-3) [1416] B      N  - 920 5  ImDd G3 V M1 V     
+0140 876-574              E687200-3 Ga Lo                                       { -3 } (411-5) [1111] -      -  - 702 11 NaHu K7 V          
+0231 Saxe                 EAA5543-8 Fl Ni                                       { -3 } (841-5) [2225] -      -  - 910 9  NaHu A2 V          
+0236 Andor                C695735-9 Ag Pi An DroyW                              { 1 }  (C6A-1) [5837] -      -  - 603 6  ImDd F3 V          
+0240 769-422              E754401-8 Ni Pa (minor)                               { -3 } (C31-5) [1114] -      -  - 924 10 NaHu G2 V          
+0332 Gothe                E42159B-7 He Ni Po Da                                 { -3 } (741-1) [7279] B      -  A 310 9  ImDd F5 V          
+0333 Mirriam              B9998A6-A Ph Pi                                       { 3 }  (F7C+2) [7B49] BDe    NW - 514 13 ImDd G6 V          
+0336 Candory              C593634-8 Ni An DroyW                                 { -2 } (A52-4) [4436] -      -  - 920 5  ImDd F6 V M3 V     
+0340 Wonderay             E88A47A-4 Wa Ni                                       { -3 } (631-1) [6176] -      -  - 210 7  NaHu M1 V M3 V     
+0433 Jone                 B792785-9 He Pi                                       { 1 }  (A6A-1) [5837] BD     N  - 810 13 ImDd G8 V M5 V     
+0440 Jinx                 D100133-7 Lo                                          { -3 } (301-5) [1124] -      -  - 202 10 NaHu G3 IV D       
+0532 Ucella               D574654-7 Ni Ag                                       { -2 } (852-4) [4435] -      -  - 410 8  CsIm F2 V M2 V     
+0533 Penelope             C560642-4 De Ni Ri                                    { -1 } (853-5) [2511] BC     -  - 323 10 ImDd F6 V M2 V     
+0534 Karin                A767768-C Ga Ag Ri Mr                                 { 5 }  (A6F+5) [7C5C] BCf    NS - 410 6  ImDd G7 V          
+0538 Wonstar              B555741-7 Ag                                          { 1 }  (969-3) [3813] BC     N  - 910 5  ImDd M0 V          
+0539 Froin                C535225-9 Lo RsZ                                      { -1 } (511-3) [1137] B      -  - 601 12 ImDd M2 V M7 V     
+0632 Gohature             C754766-7 Ag O:0732                                   { 0 }  (968-1) [6746] BC     S  - 523 15 ImDd F8 V          
+0637 Quhaiathat           C31479B-9 Ic Pi Pz                                    { 0 }  (A69+2) [977B] BD     -  A 210 6  ImDd K8 V          
+0638 Lakou                E779454-7 Ni                                          { -3 } (631-5) [2135] B      -  - 601 13 ImDd M2 V          
+0731 Ralhe                E424574-8 Ni                                          { -3 } (841-5) [3236] -      -  - 801 9  NaHu M2 V M3 V     
+0732 Iderati              A887798-C Ga Ag Ri Cp                                 { 4 }  (A6E+4) [7B5C] BCF    N  - 201 11 ImDd G9 V          
+0739 Tondoul              E5136A7-7 Ic Ni Na                                    { -3 } (851-3) [6357] -      -  - 701 10 NaHu K8 V M1 V     
+0834 875-496              E888421-7 Ni Pa                                       { -3 } (631-5) [1113] -      S  - 510 8  CsIm M3 V M7 V     
+0837 Ochecate             E747569-7 Ni Ag O:1040                                { -2 } (742-1) [6368] -      -  - 210 7  NaHu G8 V M8 V     
+0838 Mewey                D786799-5 Ga Ag Ri (Mewey)                            { 0 }  (967+1) [8766] -      -  - 701 8  NaHu K3 V M3 V     
+0840 975-452              E100316-9 Lo                                          { -2 } (821-3) [2148] -      -  - 821 10 NaHu M0 V          
+0931 Asteltine            B7A7402-A Fl Ni                                       { 1 }  (734-3) [1516] -      -  - 210 10 NaHu K7 V M3 V     
+0938 Inchin               D42035A-A De He Lo Po                                 { -1 } (A21+1) [527C] -      -  - 823 8  NaHu F0 V          
+0940 Singer               D553774-6 Po                                          { -2 } (965-4) [5534] -      -  - 901 9  NaHu M2 V M2 V     
+1031 567-908              E532000-0 Ba Po (Shriekers)                           { -3 } (200-5) [0000] -      -  - 310 9  NaXX G5 V M9 V     
+1037 Avastan              C433520-A Ni Po                                       { 0 }  (D44-4) [1515] -      -  - 724 11 NaHu M3 V          
+1040 Kuai Qing            C503758-A Ic Na Pi                                    { 1 }  (B6A+1) [785A] -      -  - 320 7  NaHu K3 V          
+1131 Faldor               E5936A7-5 Ni (Otarri)                                 { -3 } (851-3) [6355] -      -  - 520 7  NaHu M2 V          
+1132 Bowman               D000300-9 As Lo                                       { -2 } (921-5) [1114] -      S  - 811 13 CsIm M0 V          
+1133 Squallia             C438679-9 Ni                                          { -1 } (A53+1) [756A] -      -  - 320 8  NaHu F0 V          
+1138 Tarsus               B584620-A Ni Ag Ri                                    { 3 }  (A57-1) [1915] -      -  - 202 7  CsIm K9 V          
+1232 Walston              C544338-8 Lo Varg7                                    { -2 } (721-2) [3158] -      S  - 302 8  CsIm M2 V          
+1233 Flexos               E5A1422-8 Fl He Ni                                    { -3 } (731-5) [1114] -      -  - 610 8  NaHu M1 V M2 V     
+1237 Collace              B628943-D Hi In                                       { 4 }  (C8G+1) [6D2A] -      S  - 101 5  CsIm F1 V M3 V     
+1238 Pavabid              C6678D8-6 Ga Ph Pa Ri Pz                              { 0 }  (A77+1) [8856] -      -  A 701 14 CsIm K7 V          
+1331 Datrillian           E427633-8 Ni                                          { -3 } (951-5) [3325] -      -  - 801 9  NaHu M1 V          
+1332 Nirton               X500000-0 Ba                                          { -3 } (200-5) [0000] -      -  R 011 11 NaXX M0 V          
+1337 Judice               E9B2000-8 Fl He Ba RsT                                { -3 } (500-5) [0000] -      -  - 321 8  AsXX M3 V          
+1339 Trexalon             B561851-C Ph Ri                                       { 3 }  (F7D-1) [4B18] -      -  - 923 13 NaHu K8 V          
+1340 Motmos               B68468B-5 Ni Ag Ri                                    { 1 }  (855+3) [8777] -      N  - 710 7  CsIm M2 V M2 V     
+1433 Noctocol             E7A5747-8 Fl                                          { -2 } (B66-2) [7558] -      -  - 602 15 NaHu F5 V M2 V     
+1434 Tarkine              C566662-7 Ni Ag Ri Cy O:1435                          { 0 }  (854-4) [2613] -      S  - 310 9  CsIm M0 V M2 V     
+1435 Dallia               B885883-9 Ga Ph Pa Ri                                 { 2 }  (B7B-1) [5A26] -      -  - 610 9  AsXX F2 V          
+1436 Talos                E433532-9 Ni Po                                       { -2 } (942-5) [1315] -      -  - 820 9  AsXX F9 V M1 V     
+1531 Dawnworld            E885000-0 Ga Ba                                       { -3 } (200-5) [0000] -      -  - 025 17 NaXX F8 V M2 V     
+1532 Elixabeth            B426467-8 Ni O:1435                                   { -1 } (732-1) [4358] -      N  - 201 8  CsIm M1 V M5 V     
+1533 Forine               D3129B8-A Ic Hi Na In                                 { 2 }  (C8C+2) [9B5A] -      -  - 610 8  NaHu G9 V          
+1537 Mertactor            B562732-B Ri Cp                                       { 3 }  (A6D-1) [3A17] -      V  - 610 15 AsXX G1 V          
+1631 Talchek              C7B1442-8 Fl He Ni                                    { -2 } (731-5) [1214] -      -  - 601 10 CsIm K8 V M5 V     
+1632 Milagro              E31178A-7 Ic Na Pi                                    { -2 } (966+1) [9579] -      -  - 920 15 CsIm M2 V          
+1634 Pagaton              C769873-4 Ph Ri                                       { 0 }  (A76-3) [5821] -      -  - 913 11 AsXX F0 V          
+1635 Binges               A500231-A Lo                                          { 1 }  (611-3) [1316] -      -  - 720 6  AsXX M0 V          
+1637 Mille Falcs          B9A2469-C Fl He Ni Px Mr                              { 2 }  (735+3) [566D] -      KV - 301 12 AsXX M2 V          
+1731 Grote                A400404-B Ni                                          { 1 }  (C34-1) [2539] B      -  - 124 11 ImDd F8 V          
+1733 Lydia                E310430-7 Ni                                          { -3 } (631-5) [1112] B      -  - 902 11 ImDd M4 III M0 V   
+1736 Melior               D540466-7 De He Ni Po Jonk5 O:2036                    { -3 } (631-4) [3146] -      -  - 724 9  AsXX G3 V          
+1737 Egypt                BAC6567-9 Fl Ni Mr                                    { 0 }  (A44+1) [5559] -      K  - 521 14 AsXX F8 V          
+1739 Aster                C86A410-9 Wa Ni                                       { -1 } (732-5) [1314] -      -  - 401 15 AsXX K9 V          
+1836 Callia               E550852-6 De Ph Po                                    { -2 } (A75-5) [4612] -      -  - 810 11 AsXX M3 V          
+1932 Mithras              C8B5568-8 Fl Ni Px                                    { -2 } (942-2) [5358] -      -  - 302 6  AsXX M2 III M0 V   
+1934 Weiss                A626464-B Ni Re O:2036                                { 1 }  (934-1) [2539] -      -  - 703 10 AsXX M1 V          
+1935 Windsor              C783511-9 Ni Pr                                       { -1 } (843-5) [1415] -      -  - 210 9  AsXX K9 V M0 V     
+1937 Overnale             B55467A-9 Ni Ag                                       { 1 }  (D55+3) [877B] -      -  - 423 17 AsXX G3 V          
+1938 New Rome             B837866-B Ph Asla3 O:2036                             { 2 }  (E7C+1) [7A4A] -      K  - 704 12 AsXX F8 V M0 V     
+1939 Craw                 C573645-5 Ni (Crawni) Asla8                           { -2 } (852-4) [4433] -      -  - 923 11 AsXX G7 V          
+2035 Aki                  B543987-9 Hi In Po                                    { 3 }  (G8D+3) [9C59] -      -  - 214 16 AsXX G6 V M2 V     
+2036 Glisten              A000986-F As Hi Na In Cp                              { 5 }  (D8H+4) [8E4E] -      KV - 821 13 AsXX K9 V          
+2038 Trane                C639422-B Ni An                                       { 0 }  (A33-4) [1417] -      -  - 704 12 AsXX F4 V M3 V     
+2132 Centry               E422447-7 He Ni Px Po                                 { -3 } (631-3) [4157] -      -  - 220 10 AsXX K3 V          
+2134 Caledonia            C541636-5 He Ni Po                                    { -2 } (852-3) [5444] -      -  - 910 10 AsXX M4 III M0 V   
+2137 Sorel                E58569A-2 Ni Ag Ri                                    { -1 } (853+1) [8574] -      -  - 921 8  AsXX G3 V M3 V     
+2138 Horosho              C4378A6-A Ph                                          { 1 }  (C7A+1) [7949] -      V  - 920 10 AsXX F4 V          
+2140 Romar                B550456-8 De Ni Po                                    { 0 }  (933-1) [3447] -      KV - 112 6  AsXX K2 V M3 V     
+2231 Marastan             D868772-5 Ag Ri                                       { 0 }  (967-2) [5733] -      -  - 924 12 AsXX K7 V          
+2232 Crout                E4359CA-7 Hi Fo                                       { -1 } (B88+1) [B879] -      -  R 314 9  AsXX M7 III M2 V   
+2233 Tirem                C7B5975-B Fl Hi In                                    { 3 }  (E8E+1) [7C39] -      -  - 621 13 AsXX K5 V          
+2234 Inthe                C100598-B Ni                                          { 0 }  (D44+1) [555B] -      -  - 924 14 AsXX K3 V          
+2236 Tsarina              D420636-7 De He Ni Na Po                              { -3 } (851-4) [5346] -      -  - 301 10 AsXX M2 V M2 V     
+2237 Wurzburg             C795300-A Lo                                          { 0 }  (621-4) [1315] -      V  - 510 7  AsXX F8 V          
+2331 Bicornn              E563576-2 Ni Pr                                       { -3 } (741-4) [4241] -      -  - 210 11 AsXX F3 V M3 V     
+2334 Ffudn                A41489D-C Ic Ph Pi Fo                                 { 2 }  (E7C+5) [CA9G] -      -  R 904 12 AsXX M0 V          
+2336 Bendor               A756656-C Ga Ni Ag                                    { 3 }  (A57+2) [594B] -      KV - 820 8  AsXX F5 V          
+2534 Burtson              C562667-8 Ni Ri O:2733                                { -1 } (A53-1) [6558] BC     -  - 402 13 ImDd G4 V          
+2536 Squanine             A300550-B Ni                                          { 1 }  (A45-3) [1616] -      -  - 303 8  AsXX F4 V M2 V     
+2537 Dobham               A550457-A De Ni Po                                    { 1 }  (B34+1) [455A] -      V  - 523 11 AsXX G0 V          
+2538 Pyramus              E566335-2 Lo                                          { -3 } (521-5) [1131] -      -  - 214 11 AsXX K6 V          
+2539 Thisbe               E4305AD-6 De Ni Po Fo                                 { -3 } (741+1) [929A] -      -  R 322 10 AsXX F8 V          
+2540 Aramis               B659772-6                                             { 0 }  (967-4) [3712] -      -  - 924 9  AsXX K5 V          
+2632                      X695674-8 Ni Ag Fo An                                 { -2 } (852+1) [64AD] -      -  R 201    ImDd               
+2637 Robin                C00059C-C As Ni Da                                    { 0 }  (944+3) [858F] -      -  A 212 6  AsXX M2 V          
+2638 D'Mara               E75A798-5 Wa                                          { -2 } (965-2) [7555] -      -  - 910 18 AsXX F4 V          
+2639 Keltchner            C525567-9 Ni Px O:Asla                                { -1 } (943-1) [5459] -      -  - 602 15 AsXX K6 V          
+2731 Tussinian            B678324-7 Lo                                          { -1 } (521-3) [1235] B      -  - 520 7  ImDd K0 V          
+2733 Edenelt              A5638BD-B Ph Ri Fo                                    { 3 }  (H7D+5) [CB9F] BCe    -  R 934 10 ImDd G7 V          
+2735 Conway               D894586-7 Ni Ag                                       { -2 } (742-3) [4346] BC     S  - 311 12 ImDd F0 V M0 V     
+2739 Dodds                C5439DF-7 Hi In Po Fo                                 { 1 }  (B8A+5) [EAAC] -      V  R 423 13 AsXX G7 V          
+2832 Leander              E695244-5 Lo                                          { -3 } (411-5) [1133] B      -  - 801 10 ImDd K5 V M1 V     
+2833 Pepernium            D567530-3 Ni Ag Pr                                    { -2 } (742-5) [1311] BcC    -  - 503 10 ImDd M1 V          
+2834 Traltha              B590630-6 De He Ni An                                 { -1 } (853-5) [1511] B      -  - 410 8  ImDd F5 V          
+2839 Farquahar            C625563-7 Ni Cy                                       { -2 } (742-5) [2324] -      V  - 201 11 AsXX M3 V          
+2933 Raydrad              E99467A-6 Ni Ag                                       { -2 } (852+1) [8478] BC     -  - 303 10 ImDd M7 III M2 V   
+2934 Zyra                 B555448-7 Ni Pa                                       { -1 } (632-1) [4357] Bc     -  - 301 7  ImDd K8 V          
+2935 Murchison            B544433-6 Ni Pa                                       { -1 } (632-4) [1323] Bc     N  - 305 8  ImDd M5 III M3 V   
+2936 Hammermium           A5525AB-B Ni Po Da                                    { 1 }  (F45+3) [767D] B      -  A 535 11 ImDd M3 V          
+2940 Thornnastor          D534443-8 Ni                                          { -3 } (A31-5) [1125] -      V  - 804 12 AsXX M1 V          
+3032 Katarulu             B552665-B Ni Po Mr                                    { 2 }  (956+1) [4839] B      NW - 201 9  ImDd M0 V M9 V     
+3035 Prilissa             B985588-6 Ni Ag Pr                                    { 0 }  (744+1) [5556] BcC    -  - 510 9  ImDd K4 V          
+3038 Tee-Tee-Tee          C310530-9 Ni                                          { -1 } (943-5) [1414] B      -  - 902 7  ImDd M2 V          
+3039 Youghal              AA95365-B Lo CyO:Asla                                 { 1 }  (621-1) [1439] -      -  - 201 14 AsXX K3 V          
+3040 Tenelphi             D76A579-9 Wa Ni Pr                                    { -2 } (842-1) [636A] Bc     S  - 901 11 ImDd F4 V M0 V     
+3138 Zephyr               C89556A-5 Ni Ag O:3235                                { -1 } (743+1) [7477] BC     -  - 404 9  ImDd K5 V          
+3139 Chamois              B544642-5 Ni Ag                                       { 0 }  (854-4) [2611] BC     S  - 723 8  ImDd F9 V          
+3233 Ramiva               B3107A7-8 Na Pi                                       { 0 }  (D68+1) [7758] BD     -  - 913 9  ImDd M3 V          
+3235 Trin                 A894A96-F Hi In                                       { 5 }  (D9H+4) [9F4E] BEF    NS - 101 8  ImDd G0 V          
+3236 Hazel                C645747-5 Ag Pi                                       { 0 }  (967+1) [7755] BCD    -  - 110 15 ImDd F1 V M3 V     

--- a/res/Sectors/M1120/1120_Spin.xml
+++ b/res/Sectors/M1120/1120_Spin.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0"?>
+<Sector xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Name>Spinward Marches</Name>
+  <Name Lang="zh">Tloql</Name>
+  <Credits>
+
+             &lt;b&gt;The Spinward Marches&lt;/b&gt; were designed by Marc W.
+             Miller and appeared in &lt;cite&gt;Traveller Supplement 3: The
+             Spinward Marches&lt;/cite&gt; (GDW, 1979).
+
+    </Credits>
+  <Product Author="Marc W Miller" Title="MegaTraveller Imperial Encyclopedia" Publisher="GDW" Ref="http://www.drivethrurpg.com/product/429/MT-MegaTraveller-Imperial-Encyclopedia.html" />
+  <Subsectors>
+    <Subsector Index="A">Cronor</Subsector>
+    <Subsector Index="B">Jewell</Subsector>
+    <Subsector Index="C">Regina</Subsector>
+    <Subsector Index="D">Aramis</Subsector>
+    <Subsector Index="E">Querion</Subsector>
+    <Subsector Index="F">Vilis</Subsector>
+    <Subsector Index="G">Lanth</Subsector>
+    <Subsector Index="H">Rhylanor</Subsector>
+    <Subsector Index="I">Darrian</Subsector>
+    <Subsector Index="J">Sword Worlds</Subsector>
+    <Subsector Index="K">Lunion</Subsector>
+    <Subsector Index="L">Mora</Subsector>
+    <Subsector Index="M">Five Sisters</Subsector>
+    <Subsector Index="N">District 268</Subsector>
+    <Subsector Index="O">Glisten</Subsector>
+    <Subsector Index="P">Trin's Veil</Subsector>
+  </Subsectors>
+  <Allegiances>
+    <Allegiance Code="AsXX">Aslan Hierate, unknown</Allegiance>
+    <Allegiance Code="BoWo">Border Worlds</Allegiance>
+    <Allegiance Code="CsIm">Client state, Third Imperium</Allegiance>
+    <Allegiance Code="CsZh">Client state, Zhodani Consulate</Allegiance>
+    <Allegiance Code="DaCf">Darrian Confederation</Allegiance>
+    <Allegiance Code="FeAr">Federation of Arden</Allegiance>
+    <Allegiance Code="ImDd">Third Imperium, Domain of Deneb</Allegiance>
+    <Allegiance Code="NaHu">Non-Aligned, Human-dominated</Allegiance>
+    <Allegiance Code="NaVa">Non-Aligned, Vargr-dominated</Allegiance>
+    <Allegiance Code="NaXX">Non-Aligned, unclaimed</Allegiance>
+    <Allegiance Code="SwCf">Sword Worlds Confederation</Allegiance>
+    <Allegiance Code="ZhIN">Zhodani Consulate, Iadr Nsobl Province</Allegiance>
+  </Allegiances>
+  <Stylesheet>
+    border.DaCf { color: lightblue; }
+    route.DaCf { color: lightgreen; }
+
+    border.NaVa { color: olivedrab; }
+
+    border.SwCf { color: blue; }
+    route.SwCf { color: #006600; }
+  </Stylesheet>
+  <Borders>
+    <Border Allegiance="AsXX" LabelPosition="2339" Color="Yellow" Label="Aslan ihatei">1337 1436 1435 1535 1634 1735 1834 1934 1933 1932 2032 2132 2231 2331 2332 2333 2334 2335 2435 2536 2537 2637 2738 2838 2939 3039 2940 2941 2841 2741 2641 2541 2441 2341 2241 2141 2041 1941 1841 1741 1641 1541 1441 1440 1439 1438 1437 1337 </Border>
+    <Border Allegiance="BoWo" LabelPosition="1422" WrapLabel="true" Color="#828F08">1323 1422 1522 1622 1623 1624 1625 1626 1627 1626 1625 1525 1624 1623 1523 1423 1324 1323 </Border>
+    <Border Allegiance="DaCf" LabelPosition="0423" WrapLabel="true">0223 0323 0422 0421 0521 0620 0720 0820 0821 0822 0723 0724 0725 0726 0727 0728 0627 0527 0427 0426 0326 0325 0224 0223 </Border>
+    <Border Allegiance="FdAr" LabelPosition="1013" WrapLabel="true" Color="Pink" Label="Federation of Arden">0913 1012 1011 1010 1110 1209 1310 1311 1211 1112 1113 1114 1014 0915 0914 0913 </Border>
+    <Border Allegiance="ImDd" LabelPosition="0808" ShowLabel="false" Label="Third Imperium">0808</Border>
+    <Border Allegiance="ImDd" LabelPosition="0930" ShowLabel="false" Label="Third Imperium">0930</Border>
+    <Border Allegiance="ImDd" LabelPosition="0335" WrapLabel="false" Label="Third Imperium">0133 0232 0332 0432 0533 0632 0732 0733 0633 0534 0535 0635 0636 0737 0738 0638 0539 0438 0339 0238 0139 0138 0137 0136 0135 0134 0133 </Border>
+    <Border Allegiance="ImDd" LabelPosition="2021" WrapLabel="false" Label="Third Imperium">1005 1105 1204 1305 1405 1505 1604 1704 1803 1802 1903 2003 2104 2204 2305 2405 2406 2407 2408 2509 2609 2710 2809 2909 2908 2909 3009 3109 3108 3107 3207 3307 3308 3309 3310 3311 3312 3313 3314 3315 3316 3317 3318 3319 3320 3321 3322 3323 3324 3325 3326 3327 3328 3329 3330 3331 3332 3333 3334 3335 3336 3337 3338 3339 3340 3341 3241 3141 3041 3040 3140 3139 3038 3037 2937 2836 2736 2735 2634 2534 2534 2533 2532 2531 2530 2429 2329 2229 2130 2030 1930 1830 1731 1732 1733 1732 1731 1730 1729 1728 1727 1826 1825 1824 1823 1822 1821 1721 1620 1520 1420 1320 1219 1119 1019 1020 1019 1018 1118 1117 1116 1215 1214 1314 1413 1513 1612 1611 1711 1810 1910 1909 1808 1708 1607 1507 1407 1307 1207 1107 1006 1005 </Border>
+    <Border Allegiance="ImDd" LabelPosition="1430" ShowLabel="false" Label="Third Imperium">1329 1429 1430 1330 1329</Border>
+    <Border Allegiance="NaVa" LabelPosition="2704" Label="Vargr Raiders">2200 2300 2400 2500 2600 2700 2800 2900 3000 3100 3200 3300 3301 3302 3202 3103 3104 3004 3005 3006 3007 3008 3007 3006 2906 2806 2707 2708 2607 2606 2605 2604 2504 2403 2303 2202 2201 2200</Border>
+    <Border Allegiance="SwCf" LabelPosition="1327" WrapLabel="true">0921 1021 1121 1221 1222 1223 1224 1325 1424 1524 1424 1425 1526 1527 1528 1628 1529 1528 1427 1327 1227 1128 1129 1130 1129 1128 1027 0927 0926 0925 0924 0923 0922 0921 </Border>
+    <Border Allegiance="ZhIn" LabelPosition="0205" WrapLabel="true" Color="Blue" Label="Zhodani Consulate">0000 0100 0200 0101 0102 0202 0303 0403 0504 0604 0705 0804 0904 1003 1103 1102 1201 1302 1401 1402 1303 1202 1103 1003 0904 0804 0705 0604 0505 0506 0507 0508 0608 0609 0610 0611 0712 0612 0613 0614 0514 0413 0412 0512 0511 0610 0609 0608 0508 0407 0307 0206 0106 0006 0005 0004 0003 0002 0001 0000 </Border>
+  </Borders>
+  <Routes>
+    <Route Start="1106" End="1006" />
+    <Route Start="1106" End="1005" />
+    <Route Start="1106" End="1204" />
+    <Route Start="1106" End="1307" />
+    <Route Start="1307" End="1705" />
+    <Route Start="1826" End="2228" />
+    <Route Start="1705" End="1904" />
+    <Route Start="1904" End="1903" />
+    <Route Start="1904" End="2005" />
+    <Route Start="2005" End="2007" />
+    <Route Start="2007" End="1910" />
+    <Route Start="1910" End="1810" />
+    <Route Start="1810" End="1711" />
+    <Route Start="1711" End="1413" />
+    <Route Start="1413" End="1116" />
+    <Route Start="1116" End="1118" />
+    <Route Start="1910" End="1912" />
+    <Route Start="1912" End="1815" />
+    <Route Start="1815" End="1719" />
+    <Route Start="1719" End="1920" />
+    <Route Start="1920" End="2319" />
+    <Route Start="2319" End="2417" />
+    <Route Start="2417" End="2716" />
+    <Route Start="2716" End="2814" />
+    <Route Start="2814" End="2712" />
+    <Route Start="2712" End="2510" />
+    <Route Start="2510" End="2410" />
+    <Route Start="2814" End="2913" />
+    <Route Start="2913" End="3010" />
+    <Route Start="3010" End="3110" />
+    <Route Start="3110" End="3209" />
+    <Route Start="3209" End="3309" />
+    <Route Start="2913" End="3212" />
+    <Route Start="3212" End="3312" />
+    <Route Start="2319" End="2418" />
+    <Route Start="2418" End="2621" />
+    <Route Start="2621" End="2323" />
+    <Route Start="2323" End="2124" />
+    <Route Start="2124" End="1824" />
+    <Route Start="1824" End="1526" />
+    <Route Start="1526" End="1525" Allegiance="SwCf" />
+    <Route Start="1525" End="1524" Allegiance="SwCf" />
+    <Route Start="1524" End="1523" Allegiance="SwCf" />
+    <Route Start="1523" End="1522" Allegiance="SwCf" />
+    <Route Start="1524" End="1424" Allegiance="SwCf" />
+    <Route Start="1424" End="1324" Allegiance="SwCf" />
+    <Route Start="1324" End="1223" Allegiance="SwCf" />
+    <Route Start="1223" End="1123" Allegiance="SwCf" />
+    <Route Start="1123" End="1022" Allegiance="SwCf" />
+    <Route Start="1022" End="0922" Allegiance="SwCf" />
+    <Route Start="0922" End="0921" Allegiance="SwCf" />
+    <Route Start="1424" End="1325" Allegiance="SwCf" />
+    <Route Start="1325" End="1225" Allegiance="SwCf" />
+    <Route Start="1225" End="1126" Allegiance="SwCf" />
+    <Route Start="1126" End="1026" Allegiance="SwCf" />
+    <Route Start="1026" End="0927" Allegiance="SwCf" />
+    <Route Start="1526" End="1329" />
+    <Route Start="1329" End="0930" />
+    <Route Start="0930" End="0732" />
+    <Route Start="0732" End="0534" />
+    <Route Start="0534" End="0433" />
+    <Route Start="0433" End="0333" />
+    <Route Start="0333" End="0133" />
+    <Route Start="0534" End="0538" />
+    <Route Start="0538" End="0139" />
+    <Route Start="2124" End="2125" />
+    <Route Start="2125" End="1826" />
+    <Route Start="2125" End="2327" />
+    <Route Start="2327" End="2228" />
+    <Route Start="2936" End="3235" />
+    <Route Start="3235" End="3032" />
+    <Route Start="3032" End="2733" />
+    <Route Start="3032" End="3030" />
+    <Route Start="3030" End="3029" />
+    <Route Start="3029" End="2927" />
+    <Route Start="2927" End="2828" />
+    <Route Start="2927" End="3025" />
+    <Route Start="3025" End="2726" />
+    <Route Start="2726" End="2324" />
+    <Route Start="2323" End="2324" />
+    <Route Start="3025" End="3124" />
+    <Route Start="3124" End="3324" />
+    <Route Start="0001" End="0103" Allegiance="ZhCo" />
+    <Route Start="0103" End="0304" Allegiance="ZhCo" />
+    <Route Start="0304" End="0307" Allegiance="ZhCo" />
+    <Route Start="0307" End="0608" Allegiance="ZhCo" />
+    <Route Start="0608" End="0610" Allegiance="ZhCo" />
+    <Route Start="0610" End="0712" Allegiance="ZhCo" />
+    <Route Start="0712" End="0614" Allegiance="ZhCo" />
+    <Route Start="0614" End="0412" Allegiance="ZhCo" />
+    <Route Start="0303" End="0304" Allegiance="ZhCo" />
+    <Route Start="0304" End="0705" Allegiance="ZhCo" />
+    <Route Start="0705" End="0904" Allegiance="ZhCo" />
+    <Route Start="0904" End="1103" Allegiance="ZhCo" />
+    <Route Start="1103" End="1402" Allegiance="ZhCo" />
+    <Route Start="0421" End="0223" Allegiance="DaCf" />
+    <Route Start="0223" End="0325" Allegiance="DaCf" />
+    <Route Start="0325" End="0426" Allegiance="DaCf" />
+    <Route Start="0426" End="0527" Allegiance="DaCf" />
+    <Route Start="0527" End="0727" Allegiance="DaCf" />
+    <Route Start="0325" End="0624" Allegiance="DaCf" />
+    <Route Start="0624" End="0724" Allegiance="DaCf" />
+    <Route Start="2936" End="3139" />
+  </Routes>
+</Sector>

--- a/res/Sectors/M1120/M1120.xml
+++ b/res/Sectors/M1120/M1120.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Sectors>
-  <!-- placeholder -->
+  <Sector Abbreviation="Spin" Tags="Unreviewed" Selected="true" Milieu="M1120">
+    <Y>-1</Y>
+    <X>-4</X>
+    <Name>Spinward Marches</Name>
+    <Name Lang="zh">Tloql</Name>
+    <DataFile Author="Marc W Miller" Source="MegaTraveller Imperial Encyclopedia">1120_Spin.sec</DataFile>
+    <MetadataFile>1120_Spin.xml</MetadataFile>
+  </Sector>
 </Sectors>


### PR DESCRIPTION
This is the first in a series of making sectors for the Rebellion. Basically it is taking data from Second Survey (Stars, W(orlds) Belts and GG, Size, Atmo, Hydro, nobles) with Social Data from the "Source" (Starport, Pop, Gov, Law, TL, Bases and Allegiance), applying some commonsense (I hope) then regenerating the rest of the UWP into a T5 format. Differences are attributable to the difference in years ihatei, raiders, etc.  Some things are new like the one world that is "new" with no T5SS record, so no name and such. Some were historical, like some worlds changing allegiance. Some do not match like the MT description of Border Worlds vs GURPS description of Border Worlds. It is ATU and i am going thru the sources chronologically in order of publication year. It was time-consuming for one sector. I have finished 1987, now onto 1988 sources...