### PR TITLE
1120 Hinterworlds Sector

### DIFF
--- a/res/Sectors/M1120/1120_Hint.sec
+++ b/res/Sectors/M1120/1120_Hint.sec
@@ -1,0 +1,438 @@
+Hex  Name                 UWP       Remarks                  {Ix}   (Ex)    [Cx]   N B  Z PBG W  A    Stellar       
+---- -------------------- --------- ------------------------ ------ ------- ------ - -- - --- -- ---- --------------
+0101 Nahru                D100201-7 Va Lo                    { -3 } (411-5) [1113] - -  - 703 12 RaRa G0 V M8 V     
+0102 Halanna              D62A442-7 Ni                       { -3 } (631-5) [1113] - -  - 300 6  RaRa M3 V          
+0104 Adar                 B100456-A Va Ni                    { 0 }  (833+1) [3449] B -  - 402 7  MaSt M3 V M5 V     
+0201 Kaggits              A545300-B Lo                       { 1 }  (A21-2) [1416] - KM - 214 15 RaRa M1 V          
+0210 Deymun Na            B310352-D Lo                       { 1 }  (921-2) [1419] - KM - 104 11 RaRa K3 V M5 V     
+0306 Terbain              C98A523-6 Wa Ni Pr                 { -2 } (742-5) [2323] - -  - 603 9  NaHu K3 V M9 V     
+0307 Nii                  C310599-B Ni                       { 0 }  (A44+1) [656C] - -  - 803 11 NaHu M1 V          
+0402 Venad                A421621-B He Ni Na                 { 2 }  (E56-3) [2817] B -  - 324 14 MaSt M0 V M6 V     
+0406 Dirmidi              E3107CE-7 Na Pi Fo                 { -2 } (966+2) [B59B] - -  R 403 11 NaHu M0 V M0 V     
+0407 Gerdane              C000110-7 As Va Lo                 { -2 } (301-5) [1112] - -  - 901 13 RaRa M9 III D      
+0410 Leral                D310411-9 Ni                       { -3 } (930-5) [1115] - -  - 921 16 RaRa A2 V          
+0501 Ginshar              A410631-B Ni Na Da                 { 2 }  (B56-3) [2817] - K  A 803 9  NaHu K2 V          
+0504 Luki                 E79A758-7 Wa Pi                    { -2 } (966-2) [7557] - -  - 604 10 NaHu M2 V M4 V     
+0505 Frelda               C100441-8 Va Ni                    { -2 } (931-5) [1214] - -  - 812 11 RaRa M3 V          
+0602 Fugitak              C5A027A-8 De He Lo Da              { -2 } (B11+1) [417A] - -  A 125 13 NaHu F2 V M3 V     
+0603 Dermif Na            B542521-7 He Ni                    { -1 } (743-5) [1413] - M  - 522 15 RaRa M0 V          
+0605 Luggi                C6978AD-5 Ph Pa Pi Fo              { -1 } (A76+3) [C799] - -  R 324 18 RaRa K0 V          
+0608 Sablass              B6A1402-B Fl He Ni                 { 1 }  (934-2) [1517] - KM - 803 14 RaRa M0 V          
+0610 Konn                 E555416-6 Ni Pa                    { -3 } (631-4) [3145] - -  - 104 14 NaHu G0 V M7 V     
+0708 Pike                 A637644-8 Ni                       { 0 }  (C54-3) [4636] - -  - 104 11 NaHu M3 V M5 V     
+0710 Neuria               E200444-8 Va Ni                    { -3 } (931-5) [2136] - -  - 112 12 NaHu M2 V M4 V M4 V
+0801 Boilingbrook         A9C9751-D Fl Pi                    { 2 }  (96D-2) [3919] - -  - 700 9  NaHu G0 II         
+0806 Uumanur              B552444-A Ni                       { 0 }  (833-1) [2438] - M  - 820 9  NaHu K2 IV         
+0807 Salmri               E769585-6 Ni Pr Da                 { -3 } (741-5) [3234] - -  A 202 11 RaRa M1 V          
+0902 Eskufet              E779103-6 Lo                       { -3 } (301-5) [1123] - -  - 604 10 NaHu M1 V          
+0906 Damii                A000359-D As Va Lo Da              { 1 }  (521+3) [446E] - KM A 700 11 NaHu K0 V M7 V     
+0907 Serala Na            C586220-5 Lo                       { -2 } (411-5) [1111] - -  - 303 10 RaRa K5 II         
+0909 Dibs                 B654331-8 Lo                       { -1 } (721-5) [1214] - -  - 902 14 RaRa M1 V          
+1001 Kupakii              C654352-A Lo                       { -1 } (A21-4) [1216] - S  - 905 12 CsIm K4 IV M8 V    
+1006 Durne                B539511-A Ni Da                    { 0 }  (C44-3) [1516] - K  A 814 12 RaRa K1 V          
+1007 Gomms                A310679-C Ni Na                    { 2 }  (E56+2) [786D] - -  - 724 16 RaRa M3 V          
+1103 Gimisapun            A000400-C As Va Ni                 { 1 }  (934-3) [1517] - -  - 603 10 NaHu M0 V M2 V     
+1104 Tlianke              B664AA9-C Hi                       { 3 }  (E9E+4) [BD6D] - M  - 220 9  NaHu M3 V M1 V     
+1105 Khumukunar           B594100-8 Lo                       { -1 } (501-5) [1113] - M  - 902 12 NaHu M1 V          
+1109 Breevort             C9B48AA-8 Fl Ph Pi Pz              { -1 } (G77+1) [A77A] - -  A 424 17 NaHu G4 V          
+1202 Arghikii             E653557-8 Ni                       { -3 } (941-3) [5258] - -  - 102 9  NaHu M2 V          
+1205 Girar                B645766-9 Ag Pi Mr Pz              { 1 }  (D6A+1) [6848] - M  A 322 9  NaHu M2 V M5 V     
+1206 Gashuumi             B527769-7 Pi O:1205                { 0 }  (968+1) [8768] - -  - 923 14 NaHu M2 V M9 V     
+1210 Aquiar               A87A300-D Wa Lo                    { 1 }  (B21-3) [1418] - -  - 124 15 NaHu F9 V          
+1301 Imukushush           C55969A-5 Ni                       { -1 } (853+1) [8577] - S  - 720 10 CsIm G3 V          
+1302 Hyraxa               D541777-5 He Pi                    { -2 } (965-2) [7555] - -  - 624 10 NaHu M0 V M5 V     
+1306 Zelebex              C769235-8 Lo                       { -2 } (811-4) [1136] - -  - 204 11 NaHu K9 III D      
+1307 Mupikaa              A426588-A Ni                       { 0 }  (A44+1) [555A] - -  - 903 9  NaHu M2 V          
+1401 Gustavus             A100345-B Va Lo                    { 1 }  (621-1) [1439] - -  - 601 9  AnTC M1 V          
+1402 Utgaard              D1009BB-A Va Hi Na In Fo           { 1 }  (G8B+4) [BA7C] - -  R 305 11 AnTC K5 IV M3 V    
+1408 Drosyodryu           B541887-7 He Ph Pi Pz              { 0 }  (A78+1) [8857] - -  A 401 7  NaHu M3 V          
+1409 Shilikhulu           B67A110-9 Wa Lo                    { -1 } (601-4) [1114] - -  - 503 7  NaHu G3 IV M5 V    
+1601 Tudor                A94956A-9 Ni O:Glim-1438           { -1 } (C43+2) [747B] - -  - 923 18 NaHu K1 V M4 V     
+1604 Ankhamon             C889101-B Lo Da                    { 0 }  (801-4) [1117] - -  A 614 14 AnTC M2 V M3 V     
+1605 Kayhyurv             C97A100-A Wa Lo                    { -1 } (501-4) [1115] - -  - 302 7  AnTC K3 IV M5 V    
+1606 Rambaran             CAE5443-7 Ni                       { -2 } (631-5) [1224] - -  - 704 10 AnTC M3 V          
+1609 Ariden               A55578B-A Ag                       { 2 }  (E6B+5) [997C] - -  - 214 18 NaHu F1 IV         
+1705 Glower               E548442-5 Ni Pa                    { -3 } (631-5) [1111] - -  - 900 10 AnTC M0 V          
+1707 Hammerhead           B1007BC-B Va Na Pi Fo              { 2 }  (F6C+5) [A98E] - K  R 224 10 AnTC K4 V          
+1709 Xavier               E200410-9 Va Ni                    { -3 } (A30-5) [1114] - -  - 604 9  NaHu M1 V K8 V     
+1710 Dry Drop             E4238AA-7 Ph Na Pi Pz              { -2 } (A76+1) [A679] - -  A 905 12 NaHu M1 V M1 V     
+1802 Calvice              A553334-B Lo                       { 1 }  (921-1) [1439] - -  - 704 12 AnTC K7 V          
+1804 Bryce                D424427-8 Ni Px                    { -3 } (A31-3) [4158] - -  - 604 12 AnTC M1 V          
+1806 Deddigan             E100779-7 Va Na Pi                 { -2 } (966-1) [8568] - -  - 505 15 AnTC M3 V          
+1807 Jorsmuur             B544244-7 Lo                       { -1 } (411-3) [1135] - -  - 303 9  AnTC M0 V M3 V M6 V
+1809 Gamasav              E625200-8 Lo                       { -3 } (911-5) [1113] - -  - 914 12 NaHu F3 V M7 V M3 V
+1810 Jennethaka           C434730-9                          { -1 } (B68-4) [2614] - -  - 920 11 NaHu M2 V          
+1907 Ansumer              A72A538-C Ni                       { 1 }  (845+1) [565C] - K  - 901 6  AnTC M2 V          
+1908 Heflet               C100126-9 Va Lo                    { -2 } (901-2) [1148] - -  - 724 12 AnTC M2 V          
+1909 Brandi               A655620-9 Ga Ni Ag                 { 1 }  (E55-3) [1714] - -  - 133 13 NaHu K0 V          
+2001 Borman               E547666-6 Ni Ag O:2401             { -1 } (853-3) [5545] - -  - 804 7  NaHu M6 II D       
+2003 Apogee               A7678A6-B Ga Ph Pa Ri              { 3 }  (E7D+2) [7B4A] - -  - 104 12 AnTC K0 V          
+2005 Anubis               B310ABD-C Hi Na In Cx Fo           { 4 }  (G9F+5) [EE9G] - KM R 704 15 AnTC G4 V M7 V     
+2006 Chester              B866441-6 Ga Ni Pa                 { -1 } (632-5) [1312] - M  - 614 13 AnTC K7 IV         
+2010 Hyam                 A553744-9                          { 0 }  (C69-1) [5737] - -  - 612 13 NaHu G1 II D       
+2107 Rimswing             B428532-A Ni                       { 0 }  (844-3) [1516] - K  - 810 8  AnTC M2 V          
+2109 Gibbett              B000445-D As Va Ni                 { 1 }  (934-1) [253B] - -  - 221 15 NaHu M4 III        
+2110 Tur-Hunar            D84A666-7 Wa Ni Mr                 { -2 } (852-4) [5446] - S  - 703 9  CsIm M0 V K2 V     
+2201 Reuper               A310743-C Na Pi                    { 2 }  (C6C-1) [4929] - -  - 603 14 AnTC G7 III M5 V   
+2205 Didinack             B200689-9 Va Ni Na                 { 0 }  (954+1) [766A] - -  - 310 11 AnTC K2 V          
+2206 Brang                A40026A-B Va Lo O:2005             { 1 }  (911+3) [437D] - -  - 414 10 AnTC F2 V          
+2301 Testament            A100489-D Va Ni                    { 1 }  (A34+2) [556E] - -  - 804 15 NaHu M3 V          
+2306 Fafi                 C567764-6 Ag Ri O:2005             { 1 }  (968-1) [5834] - -  - 204 11 AnTC M2 V M2 V     
+2401 Dullsure             B584741-9 Ag Ri                    { 2 }  (D6B-1) [3915] - -  - 904 14 NaHu M2 V M6 V     
+2404 Kemphus              DAA869A-8 Fl Ni Ag                 { -1 } (C53-1) [857A] - -  - 904 11 AnTC M1 V M7 V     
+2408 Sextant              E42785A-7 Ph Pi                    { -2 } (A76+1) [A679] - -  - 700 4  NaHu K3 V          
+2409 Tuscaloma            D100230-9 Va Lo                    { -3 } (911-5) [1114] - -  - 714 10 NaHu M0 V          
+2504 Vaughn               A79A343-A Wa Lo                    { 0 }  (821-1) [1327] - KM - 403 12 AnTC K0 II         
+2506 Remik                B789127-8 Lo                       { -1 } (701-1) [1158] - -  - 713 12 AnTC K0 V M6 V     
+2607 Nagikare             C54248C-7 He Ni Da LamuW           { -2 } (631+1) [728A] - -  A 914 14 CyUn M2 V M5 V     
+2608 Goore                B4336A8-C Ni Na Px LamuW           { 2 }  (C56+1) [685C] - K  - 522 9  CyUn F0 V          
+2610 Dashimev             E747303-7 Lo Da LamuW              { -3 } (521-5) [1124] - -  A 200 6  CyUn K7 V          
+2705 Cessinyv             D697537-5 Ni Ag                    { -2 } (742-2) [5355] - -  - 604 12 NaHu G0 V          
+2708 Verganeg             BA9A566-9 Oc Wa Ni LamuW O:2709    { -1 } (943-1) [4448] - -  - 902 8  CyUn M3 V M7 V     
+2709 Darunne              C300775-A Va Na Pi LamuW           { 0 }  (B69-1) [5738] - -  - 502 10 CyUn M3 V          
+2802 Kikove               C557231-6 Lo Da                    { -2 } (411-5) [1112] - -  A 904 14 NaHu K2 V M4 V     
+2804 Maggiv               B310733-9 Na Pi LamuW              { 0 }  (E69-2) [4726] - K  - 405 13 CyUn M1 V          
+2806 Terpunne             C559210-6 Lo LamuW                 { -2 } (411-5) [1111] - -  - 113 12 CyUn M8 III D      
+2901 Baliev               D689563-4 Ni Pr Cy LamuW O:3003    { -3 } (741-5) [2221] - -  - 204 13 CyUn K4 V          
+2907 Cikuek               B658433-B Ni Pa (Lamura Gav/Teg)   { 1 }  (834-2) [1528] - M  - 102 11 CyUn M1 V          
+2909 Gigivere             C422484-A He Ni LamuW              { -1 } (A32-2) [2338] - -  - 913 9  CyUn K8 III D      
+3001 Varmuki              E7767AA-5 Ag Pi Pz LamuW           { -1 } (966+1) [9677] - -  A 721 9  CyUn G2 V M3 V     
+3002 Hetriame             D555772-6 Ag LamuW                 { -1 } (966-5) [3612] - -  - 320 10 CyUn M1 V M3 V     
+3003 Alike                A53898A-D Hi Cx Lamu8              { 3 }  (E8F+5) [BC7F] - K  - 603 12 CyUn M2 V          
+3004 Darun                D9D4320-7 Lo LamuW                 { -3 } (521-5) [1112] - -  - 203 14 CyUn K0 V          
+3005 Lerive               D551764-2 LamuW O:3003             { -2 } (963-4) [5531] - -  - 401 11 CyUn K0 IV M6 V    
+3009 Twohoy               C596775-5 Ag Pi Chir7 Lamu2        { 0 }  (967-2) [5733] - -  - 811 13 CyUn K7 V M9 V     
+3101 Beedrav              E6A6665-8 Fl Ni Ag Da LamuW O:3003 { -1 } (B53-5) [4536] - -  A 603 14 CyUn M2 V          
+3102 Nemini               B434100-E Lo LamuW                 { 1 }  (601-3) [1219] - -  - 612 11 CyUn M2 V          
+3103 Bachev               BAC5333-A Fl Lo LamuW              { 0 }  (821-1) [1327] - KM - 303 13 CyUn M0 V          
+3104 Civerimu             C693567-7 Ni LamuW O:3003          { -2 } (742-2) [5357] - -  - 423 13 CyUn M0 V          
+3110 Gavarisu             C100572-9 Va Ni LamuW              { -2 } (742-5) [1315] - -  - 200 9  CyUn M1 V          
+3206 Catek                D10049D-7 Va Ni Fo LamuW           { -3 } (631+1) [819B] - -  R 614 16 CyUn M2 V          
+3209 Frumurev             C200686-9 Va Ni Na LamuW           { -1 } (C53-2) [5548] - -  - 704 10 CyUn G4 V          
+3210 Bage                 E8A4512-8 Fl Ni Ag LamuW           { -2 } (942-5) [1314] - -  - 602 14 CyUn M4 III        
+0114 Ranlm                C100630-A Va Ni Na                 { 0 }  (B54-4) [1615] - -  - 503 12 RaRa M2 V M4 V     
+0116 Shaa                 A300842-A Va Ph Na Pi              { 1 }  (A7A-2) [4916] - -  - 600 4  NaHu M2 V          
+0120 Aqqle                E9D89B9-4 Hi Pi Pz                 { -1 } (B86+1) [A865] - -  A 822 12 NaHu K4 V          
+0311 Berange              C428ACB-7 Hi In Cx Fo              { 1 }  (C9A+3) [CB79] - -  R 414 16 RaRa M3 V          
+0315 Gisamuve             C9A6249-8 Fl Lo                    { -2 } (911-1) [3169] - -  - 605 17 RaRa M3 V M7 V     
+0316 Ravane               B7B6675-8 Fl Ni                    { 0 }  (954-3) [4636] - -  - 301 8  RaRa F3 V M4 V     
+0317 Herann               C425473-9 Ni                       { -2 } (931-4) [1226] - S  - 603 7  CsIm G1 V M6 V     
+0318 Gaggin               D310411-7 Ni                       { -3 } (631-5) [1113] - -  - 404 12 NaHu F7 III        
+0320 Blessed              E20068A-7 Va Ni Na                 { -2 } (852-1) [8479] - -  - 102 11 NaHu F0 V          
+0413 Kandusa              B20076B-7 Va Na Pi O:0712          { 0 }  (968+2) [9779] - -  - 804 13 RaRa G0 V M8 V     
+0417 Galia                D546615-5 Ni Ag                    { -1 } (853-4) [4533] - -  - 300 5  NaHu K5 V M0 V     
+0419 Strend               B2006AA-8 Va Ni Na Da              { 0 }  (C54+1) [867A] - -  A 113 14 NaHu F4 V          
+0514 Shadow               D434223-6 Lo                       { -3 } (411-5) [1123] - -  - 504 8  RaRa A2 V M0 V     
+0515 Twukayudiess         E537200-8 Lo                       { -3 } (411-5) [1113] - -  - 100 9  RaRa M0 V          
+0516 Gavime               C77678A-5 Ag Pi                    { 0 }  (967+2) [9777] - -  - 814 9  RaRa M2 III        
+0517 Lodanar              E798132-5 Lo                       { -3 } (301-5) [1111] - -  - 904 9  NaHu M2 V          
+0520 Harov                A77A433-C Wa Ni                    { 1 }  (934-1) [1529] - KM - 503 6  NaHu M2 V M5 V M0 V
+0617 Dyse                 D100532-7 Va Ni                    { -3 } (741-5) [1213] - -  - 904 12 NaHu M3 V          
+0620 Tiffany              CA8A788-9 Oc Wa Ri                 { 0 }  (D69+1) [7759] - S  - 604 16 CsIm M2 V M2 V     
+0712 Nummen               B95A653-B Wa Ni                    { 2 }  (E56-2) [3828] - K  - 224 14 RaRa M1 V          
+0713 Scordon              C552577-5 Ni                       { -2 } (742-2) [5355] - -  - 505 12 NaHu G4 V M7 V     
+0714 Even-Score           C625856-7 Ph Pi                    { -1 } (A77-2) [7746] - -  - 804 9  NaHu M1 V          
+0718 Parthia              C310100-9 Lo                       { -2 } (701-5) [1114] - -  - 404 10 NaHu M0 V          
+0813 Dold                 A572202-D He Lo                    { 1 }  (911-2) [1319] - KM - 205 13 RaRa M1 V M2 V     
+0814 Baller               E100135-A Va Lo                    { -2 } (701-3) [1138] - -  - 813 15 RaRa M2 V M1 V     
+0817 Quiet Pride          A9A7478-9 Fl Ni Pa                 { -1 } (732+1) [4359] - KM - 501 14 NaHu K0 V M7 V     
+0818 Golus                E100446-9 Va Ni                    { -3 } (A30-3) [3148] - -  - 204 17 NaHu K8 II         
+0916 Hattop               C846634-5 Ni Ag                    { 0 }  (854-3) [4633] - -  - 124 14 RaRa M2 V          
+0917 Cassius              C97A631-7 Wa Ni                    { -1 } (853-5) [2513] - -  - 613 10 NaHu M0 V          
+0918 Khadi                E553414-7 Ni                       { -3 } (631-5) [2135] - -  - 503 12 CsIm G8 V          
+0919 Edmund               E400798-7 Va Na Pi                 { -2 } (966-2) [7557] - -  - 312 11 NaHu K2 V M4 V     
+1012 Khushudug            C895687-5 Ni Ag Da                 { 0 }  (854-1) [6655] - -  A 401 7  NaHu K0 V M1 V     
+1015 Agbi                 C43149B-9 Ni Da                    { -2 } (931+1) [627B] - -  A 603 13 NaHu M3 V M6 V     
+1020 Caliban              E310343-7 Lo                       { -3 } (521-5) [1124] - -  - 913 16 NaHu G8 V          
+1115 Ceearr               E1006BE-7 Va Ni Na Fo              { -2 } (852+1) [A49B] - -  R 214 12 NaHu K2 V M2 V     
+1116 Kanterovich          D687313-3 Ga Lo                    { -3 } (521-5) [1121] - -  - 203 10 NaHu K5 V          
+1117 Carbaday             B635788-8                          { 0 }  (C68+1) [7758] - -  - 703 11 NaHu M1 V          
+1120 Undru                C100125-9 Va Lo                    { -2 } (701-3) [1137] - -  - 904 10 NaHu K2 V          
+1211 Liibaar              C666897-6 Ga Ph Pa Ri              { 0 }  (A77+1) [8856] - S  - 303 11 CsIm K4 V          
+1212 Rotstern             D551457-8 Ni                       { -3 } (B31-3) [4158] - -  - 714 12 NaHu M0 V          
+1313 Lu                   B100668-9 Va Ni Na O:1315          { 0 }  (E54+1) [6659] - -  - 624 18 NaHu M3 V M4 V     
+1315 Arkon                C56999B-A Hi Pr Pz                 { 1 }  (F8B+4) [BA7C] - -  A 113 13 NaHu G4 V M8 V     
+1316 G-R                  C676200-5 Lo                       { -2 } (411-5) [1111] - -  - 813 8  NaHu F3 V          
+1413 Early Frost          E556552-5 Ni Ag                    { -2 } (742-5) [1311] - -  - 803 9  NaHu M2 V          
+1417 Varag                A588762-8 Ag Ri O:1519             { 2 }  (C6A-2) [3914] - -  - 803 13 NaHu K3 II         
+1420 Normand              C5436BG-5 Ni Fo                    { -1 } (853+3) [B5AA] - -  R 904 8  NaHu G2 V          
+1514 Ikumm                C310732-8 Na Pi                    { -1 } (A67-5) [3614] - -  - 810 4  NaHu K1 V          
+1519 Mainline             B6797AB-9 Pi Pz                    { 0 }  (E69+3) [977B] - M  A 814 17 NaHu K0 V M2 V     
+1520 Peterstadt           B83769A-9 Ni                       { 0 }  (D54+2) [867B] - M  - 805 17 NaHu K9 IV M9 V    
+1611 Deanne               E99A300-5 Wa Lo                    { -3 } (521-5) [1111] - -  - 405 12 NaHu K7 V M9 V M6 V
+1613 Hont                 C579355-9 Lo                       { -2 } (821-3) [1137] - -  - 803 11 NaHu M3 V          
+1614 Zhreggeushi          E434121-6 Lo                       { -3 } (301-5) [1112] - -  - 922 13 NaHu M3 V M8 V     
+1615 Darny's Rock         C100644-7 Va Ni Na                 { -1 } (853-4) [4535] - -  - 902 7  NaHu M0 V M8 V     
+1616 Thanas               B763786-6 Ri                       { 1 }  (968+1) [6845] - -  - 604 16 NaHu M5 III D      
+1619 Bucolia              C87858C-7 Ni Ag Da                 { -1 } (743+2) [848A] - -  A 900 4  NaHu K2 V          
+1711 Glass                B525856-A Ph Pi                    { 1 }  (E7A+1) [7949] - M  - 822 14 NaHu M1 V M5 V     
+1712 Strane               D648865-5 Ph Pa Pi O:1711          { -2 } (A75-4) [6633] - -  - 810 7  NaHu M4 III D      
+1714 Helvo                D200852-7 Va Ph Na Pi              { -2 } (A76-5) [4613] - -  - 404 11 NaHu F8 IV         
+1719 Yellowtide           C563226-9 Lo                       { -2 } (811-2) [1148] - -  - 904 9  NaHu K8 V M6 V     
+1720 Annex                B434300-C Lo Da                    { 1 }  (921-3) [1417] - -  A 104 16 NaHu K6 V          
+1816 Skigg                A100120-D Va Lo                    { 1 }  (701-3) [1218] - -  - 213 13 NaHu M0 V          
+1817 Namillo              C666341-9 Ga Lo                    { -2 } (721-5) [1115] - S  - 220 10 CsIm M0 III D      
+1820 Ipidina              C3008B7-8 Va Ph Na Pi              { -1 } (C77-1) [8758] - -  - 711 6  NaHu M3 V M6 V     
+1915 Streeve              C99A698-8 Wa Ni                    { -1 } (D53-2) [6558] - -  - 314 12 NaHu G2 V          
+1917 Mey Tyro             D534654-7 Ni                       { -2 } (852-5) [4435] - -  - 102 14 NaHu G4 V          
+1920 Xavid                C43579A-6                          { -1 } (966+1) [9678] - -  - 102 13 NaHu G4 V M8 V     
+2011 Likugash             C537477-A Ni                       { -1 } (B32+1) [435A] - -  - 423 15 NaHu K4 V          
+2015 Effit                A5936B6-A Ni                       { 1 }  (C55+1) [5749] - -  - 104 13 NaHu A4 V          
+2016 Kishir               B73A344-A Wa Lo                    { 0 }  (621-1) [1338] - -  - 701 5  NaHu M0 V          
+2111 Hasvari              C4245AC-7 Ni Fo                    { -2 } (742+1) [838A] - -  R 204 10 NaHu M7 III        
+2112 Jaris                C554300-6 Lo                       { -2 } (521-5) [1111] - -  - 704 11 NaHu A4 V M4 V     
+2119 Drygrass             C546576-5 Ni Ag Da                 { -1 } (743-2) [4444] - -  A 214 13 NaHu M1 V K9 V     
+2120 Manak                D433551-9 Ni                       { -3 } (941-5) [1215] - -  - 902 13 NaHu K4 V          
+2216 Jaffik               C9B4453-A Fl Ni Da                 { -1 } (A32-3) [1327] - -  A 904 17 NaHu M0 V          
+2218 Zisurar              D522302-8 He Lo                    { -3 } (721-5) [1114] - -  - 902 8  NaHu K9 V          
+2313 Tamrice              B432496-A Ni Px                    { 0 }  (833+1) [3449] - M  - 320 7  NaHu M1 V          
+2315 Khugili              C545111-8 Lo                       { -2 } (701-5) [1114] - -  - 304 12 NaHu G6 V M6 V     
+2316 Trial                A563566-C Ni Pr Mr                 { 1 }  (B45+1) [464B] - KM - 304 12 NaHu G2 V M2 V     
+2318 Scratch              C546354-6 Lo                       { -2 } (521-4) [1134] - -  - 522 13 NaHu M3 V M6 V     
+2413 Arctica Nova         D529666-7 Ni O:2814                { -2 } (852-4) [5446] - -  - 604 12 NaHu M2 V          
+2414 Dar                  B666502-9 Ga Ni Ag Pr              { 0 }  (C44-3) [1515] - -  - 623 13 NaHu M0 V          
+2418 Hypagg               C574242-9 Lo                       { -2 } (911-5) [1115] - S  - 414 10 CsIm K6 V M8 V     
+2516 Whitesheet           C787303-5 Ga Lo                    { -2 } (521-5) [1122] - -  - 902 14 NaHu G5 V          
+2614 Obendal              B9D4431-7 Ni Da                    { -1 } (632-5) [1313] - -  A 504 9  NaHu M2 V          
+2615 Lost Echo            B576148-8 Lo                       { -1 } (601-1) [1158] - -  - 303 9  NaHu M3 V          
+2617 Carmine              C7A2400-8 Fl He Ni                 { -2 } (931-5) [1213] - -  - 703 7  NaHu K8 II         
+2620 Marble               CAB5530-8 Fl Ni                    { -2 } (B42-5) [1313] - -  - 504 14 NaHu A3 V          
+2713 Calbern              C000543-A As Va Ni                 { -1 } (C43-3) [2427] - -  - 714 9  NaHu K2 III        
+2813 Mura                 B884556-A Ni Ag Pr                 { 1 }  (C45+1) [4649] - -  - 523 9  NaHu K2 V          
+2814 Tren                 B4007BG-B Va Na Pi Fo              { 2 }  (B6C+5) [C9AG] - KM R 711 14 NaHu M1 V M6 V     
+2816 Gruuvurr             BAA9326-8 Fl Lo                    { -1 } (921-2) [2247] - -  - 904 13 NaHu M3 III D      
+2817 Pru-magu             A9B4433-A Fl Ni GniiW              { 0 }  (733-2) [1427] - -  - 201 9  GnCl K6 IV         
+2912 Cerban               C434420-A Ni                       { -1 } (932-4) [1315] - -  - 521 12 NaHu G4 V M2 V     
+2916 Treber               A66A535-B Wa Ni Pr                 { 1 }  (845-1) [3639] - -  - 610 13 NaHu M3 V          
+2917 Ar-domm'l            A100374-C Va Lo GniiW              { 1 }  (A21-1) [143A] - K  - 614 12 GnCl K8 V M2 V     
+2920 Pru-drend            D310554-A Ni GniiW                 { -2 } (E42-3) [3338] - -  - 525 18 GnCl K2 V          
+3015 Kwekyl               B965645-8 Ni Ag Ri                 { 2 }  (C56-1) [4836] - -  - 104 9  NaHu M1 V M5 V     
+3111 Lermeliv             E534622-6 Ni LamuW                 { -2 } (852-5) [2412] - -  - 502 15 CyUn M0 V          
+3114 Jukake               C778530-5 Ni Ag                    { -1 } (743-5) [1411] - -  - 503 15 NaHu M2 V M8 V M6 V
+3117 Pru-trumonn          C543157-7 Lo GniiW                 { -2 } (301-2) [1157] - -  - 404 14 GnCl K3 V M6 V     
+3119 Pru-devum            C986676-6 Ni Ag Ri GniiW           { 1 }  (855-1) [5745] - -  - 914 13 GnCl M0 V M2 V     
+3212 Speehl               A000245-D As Va Lo                 { 1 }  (811-1) [133B] - -  - 504 14 NaHu K2 V          
+3218 Pru-gam              C100344-9 Va Lo GniiW              { -2 } (721-3) [1137] - -  - 602 11 GnCl G7 III        
+3219 Ghi-nabrin'l         D527333-7 Lo GniiW                 { -3 } (521-5) [1124] - -  - 702 12 GnCl M1 V          
+3220 Ghi-radul            D8A3325-8 Fl Lo GniiW              { -3 } (821-5) [1136] - -  - 203 7  GnCl M1 V          
+0123 Kunlam               D551522-3 Ni                       { -3 } (741-5) [1211] - -  - 613 8  NaHu K4 V M4 V     
+0124 Relar                C567699-4 Ni Ag Ri                 { 1 }  (855+1) [7765] - -  - 115 15 NaHu K1 V M5 V     
+0126 Khi                  A643500-B Ni                       { 1 }  (C45-3) [1616] - -  - 805 12 NaHu A4 V G6 V     
+0128 Irdikur              B666777-8 Ga Ag Ri Pz              { 2 }  (C6A+2) [7958] - -  A 221 10 SoCf G4 V          
+0322 Mire                 C66859D-7 Ni Ag Pr Fo              { -1 } (743+3) [949B] - -  R 402 8  NaHu K3 V          
+0326 Aympe                A6A137A-9 Fl He Lo                 { -1 } (A21+3) [527B] - KM - 223 13 NaHu K5 V M1 V     
+0327 Strabbin             B765236-B Ga Lo Da                 { 1 }  (711+1) [134A] - -  A 603 11 NaHu M3 V M5 V     
+0328 Galazii              B8A3679-8 Fl Ni Px                 { 0 }  (C54+1) [7669] - M  - 713 11 NaHu K1 V          
+0423 Benson               A557200-E Lo                       { 1 }  (611-3) [1319] - -  - 702 10 NaHu M0 V M7 V     
+0424 Arkina               B997621-7 Ni Ag                    { 1 }  (855-4) [2713] - -  - 803 10 NaHu K9 IV         
+0521 Morgan's Rest        C525200-9 Lo                       { -2 } (711-5) [1114] - -  - 512 13 NaHu M0 V          
+0523 Turek                E89A7BB-7 Wa Pi Fo                 { -2 } (966+1) [9579] - -  R 103 14 NaHu K4 V M1 V     
+0524 Riies                C888975-8 Hi Pr                    { 0 }  (G89-2) [7936] - -  - 923 13 NaHu G3 V M1 V     
+0525 Assar                C744210-6 Lo                       { -2 } (411-5) [1111] - -  - 103 9  NaHu M3 V          
+0526 Everana              B538555-9 Ni                       { -1 } (843-2) [3437] - -  - 501 9  NaHu M2 V K4 V     
+0528 Windsor              B652542-A Ni                       { 0 }  (A44-3) [1516] - M  - 703 10 NaHu A0 V          
+0621 Torrent              C78A379-8 Wa Lo                    { -2 } (A21-1) [4169] - -  - 414 14 NaHu M0 V M2 V M1 V
+0622 Calmere              D655643-4 Ga Ni Ag                 { -1 } (853-5) [3521] - -  - 503 11 NaHu K3 V M4 V M1 V
+0623 Straub               C31088A-9 Ph Na Pi                 { -1 } (G78+2) [A77B] - -  - 124 11 NaHu M3 V M8 V     
+0624 Hugus                D434554-8 Ni                       { -3 } (941-5) [3236] - -  - 302 6  NaHu M2 V          
+0721 Brannif              C100126-9 Va Lo                    { -2 } (601-2) [1148] - -  - 721 7  NaHu M1 V M6 V     
+0722 Windrift             C566559-A Ni Ag Pr                 { 0 }  (B44+2) [656B] - -  - 904 16 NaHu M1 V M5 V     
+0725 Hapsburg             B521345-8 He Lo Da                 { -1 } (821-3) [1236] - M  A 603 12 SoCf M0 V          
+0824 Nullia               A5669B7-D Hi Pr (Nullians)         { 3 }  (H8F+4) [9C5D] - KM - 524 13 NaHu G4 V M3 V     
+0830 Sweet Water          B575545-B Ni Ag                    { 2 }  (946+1) [3739] - -  - 902 13 NaHu M3 V          
+0921 Brosak               B544576-A Ni Ag                    { 1 }  (B45+1) [4649] - -  - 804 12 NaHu M2 V          
+0923 Sigam                C66A59C-A Wa Ni Pr Da              { -1 } (843+3) [848D] - -  A 501 10 NaHu K6 II         
+0924 Lady Mac             A200320-A Va Lo Da                 { 0 }  (B21-3) [1315] - -  A 415 11 SoCf K2 V M5 V     
+1021 Overshoal            C67A878-7 Wa Ph Pi                 { -1 } (A77-1) [8757] - -  - 303 10 NaHu K1 V          
+1026 Angerhelm            A888699-9 Ni Ag Ri Da              { 2 }  (A56+4) [786A] - KM A 402 9  NaHu M0 V          
+1030 Far Cry              B568500-B Ni Ag Pr                 { 2 }  (C46-1) [1716] - KM - 205 15 NaHu M3 V          
+1123 Meadow               C595654-7 Ni Ag                    { 0 }  (854-3) [4635] - -  - 103 13 NaHu G1 V          
+1124 Ane                  B684511-8 Ni Ag Pr                 { 0 }  (B44-4) [1514] - -  - 713 7  NaHu K6 IV         
+1128 213-584              A100321-C Va Lo Da StalW           { 1 }  (921-3) [1418] - -  A 204 15 OcWs K3 III        
+1221 Calm Reverie         C310374-8 Lo                       { -2 } (721-4) [1136] - -  - 702 7  NaHu M1 V          
+1223 Uga                  E566740-3 Ag Ri                    { 0 }  (966-4) [2711] - -  - 203 9  NaHu M1 V M7 V     
+1322 Yokoya's Stand       D5A36B9-8 Fl Ni Px Da              { -2 } (E52-2) [7469] - -  A 224 18 NaHu M1 V M9 V     
+1328 214-389              D75887B-6 Ph Pa Pz (Stalkers)      { -2 } (A75+1) [A678] - -  A 414 14 OcWs M1 II M6 V    
+1329 Daniss               C100312-8 Va Lo                    { -2 } (A21-5) [1114] - -  - 114 12 OcWs M1 V M6 V     
+1421 Stailveiki           C100511-7 Va Ni                    { -2 } (742-5) [1313] - -  - 411 11 NaHu M3 V M9 V     
+1423 Horton               D668200-7 Lo                       { -3 } (411-5) [1112] - -  - 305 12 NaHu M3 V K4 V     
+1426 212-332              C858100-7 Lo Da StalW              { -2 } (301-5) [1112] - -  A 605 8  OcWs G2 V M5 V     
+1427 213-701              C694126-9 Lo Da StalW              { -2 } (601-2) [1148] - -  A 103 14 OcWs G8 V          
+1522 Shugii               E776620-5 Ni Ag                    { -1 } (853-5) [1511] - -  - 904 10 NaHu M2 V          
+1523 Lastop               B544532-9 Ni Ag                    { 0 }  (A44-3) [1515] - -  - 303 6  NaHu M3 V          
+1622 Briua                B55199E-C Hi Fo                    { 3 }  (D8E+5) [DC9G] - KM R 902 7  NaHu M2 V          
+1625 Blood                C766100-7 Ga Lo Da                 { -2 } (301-5) [1112] - -  A 204 12 OcWs M2 V          
+1723 Hood                 CA96122-6 Lo                       { -2 } (301-5) [1112] - -  - 603 9  NaHu M3 V M0 V     
+1726 211-111              B656313-7 Ga Lo Da StalW           { -1 } (521-4) [1224] - -  A 904 13 OcWs G7 V          
+1728 Shista               C000788-7 As Va Na Pi Pz           { -1 } (967-1) [7657] - -  A 520 6  OcWs A6 V          
+1730 Keratl               A310658-A Ni Na Cx Da              { 1 }  (B55+1) [675A] - -  A 303 12 OcWs G0 V          
+1822 Greene               C787586-9 Ga Ni Ag Pr              { -1 } (A43-1) [4448] - -  - 412 13 NaHu M3 V          
+1826 211-902              E310235-8 Lo Da StalW              { -3 } (711-5) [1136] - -  A 903 9  OcWs M2 V G7 V     
+1829 Givan                B665488-7 Ga Ni Pa                 { -1 } (632-1) [4357] - -  - 404 10 NaHu F2 V          
+1830 Kiree                B8B3323-8 Fl Lo                    { -1 } (A21-4) [1225] - -  - 205 13 NaHu G6 V          
+1923 Orphan               B656565-7 Ga Ni Ag O:1622          { 0 }  (744-2) [3535] - -  - 302 15 NaHu M2 V          
+1924 Branch               E655540-4 Ga Ni Ag                 { -2 } (742-5) [1311] - -  - 412 12 NaHu A5 IV         
+1925 Rouen                D765366-5 Ga Lo O:1622             { -3 } (521-4) [2144] - -  - 711 10 NaHu M1 V          
+1926 Green Lip            E744444-5 Ni Pa                    { -3 } (631-5) [2133] - -  - 504 16 NaHu M1 V          
+1928 Sponge               C2008A7-7 Va Ph Na Pi              { -1 } (A77-1) [8757] - -  - 403 13 NaHu M0 V M5 V     
+1930 DN-4457              D300410-7 Va Ni                    { -3 } (631-5) [1112] - -  - 324 9  NaHu M1 V          
+2026 Turnstyle            D410476-8 Ni                       { -3 } (C31-4) [3147] - -  - 224 15 NaHu G4 V          
+2027 Archambault          B955312-6 Lo                       { -1 } (521-5) [1212] - -  - 804 11 NaHu M0 V M1 V     
+2029 Pulfenex             A76A313-C Wa Lo                    { 1 }  (921-1) [1429] - KM - 704 10 NaHu K6 V M8 V     
+2127 Plant                C100436-7 Va Ni                    { -2 } (631-3) [3246] - -  - 201 7  NaHu K0 V          
+2128 Lorbin               B100533-B Va Ni Da                 { 1 }  (945-2) [2628] - -  A 302 6  NaHu K0 V M7 V     
+2129 Pusan                B31098B-B Hi Na In                 { 4 }  (C8F+5) [BD7D] - -  - 701 5  NaHu M0 V          
+2130 Ry Deena             E435434-7 Ni                       { -3 } (631-5) [2135] - -  - 114 12 NaHu K2 V          
+2222 Perseus              B692400-7 He Ni                    { -1 } (632-5) [1312] - M  - 505 14 NaHu G1 V          
+2223 Gured                C548100-7 Lo                       { -2 } (301-5) [1112] - -  - 704 13 NaHu K7 V          
+2224 Allaqua              B5546AA-9 Ni Ag Da                 { 1 }  (C55+3) [877B] - M  A 504 10 NaHu M3 V          
+2225 Scarab               B100449-C Va Ni                    { 1 }  (B34+2) [556D] - -  - 214 15 NaHu M1 V          
+2226 Barks' Pebbles       B000510-A As Va Ni                 { 0 }  (A44-3) [1515] - -  - 903 9  NaHu M3 V          
+2228 Garmill              C545568-8 Ni Ag O:2129             { -1 } (C43-1) [5458] - -  - 214 17 NaHu G4 V          
+2230 Ariadne              C554669-4 Ni Ag O:2129             { 0 }  (854+1) [7665] - -  - 124 10 NaHu G2 V M2 V     
+2322 Dreead'n             A000100-D As Va Lo                 { 1 }  (801-2) [1218] - KM - 923 11 NaHu M2 V M6 V     
+2330 Hardball             E300653-7 Va Ni Na                 { -2 } (852-5) [3424] - -  - 413 13 NaHu M1 V M8 V     
+2421 Nermiss              A564544-B Ni Ag Pr                 { 2 }  (846+1) [3739] - -  - 801 10 NaHu M2 V          
+2423 Stessull             E100647-7 Va Ni Na                 { -2 } (852-3) [6457] - -  - 604 10 NaHu M2 V          
+2424 Cepnu                C7A2485-8 Fl He Ni                 { -2 } (A31-4) [2236] - -  - 404 17 NaHu M3 V M2 V     
+2425 Serifia              E4337C8-6 Na Pz                    { -2 } (965-2) [7556] - -  A 304 12 NaHu M3 V          
+2428 Hyrexim              B31077B-B Na Pi                    { 2 }  (96C+4) [997D] - M  - 800 6  NaHu G5 III        
+2429 Pyfis                D867556-5 Ga Ni Ag Pr Da           { -2 } (742-3) [4344] - -  A 804 11 NaHu G4 V M8 V     
+2521 Anador               B555524-8 Ni Ag                    { 0 }  (744-2) [3536] - M  - 500 8  NaHu M3 V M6 V M0 V
+2523 Kifynn               D686455-5 Ga Ni Pa                 { -3 } (631-5) [2133] - -  - 400 4  NaHu M0 V          
+2524 Benankas             A7A3353-C Fl Lo                    { 1 }  (821-2) [1429] - -  - 903 11 NaHu G6 V          
+2623 Reeta Yuonn          A100625-D Va Ni Na                 { 2 }  (C56-1) [483B] - -  - 804 14 NaHu M1 V          
+2625 Kinji                C774231-7 Lo                       { -2 } (411-5) [1113] - -  - 110 11 NaHu M2 V          
+2626 Vyran                B552520-9 Ni                       { -1 } (B43-4) [1414] - M  - 404 15 NaHu M3 V          
+2721 Ar-stoon'l           A7B2547-9 Fl He Ni Px Cx GniiW     { -1 } (A43+1) [5459] - KM - 703 11 GnCl A1 V          
+2725 Nerfane              B575645-5 Ni Ag                    { 1 }  (855-2) [4733] - -  - 604 14 NaHu K3 V M6 V     
+2727 Gardeel              A7A2400-B Fl He Ni                 { 1 }  (734-3) [1516] - -  - 501 8  NaHu K9 V M5 V     
+2728 PaGa                 B783787-6 Ri Pz                    { 1 }  (968+1) [7856] - -  A 603 14 NaHu A2 II M5 V D  
+2821 Pru-grov             D100788-7 Va Na Pi GniiW           { -2 } (966-2) [7557] - -  - 303 11 GnCl M1 V M0 V     
+2829 Iaasiv               EAC5AA9-B Fl Hi In                 { 2 }  (F9D+3) [BC6C] - -  - 603 13 NaHu M0 V          
+2924 Pru-mavin            D855887-2 Ga Ph Pa (Gniivi)        { -2 } (A73-2) [8652] - -  - 204 9  GnCl G2 V          
+3021 Pru-berv             A88A420-B Wa Ni GniiW              { 1 }  (934-3) [1516] - -  - 203 10 GnCl K1 V          
+3026 Gefry                A6A378B-8 Fl Pi                    { 0 }  (C68+2) [977A] - -  - 603 7  NaHu M0 V M8 V     
+3027 Nils                 D859215-5 Lo Da                    { -3 } (411-5) [1133] - -  A 400 9  NaHu M1 V          
+3029 Byroon 67            D300433-7 Va Ni                    { -3 } (631-5) [1124] - -  - 200 6  NaHu M0 V M5 V     
+3030 Deverya              C995753-5 Ag Pi                    { 0 }  (967-3) [4722] - -  - 501 8  NaHu M3 V M7 V     
+3122 Pru-buash            C6A5473-9 Fl Ni Pa GniiW           { -2 } (A31-4) [1226] - -  - 904 11 GnCl M2 V          
+3123 Pru-ummur            E425241-7 Lo GniiW                 { -3 } (411-5) [1113] - -  - 603 11 GnCl M0 V M4 V     
+3128 Weyloor              A200248-B Va Lo                    { 1 }  (811+1) [235B] - -  - 204 12 NaHu M3 V M4 V     
+3129 Nyzch                B200435-B Va Ni                    { 1 }  (A34-1) [2539] - -  - 313 11 NaHu M2 V M3 V     
+3130 Lylol                A775313-8 Lo                       { -1 } (721-4) [1225] - -  - 202 11 NaHu M3 V M5 V M1 V
+3221 Pru-goomh            A100310-C Va Lo GniiW              { 1 }  (921-3) [1417] - -  - 504 17 GnCl M1 V M4 V     
+3222 Ghi-koord'l          D5728A9-5 He Ph Pi Pz GniiW        { -2 } (A75-1) [9666] - -  A 200 8  GnCl G2 V M7 V     
+3223 Pru-pasch            B6A1488-C Fl He Ni Px GniiW        { 1 }  (A34+1) [455C] - -  - 513 13 GnCl M0 V K9 V     
+3224 Elyxis               A65A551-D Wa Ni                    { 1 }  (A45-3) [1619] - -  - 703 12 NaHu F3 V          
+0131 Krevor               B200686-7 Va Ni Na                 { 0 }  (854-2) [5646] - -  - 115 17 NaHu A2 V          
+0134 Byooki               D31079A-7 Na Pi                    { -2 } (966+1) [9579] - -  - 903 9  NaHu M2 V          
+0137 Eki Chi              D200640-7 Va Ni Na                 { -2 } (852-5) [1412] - -  - 400 7  NaHu M2 V          
+0232 Murlum               C8A5420-8 Fl Ni Pa Da              { -2 } (831-5) [1213] - -  A 502 10 SoCf G1 V M3 V     
+0233 Goromas              C728787-8 Pi                       { -1 } (B67-1) [7658] - -  - 620 10 NaHu K1 V M4 V     
+0238 Ame                  C876221-6 Lo                       { -2 } (411-5) [1112] - -  - 513 14 NaHu A3 V M8 V     
+0239 Famerra              E310499-7 Ni                       { -3 } (631-2) [5168] - -  - 104 15 NaHu F4 V          
+0334 Kotori               C747654-5 Ni Ag                    { 0 }  (854-3) [4633] - -  - 904 13 NaHu G1 IV         
+0337 Tonde Monai          B200200-E Va Lo                    { 1 }  (A11-3) [1319] - M  - 215 15 NaHu F2 V M1 V     
+0438 Haiiro               E799000-0 Ba                       { -3 } (200-5) [1101] - -  - 804 8  NaXX K5 V          
+0439 York                 B100303-A Va Lo                    { 0 }  (921-2) [1327] - M  - 104 17 NaHu K8 V M6 V     
+0440 Franzweld            B65747A-A Ga Ni Pa                 { 0 }  (933+3) [647C] - M  - 903 13 NaHu A3 V          
+0533 Haru                 C667510-9 Ga Ni Ag Pr              { -1 } (B43-4) [1414] - -  - 104 15 NaHu G0 V          
+0634 Schmutz              E100202-7 Va Lo                    { -3 } (411-5) [1113] - -  - 613 11 NaHu M2 V M6 V     
+0640 Mizu                 B87A534-8 Wa Ni                    { -1 } (743-3) [3436] - -  - 600 8  NaHu M2 V M3 V     
+0732 Saito                C748AC8-8 Hi In Pz                 { 1 }  (G9A+1) [AB58] - -  A 204 11 NaHu F9 V M4 V M7 V
+0737 Tyotto               E8C4100-9 Fl Lo                    { -3 } (401-5) [1114] - -  - 601 10 NaHu M3 V M5 V     
+0738 Hurn                 A73659D-D Ni Fo                    { 1 }  (745+5) [969H] - KM R 800 9  NaHu M1 V          
+0739 Gustavus             C000525-B As Va Ni Da              { 0 }  (B44-2) [3539] - -  A 504 15 SoCf M0 V          
+0740 Strnad               C200664-7 Va Ni Na O:1040          { -1 } (853-4) [4535] - -  - 320 13 NaHu K2 V          
+0834 Vanguardia           B99A9A8-9 Wa Hi In                 { 2 }  (F8C+3) [9B59] - -  - 804 8  NaHu M2 V          
+0835 Prospect             C564667-5 Ni Ag Ri Da O:0834       { 1 }  (855+1) [6755] - -  A 924 15 NaHu M1 V M4 V     
+0836 Selding              A661444-9 Ni                       { -1 } (932-1) [2337] - KM - 812 15 NaHu M3 V          
+0839 Edwards' Meet        C64A667-9 Wa Ni O:1040             { -1 } (C53-1) [6559] - -  - 722 11 NaHu G0 V          
+0840 Cleavon              E434441-8 Ni                       { -3 } (931-5) [1114] - -  - 103 10 NaHu K4 V          
+0933 Hotspur              C310569-A Ni O:0834                { -1 } (B43+1) [646B] - -  - 504 14 NaHu K2 V          
+0938 Xenxeng              C100210-8 Va Lo                    { -2 } (711-5) [1113] - -  - 312 11 NaHu K9 V M6 V     
+0939 Red Sky              D56667A-4 Ni Ag Ri                 { 0 }  (854+1) [8676] - -  - 302 7  NaHu M6 III        
+1038 Shan-Hu              C31058A-9 Ni                       { -2 } (D42+1) [737B] - -  - 633 14 NaHu M2 V          
+1040 Hefry's Dregs        A100720-A Va Na Pi                 { 1 }  (C6A-2) [2815] - -  - 503 8  NaHu M2 V          
+1131 Parmenter            E100235-9 Va Lo                    { -3 } (811-4) [1137] - -  - 704 9  NaHu K2 V          
+1132 Strom                B561656-8 Ni Ri                    { 1 }  (B55-1) [5747] - M  - 603 11 NaHu M1 V          
+1134 Ayyar                B310144-C Lo                       { 1 }  (601-1) [123A] - -  - 312 10 NaHu M4 II         
+1136 Nix                  E100200-7 Va Lo                    { -3 } (411-5) [1112] - -  - 603 11 NaHu G5 V M5 V     
+1139 Strabbid             B100842-8 Va Ph Na Pi              { 0 }  (D78-4) [4814] - -  - 612 14 NaHu M0 V          
+1231 Leroy                C574969-9 Hi In Pz O:1335          { 1 }  (D8B+3) [AA6A] - -  A 111 9  NaHu G0 V M4 V     
+1233 Vizier               C52A220-9 Lo                       { -2 } (811-5) [1114] - -  - 104 13 NaHu K4 V          
+1235 Yoryunssoy           E554772-4 Ag DroyW                 { -1 } (965-5) [3611] - -  - 711 9  NaXX G3 V          
+1237 Eskerson             D422425-9 He Ni                    { -3 } (B30-4) [2137] - -  - 905 13 NaHu K2 V          
+1238 Champion             A889330-C Lo                       { 1 }  (821-3) [1417] - -  - 803 16 NaHu M2 V M2 V M0 V
+1334 Slider               C588210-4 Lo                       { -2 } (411-5) [1111] - -  - 203 13 NaHu G0 V          
+1335 Elan                 B4218AC-A He Ph Na Pi Fo           { 1 }  (D7A+5) [B98D] - -  R 303 10 NaHu M2 V          
+1339 Avatar               E436000-0 Ba                       { -3 } (200-5) [1101] - -  - 604 11 NaXX M3 V          
+1432 Leenitakot           X77A6BB-5 Wa Ni Fo An Chir8 Stal2  { -2 } (852-1) [8477] - -  R 310 10 OcWs K3 V M7 V     
+1435 Gammist              B551201-9 Lo                       { -1 } (711-3) [1115] - KM - 403 10 NaHu M1 V M0 V     
+1436 Murmur               B9B448B-A Fl Ni Da                 { 0 }  (A33+3) [647C] - -  A 704 11 SoCf M8 II M2 V    
+1438 Nectar               D585776-6 Ag Ri                    { 0 }  (967-1) [6745] - -  - 103 11 NaHu M2 V          
+1439 Rendezvous           D310333-7 Lo                       { -3 } (521-5) [1124] - -  - 504 12 NaHu G1 V M4 V     
+1440 Base 45              B551105-8 Lo                       { -1 } (701-3) [1136] - -  - 304 8  NaHu K0 V M6 V     
+1531 Kervid               E99A7CD-7 Wa Pi Fo                 { -2 } (966+2) [B59B] - -  R 804 15 OcWs K0 V          
+1536 Keasarge             B310253-A Lo                       { 0 }  (811-2) [1227] - -  - 404 16 NaHu M7 II         
+1539 Brand                B5595A9-B Ni                       { 1 }  (B45+2) [666C] - M  - 913 7  NaHu M0 V M9 V M9 V
+1632 Gamvina              B94A6BE-9 Wa Ni Fo                 { 0 }  (B54+4) [A69D] - -  R 903 8  NaHu M1 V          
+1634 Nerkaal              C422637-7 He Ni Na                 { -1 } (853-2) [6557] - -  - 904 10 NaHu F2 V M5 V     
+1635 Driank               B310455-D Ni                       { 1 }  (A34-1) [253B] - M  - 504 11 NaHu M2 V M2 V     
+1640 Cinder               D300387-7 Va Lo                    { -3 } (521-3) [3157] - -  - 404 9  NaHu M2 V          
+1733 Sharina              C725455-9 Ni                       { -2 } (A31-3) [2237] - -  - 204 10 NaHu F4 V M5 V     
+1734 Forban               C544663-7 Ni Ag Cy O:2032          { 0 }  (854-4) [3624] - -  - 403 6  NaHu G3 V          
+1737 Early Frost          B9A5233-9 Fl Lo                    { -1 } (911-3) [1126] - M  - 123 12 NaHu M0 V          
+1740 Ki Gaven             E542769-5 He Pi Mr                 { -2 } (965-1) [8566] - M  - 105 13 NaHu A3 V M5 V     
+1831 Lerein               C76699D-5 Ga Hi Pr Fo              { 0 }  (B88+4) [D999] - -  R 710 11 NaHu K6 III D      
+1833 Davin                E436310-6 Lo                       { -3 } (521-5) [1111] - -  - 801 7  NaHu M1 V K7 V     
+1836 Spire                A6A1842-9 Fl He Ph Pi              { 0 }  (D79-3) [4815] - -  - 103 10 NaHu M3 V M9 V     
+1838 Long Shadow          E895557-5 Ni Ag                    { -2 } (742-2) [5355] - -  - 804 10 NaHu G1 V M4 V     
+1931 Baliell              B426425-A Ni                       { 0 }  (B33-1) [2438] - M  - 214 14 NaHu G3 V          
+1937 Hardgas              B978510-9 Ni Ag                    { 0 }  (B44-3) [1514] - M  - 404 12 NaHu M1 V M9 V     
+1940 Herod                B100335-A Va Lo Da                 { 0 }  (921-1) [1338] - M  A 204 15 NaHu M2 V          
+2032 Dahlia               B754A8A-B Hi                       { 3 }  (F9E+5) [CD7D] - -  - 603 8  NaHu M2 V          
+2033 Stoner               C100577-7 Va Ni Da                 { -2 } (742-2) [5357] - -  A 111 11 NaHu K4 V          
+2034 Lorrain              D553156-6 Lo                       { -3 } (301-4) [1145] - -  - 914 9  NaHu G7 V          
+2035 Grange               C100310-A Va Lo                    { -1 } (921-4) [1215] - -  - 422 12 NaHu K5 V M9 V     
+2039 Tibbets              B310567-A Ni O:1836                { 0 }  (B44+1) [555A] - -  - 504 11 NaHu M3 V M2 V     
+2131 Golgotha             D8C3536-9 Fl Ni                    { -3 } (B41-3) [4248] - -  - 504 9  NaHu K6 III        
+2132 Yerve                B410847-A Ph Na Pi                 { 1 }  (B7A+3) [895A] - KM - 501 7  NaHu M0 II         
+2133 Second Wash          B58A310-9 Wa Lo                    { -1 } (921-4) [1214] - -  - 504 14 NaHu K1 V M7 V M0 V
+2135 Hike                 C547879-5 Ph Pa Pi                 { -1 } (A76+1) [9766] - -  - 312 11 NaHu G1 V M8 V M0 V
+2137 Tempri               A758878-A Ph Pa                    { 1 }  (F7A+2) [895A] - N  - 905 13 CsIm K3 V          
+2138 Alpert               A545458-B Ni Pa                    { 1 }  (634+2) [455B] - KM - 200 7  NaHu M2 V          
+2231 Gymex                C310467-7 Ni O:2132                { -2 } (631-2) [4257] - -  - 804 14 NaHu G3 V          
+2236 Rumoskyl             C100767-A Va Na Pi O:1836          { 0 }  (D69+1) [775A] - -  - 504 8  NaHu M1 V          
+2240 Shi-shi              E310420-7 Ni                       { -3 } (631-5) [1112] - -  - 602 7  NaHu K0 V          
+2332 Mereasis             B868653-8 Ni Ag Ri                 { 2 }  (956-2) [3825] - -  - 701 9  NaHu K3 V M0 V     
+2340 Sanctus              C31078A-8 Na Pi                    { -1 } (C67+1) [967A] - -  - 303 11 NaHu M2 V M0 V     
+2435 Pipeline             E574453-8 Ni Pa                    { -3 } (931-5) [1125] - -  - 203 12 NaHu G4 V M2 V     
+2436 Duster               E431537-6 Ni                       { -3 } (741-3) [5256] - -  - 914 11 NaHu M1 V M7 V     
+2438 Lykoov               B555555-B Ni Ag                    { 2 }  (C46+1) [3739] - -  - 623 16 NaHu M3 V          
+2533 Mamgarimu            C68479B-4 Ag Ri Pz                 { 1 }  (967+3) [9876] - -  A 404 16 NaHu M0 III        
+2534 Derivann             B85A210-9 Wa Lo                    { -1 } (711-4) [1114] - -  - 203 16 NaHu K8 V          
+2536 Beenateotyl          E772132-5 He Lo                    { -3 } (301-5) [1111] - -  - 703 14 NaHu M3 V          
+2539 Huraal               E698143-6 Lo                       { -3 } (301-5) [1123] - -  - 111 12 NaHu K7 V          
+2540 Wygren               B884350-9 Lo                       { -1 } (B21-4) [1214] - -  - 524 13 NaHu K6 V          
+2634 Shilling             C789774-4 Ri                       { 0 }  (966-2) [5732] - -  - 903 14 NaHu M0 V M2 V     
+2635 Glodon               D400501-7 Va Ni                    { -3 } (741-5) [1213] - -  - 600 6  NaHu M0 V          
+2731 Caramond             A534454-B Ni                       { 1 }  (834-1) [2539] - -  - 502 9  NaHu G2 V          
+2736 Giliim               C7A3435-9 Fl Ni                    { -2 } (931-3) [2237] - -  - 803 13 NaHu K3 V M9 V     
+2738 Varin-yeel           B553630-A Ni                       { 1 }  (D55-3) [1715] - -  - 714 14 NaHu M1 V          
+2739 Carnir               A31045A-D Ni                       { 1 }  (B34+3) [657F] - -  - 714 14 NaHu K1 V          
+2831 Opayix               B422513-8 He Ni Da                 { -1 } (C43-4) [2425] - -  A 323 13 NaHu K6 IV         
+2832 Cyveel               BA5A203-B Oc Wa Lo                 { 1 }  (811-2) [1328] - -  - 313 14 NaHu M2 V M0 V     
+2833 Entyrbal             A579410-A Ni                       { 0 }  (933-3) [1415] - -  - 712 12 NaHu F0 V          
+2834 Syth                 C8C8853-9 Fl Ph Pi                 { -1 } (B78-3) [5726] - -  - 110 11 NaHu K2 V M2 V     
+2840 Isannix              C310546-8 Ni                       { -2 } (D42-3) [4347] - -  - 524 13 NaHu M0 V          
+2935 Sysix                B623300-B Lo Jend1                 { 1 }  (B21-3) [1416] - -  - 624 10 CoLp M1 V          
+2936 Horizon              E20099B-9 Va Hi Na In Pz Jend7     { 0 }  (F8A+3) [B97B] - -  A 204 10 CoLp K1 V          
+3031 Osyrmir              C6B1677-8 Fl He Ni                 { -1 } (B53-2) [6558] - -  - 103 10 NaHu K2 V          
+3033 Brovarr              C100876-7 Va Ph Na Pi              { -1 } (A77-2) [7746] - -  - 824 13 NaHu K4 V          
+3035 Geval                B426777-C Pi Jend4                 { 2 }  (C6C+2) [795C] - -  - 112 8  CoLp M0 V          
+3131 Hervash              C88A79B-5 Wa Ri Pz                 { 0 }  (967+2) [9777] - -  A 702 13 NaHu M3 V          
+3135 Sanzig               C300867-A Va Ph Na Pi Jend6 O:3035 { 0 }  (D79+1) [885A] - -  - 103 11 CoLp G2 V M3 V     
+3136 Nyralys              B5448BC-9 Ph Pa Pi Fo Jend5        { 0 }  (E79+4) [B88C] - -  R 704 12 CoLp M0 V M4 V     
+3233 Lendisa              C785556-A Ga Ni Ag Pr              { 0 }  (B44+1) [4549] - -  - 104 13 CoLp M1 V M4 V     

--- a/res/Sectors/M1120/1120_Hint.xml
+++ b/res/Sectors/M1120/1120_Hint.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0"?>
+<Sector xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Name>Hinterworlds</Name>
+  <Credits>
+
+             &lt;b&gt;Hinterworlds&lt;/b&gt; sector was designed by Marc W. Miller
+             and appears in &lt;cite&gt;Atlas of the Imperium&lt;/cite&gt; (GDW,
+             1984).
+
+             It was refined by Rob Caswell and Karl Johnson and
+             appears in &lt;cite&gt;Challenge Magazine&lt;/cite&gt;.
+
+    </Credits>
+  <Product Author="Rob Caswell and Karl Johnson" Title="'Special Supplement: The Hinterworlds' Challenge Magazine No. 39" Publisher="GDW" Ref="http://www.drivethrurpg.com/product/87200/CHALLENGE-Magazine-No-39.html" />
+  <Subsectors>
+    <Subsector Index="A">Adar</Subsector>
+    <Subsector Index="B">Tlianke</Subsector>
+    <Subsector Index="C">Anubis</Subsector>
+    <Subsector Index="D">Pendiash Ginshar</Subsector>
+    <Subsector Index="E">Cimeon</Subsector>
+    <Subsector Index="F">Darvis</Subsector>
+    <Subsector Index="G">Cromar</Subsector>
+    <Subsector Index="H">Menere's Reach</Subsector>
+    <Subsector Index="I">Nullia</Subsector>
+    <Subsector Index="J">Bruia</Subsector>
+    <Subsector Index="K">Silver Laurel</Subsector>
+    <Subsector Index="L">Sontra</Subsector>
+    <Subsector Index="M">Hashi</Subsector>
+    <Subsector Index="N">Kandra</Subsector>
+    <Subsector Index="O">Tempri</Subsector>
+    <Subsector Index="P">Aquila</Subsector>
+  </Subsectors>
+  <Allegiances>
+    <Allegiance Code="AnTC">Anubian Trade Coalition</Allegiance>
+    <Allegiance Code="CoLp">Council of Leh Perash</Allegiance>
+    <Allegiance Code="CsIm">Client state, Third Imperium</Allegiance>
+    <Allegiance Code="CyUn">Cytralin Unity</Allegiance>
+    <Allegiance Code="GnCl">Gniivi Collective</Allegiance>
+    <Allegiance Code="MaSt">Margaret's Domain</Allegiance>
+    <Allegiance Code="NaHu">Non-Aligned, Human-dominated</Allegiance>
+    <Allegiance Code="NaXX">Non-Aligned, unclaimed</Allegiance>
+    <Allegiance Code="OcWs">Outcasts of the Whispering Sky</Allegiance>
+    <Allegiance Code="RaRa">Ral Ranta</Allegiance>
+    <Allegiance Code="SoCf">Solomani Confederation</Allegiance>
+  </Allegiances>
+  <Stylesheet>
+    border.AnTC { color: lime; }
+    route.AnTC { color: lightgreen; }
+
+    border.CoLp { color: blue; }
+    route.CoLp { color: blue; }
+
+    border.CyUn { color: orange; }
+    route.CyUn { color: sandybrown; }
+
+    border.GnCl { color: hotpink; }
+    route.GnCl { color: mediumorchid; }
+1129
+    border.MaSt { color: crimson; }
+
+    border.OcWs { color: white; }
+    route.OcWs { color: crimson; }
+
+    border.RaRa { color: purple; }
+    route.RaRa { color: lightyellow; }
+
+    border.SoCf { color: orange; }
+  </Stylesheet>
+  <Borders>
+    <Border WrapLabel="true" Allegiance="AnTC" LabelPosition="2203">1401 1502 1602 1703 1802 1903 2002 2102 2201 2202 2303 2403 2504 2505 2506 2405 2306 2206 2107 2007 1908 1807 1707 1606 1605 1604 1603 1503 1402 1401</Border>
+    <Border WrapLabel="false" Allegiance="CyUn" LabelPosition="3108">2607 2707 2806 2805 2804 2904 2903 2902 2901 3001 3101 3201 3302 3303 3304 3305 3306 3307 3308 3309 3310 3311 3312 3211 3111 3010 2910 2809 2710 2610 2609 2608 2607</Border>
+    <Border WrapLabel="true" Allegiance="GnCl" LabelPosition="2919">2721 2820 2819 2818 2817 2917 3017 3117 3217 3318 3319 3320 3321 3322 3323 3324 3325 3324 3223 3123 3023 2924 2923 2922 2821 2721</Border>
+    <Border WrapLabel="true" Allegiance="MaSt" LabelPosition="0303">0000 0100 0200 0300 0400 0500 0400 0401 0402 0303 0203 0104 0004 0005 0006 0005 0004 0003 0002 0001 0000</Border>
+    <Border WrapLabel="true" Allegiance="CoLp" LabelPosition="3037">2935 3034 3134 3233 3333 3332 3331 3332 3333 3334 3335 3336 3337 3338 3337 3236 3136 3035 2936 2935</Border>
+    <Border WrapLabel="true" Allegiance="OcWs" LabelPosition="1529">1128 1227 1327 1426 1526 1625 1726 1826 1727 1728 1729 1730 1630 1531 1431 1432 1431 1430 1429 1329 1228 1128</Border>
+    <Border WrapLabel="true" Allegiance="RaRa" LabelPosition="0301">0101 0201 0102 0101</Border>
+    <Border WrapLabel="false" Allegiance="RaRa" LabelPosition="0412">0114 0213 0212 0211 0210 0310 0409 0408 0407 0507 0506 0505 0604 0603 0604 0605 0606 0707 0807 0907 1006 1007 0908 0909 0908 0807 0707 0607 0608 0509 0510 0511 0611 0712 0612 0613 0614 0715 0814 0813 0814 0815 0916 0815 0715 0615 0516 0415 0316 0315 0214 0114</Border>
+    <Border WrapLabel="true" Allegiance="SoCf" Label="Solomani Confederation" LabelPosition="0329">0028 0128 0129 0029 0028 </Border>
+  </Borders>
+  <Routes>
+    <Route Start="0104" End="0201" />
+    <Route Start="0201" End="0402" />
+    <Route Start="0603" End="0605" Allegiance="RaRa" />
+    <Route Start="0605" End="0806" Allegiance="RaRa" />
+    <Route Start="0806" End="0907" Allegiance="RaRa" />
+    <Route Start="0907" End="1007" Allegiance="RaRa" />
+    <Route Start="0907" End="0708" Allegiance="RaRa" />
+    <Route Start="0708" End="0608" Allegiance="RaRa" />
+    <Route Start="0608" End="0407" Allegiance="RaRa" />
+    <Route Start="0608" End="0610" Allegiance="RaRa" />
+    <Route Start="0610" End="0410" Allegiance="RaRa" />
+    <Route Start="0410" End="0311" Allegiance="RaRa" />
+    <Route Start="0311" End="0210" Allegiance="RaRa" />
+    <Route Start="0610" End="0712" Allegiance="RaRa" />
+    <Route Start="0712" End="0813" Allegiance="RaRa" />
+    <Route Start="0813" End="0814" Allegiance="RaRa" />
+    <Route Start="0814" End="0916" Allegiance="RaRa" />
+    <Route Start="0813" End="0714" Allegiance="RaRa" />
+    <Route Start="0714" End="0514" Allegiance="RaRa" />
+    <Route Start="0514" End="0413" Allegiance="RaRa" />
+    <Route Start="0413" End="0315" Allegiance="RaRa" />
+    <Route Start="0315" End="0114" Allegiance="RaRa" />
+    <Route Start="0210" End="0010" Allegiance="RaRa" />
+    <Route Start="1402" End="1401" Allegiance="AnTC" />
+    <Route Start="1401" End="1601" Allegiance="AnTC" />
+    <Route Start="1601" End="2003" Allegiance="AnTC" />
+    <Route Start="2003" End="2001" Allegiance="AnTC" />
+    <Route Start="2001" End="2201" Allegiance="AnTC" />
+    <Route Start="2003" End="2005" Allegiance="AnTC" />
+    <Route Start="2005" End="2205" Allegiance="AnTC" />
+    <Route Start="2005" End="1804" Allegiance="AnTC" />
+    <Route Start="1804" End="1605" Allegiance="AnTC" />
+    <Route Start="1605" End="1606" Allegiance="AnTC" />
+    <Route Start="1606" End="1707" Allegiance="AnTC" />
+    <Route Start="1707" End="1807" Allegiance="AnTC" />
+    <Route Start="1807" End="1907" Allegiance="AnTC" />
+    <Route Start="1907" End="2006" Allegiance="AnTC" />
+    <Route Start="2006" End="2107" Allegiance="AnTC" />
+    <Route Start="2107" End="2206" Allegiance="AnTC" />
+    <Route Start="2206" End="2306" Allegiance="AnTC" />
+    <Route Start="2306" End="2506" Allegiance="AnTC" />
+    <Route Start="2506" End="2504" Allegiance="AnTC" />
+    <Route Start="3102" End="3003" Allegiance="CyUn" />
+    <Route Start="3003" End="3104" Allegiance="CyUn" />
+    <Route Start="3003" End="2804" Allegiance="CyUn" />
+    <Route Start="2804" End="2806" Allegiance="CyUn" />
+    <Route Start="2806" End="2907" Allegiance="CyUn" />
+    <Route Start="2907" End="2708" Allegiance="CyUn" />
+    <Route Start="2708" End="2608" Allegiance="CyUn" />
+    <Route Start="2907" End="2909" Allegiance="CyUn" />
+    <Route Start="2909" End="3009" Allegiance="CyUn" />
+    <Route Start="3009" End="3110" Allegiance="CyUn" />
+    <Route Start="3110" End="3209" Allegiance="CyUn" />
+    <Route Start="3102" End="0201" EndOffsetX="1" Allegiance="CyUn" />
+    <Route Start="3104" End="0203" EndOffsetX="1" Allegiance="CyUn" />
+    <Route Start="3209" End="0208" EndOffsetX="1" Allegiance="CyUn" />
+    <Route Start="2817" End="2917" Allegiance="GnCl" />
+    <Route Start="2917" End="3117" Allegiance="GnCl" />
+    <Route Start="3117" End="3119" Allegiance="GnCl" />
+    <Route Start="3119" End="3218" Allegiance="GnCl" />
+    <Route Start="3119" End="2920" Allegiance="GnCl" />
+    <Route Start="2920" End="2821" Allegiance="GnCl" />
+    <Route Start="2821" End="2721" Allegiance="GnCl" />
+    <Route Start="2920" End="3021" Allegiance="GnCl" />
+    <Route Start="3021" End="3122" Allegiance="GnCl" />
+    <Route Start="3122" End="3221" Allegiance="GnCl" />
+    <Route Start="3221" End="3222" Allegiance="GnCl" />
+    <Route Start="3222" End="3223" Allegiance="GnCl" />
+    <Route Start="3218" End="0320" EndOffsetX="1" Allegiance="GnCl" />
+    <Route Start="1128" End="1329" Allegiance="OcWs" />
+    <Route Start="1329" End="1328" Allegiance="OcWs" />
+    <Route Start="1328" End="1427" Allegiance="OcWs" />
+    <Route Start="1427" End="1426" Allegiance="OcWs" />
+    <Route Start="1426" End="1625" Allegiance="OcWs" />
+    <Route Start="1625" End="1726" Allegiance="OcWs" />
+    <Route Start="1726" End="1826" Allegiance="OcWs" />
+    <Route Start="1726" End="1728" Allegiance="OcWs" />
+    <Route Start="1728" End="1730" Allegiance="OcWs" />
+    <Route Start="1730" End="1531" Allegiance="OcWs" />
+    <Route Start="2935" End="3136" Allegiance="CoLp" />
+    <Route Start="3136" End="0336" EndOffsetX="1" Allegiance="CoLp" />
+  </Routes>
+</Sector>

--- a/res/Sectors/M1120/M1120.xml
+++ b/res/Sectors/M1120/M1120.xml
@@ -35,4 +35,12 @@
     <DataFile Type="SecondSurvey">1120_Fore.sec</DataFile>
     <MetadataFile>1120_Fore.xml</MetadataFile>
   </Sector>
+
+  <Sector Abbreviation="Hint" Tags="Unreviewed" Selected="true" Milieu="M1120">
+    <Y>2</Y>
+    <X>2</X>
+    <Name>Hinterworlds</Name>
+    <DataFile Type="SecondSurvey">1120_Hint.sec</DataFile>
+    <MetadataFile>1120_Hint.xml</MetadataFile>
+  </Sector>
 </Sectors>


### PR DESCRIPTION
No big changes.  The 1105 sector data mostly matched the  original 1120 article except for some ownership which 1105 made sense.  The big change is the border tweaks.  Reflecting the Rebellion Sourcebook maps, the purported Solomani gains in Old Expanses would allow for a contiguous border extending into Hinterworlds.