### PR TITLE
Vilani & Vargr 1: Imperial Sectors

### DIFF
--- a/res/Sectors/M1120/1120_Core.sec
+++ b/res/Sectors/M1120/1120_Core.sec
@@ -1,0 +1,548 @@
+Hex  Name                 UWP       Remarks                {Ix}   (Ex)    [Cx]   N     B  Z PBG W  A    Stellar        
+---- -------------------- --------- ---------------------- ------ ------- ------ ----- -- - --- -- ---- ---------------
+0103 Irkigkhan            ?9C4???-? Fl                                           -     -  - ?23 8  LuIm M2 V           
+0104 Shana Ma             ?551???-? Po                                           -     -  - ?03 9  LuIm K2 IV M7 V     
+0106 Niizediju            ?9C6???-? Fl                                           -     -  - ?04 7  LuIm A1 V           
+0202 Azimuth              ?847???-?                                              -     -  - ?00 13 LuIm M2 V M7 V      
+0203 Khaur Ga             ?434???-?                                              -     -  - ?00 9  LuIm K1 V           
+0208 Gekshiiuun           ?527???-?                                              -     -  - ?23 9  LuIm F9 IV          
+0210 Uras                 ?797???-?                                              -     -  - ?01 8  LuIm M2 V M7 V      
+0302 Khaam                ?597???-?                                              -     -  - ?01 13 LuIm M1 V           
+0304 Kuunaa               ?8B5???-? Fl                                           -     -  - ?23 10 LuIm M0 V           
+0305 Muudeshi             ?100???-? Va                                           -     -  - ?01 8  LuIm G1 V           
+0306 Kiid                 ?786???-? Ga                                           -     -  - ?22 9  LuIm M1 V           
+0307 Pasliir              ?574???-?                                              -     -  - ?00 9  LuIm K0 V           
+0308 Shar                 ?688???-?                                              -     -  - ?14 13 LuIm M0 V           
+0310 Mag                  ?888???-?                                              -     -  - ?02 11 LuIm M1 V K8 V      
+0402 Apge                 ?772???-? He                                           -     -  - ?10 10 LuIm M2 V           
+0403 Irli Un              ?000???-? As Va                                        -     -  - ?04 9  LuIm M1 V           
+0405 Dake Ag              ?674???-?                                              -     -  - ?14 8  LuIm K1 V M5 V      
+0408 Arkag Ka             ?553???-? Po                                           -     -  - ?02 16 LuIm M2 V M4 V      
+0409 Gin                  ?994???-?                                              -     -  - ?02 13 LuIm M3 V           
+0410 Castell              ?779???-?                                              -     -  - ?02 10 LuIm G4 V M6 V      
+0502 Niir                 ?76A???-? Wa                                           -     -  - ?20 12 LuIm M1 V M3 V      
+0505 Trokusian            ?430???-? De Po                                        -     -  - ?24 12 LuIm M1 V           
+0603 Dashgad              ?540???-? De He Po                                     -     -  - ?01 15 LuIm G1 V           
+0606 Khuumiam             ?736???-?                                              -     -  - ?11 11 LuIm M0 V           
+0707 Maaruur              ?692???-? He                                           -     -  - ?21 11 LuIm K8 V M1 V      
+0806 Sabsee               ?312???-? Ic                                           -     -  - ?00 13 LuIm M2 V           
+0808 Kikim                ?575???-?                                              -     -  - ?14 8  LuIm M0 V M6 V      
+0901 Karnika              ?755???-? Ga                                           -     -  - ?02 9  LuIm G0 V           
+0903 Disal                ?000???-? As Va                                        -     -  - ?13 10 LuIm K5 V           
+0905 Shazeku              ?553???-? Po                                           -     -  - ?00 12 LuIm M2 V M7 V      
+0906 Muumuu               ?776???-?                                              -     -  - ?02 14 LuIm M3 V K7 V      
+0907 Gish                 ?778???-?                                              -     -  - ?30 16 LuIm G0 V M7 V      
+0910 Tinea-Fabre          ?567???-?                                              -     -  - ?05 13 LuIm K3 V M1 V      
+1002 Mishaar              ?540???-? De He Po                                     -     -  - ?20 7  LuIm M2 V           
+1008 Uusla                ?302???-? Ic Va                                        -     -  - ?04 7  LuIm K3 V           
+1009 Luumiiliiplen        ?536???-?                                              -     -  - ?13 9  LuIm K4 V           
+1101 Kiimi Di             ?420???-? De He Po                                     -     -  - ?02 8  LuIm M2 V           
+1102 Girikash             ?594???-?                                              -     -  - ?24 13 LuIm M1 V           
+1104 Rae                  ?580???-? De                                           -     -  - ?23 12 LuIm G1 V M9 V      
+1108 Uumeaxan             ?765???-? Ga                                           -     -  - ?14 11 LuIm M2 V           
+1109 Uuruun Kuu           ?987???-?                                              -     -  - ?14 10 LuIm M0 V           
+1202 Kargi                ?569???-?                                              -     -  - ?05 8  LuIm M3 V G8 V      
+1204 Limashimii           ?547???-?                                              -     -  - ?02 7  LuIm M2 V           
+1205 Miilap Kas           ?590???-? De He                                        -     -  - ?04 9  LuIm K3 V           
+1302 Uumaad Nurir         ?778???-?                                              -     -  - ?04 8  LuIm K0 V           
+1307 Ashduuma             ?88A???-? Wa                                           -     -  - ?10 15 LuIm M0 V M1 V      
+1308 Akussanja            ?557???-?                                              -     -  - ?04 9  LuIm M4 V M9 V      
+1309 Uuniluu              ?94A???-? Wa                                           -     -  - ?01 10 LuIm M2 V M7 V M8 V 
+1403 Gakxaal              ?896???-?                                              -     -  - ?21 9  LuIm G1 V           
+1407 Imguu                ?200???-? Va                                           -     -  - ?20 14 LuIm M1 V           
+1410 Uurgin               ?310???-?                                              -     -  - ?03 16 LuIm M3 V           
+1503 Zektind Ir           ?536???-?                                              -     -  - ?04 11 LuIm M0 V           
+1505 Kuum                 ?667???-? Ga                                           -     -  - ?14 8  LuIm K9 V           
+1506 Kakaaguur            ?586???-?                                              -     -  - ?04 8  LuIm K3 V           
+1508 Asmi                 ?697???-?                                              -     -  - ?00 10 LuIm G5 V           
+1510 Kinuu                ?310???-?                                              -     -  - ?03 11 LuIm M2 II          
+1605 Giiakiis E           ?546???-?                                              -     -  - ?00 12 LuIm K1 V           
+1609 Sirma                ?424???-?                                              -     -  - ?02 13 LuIm K4 V M3 V      
+1610 Nagan                ?645???-?                                              -     -  - ?03 10 LuIm M1 V           
+1701 Kama                 ?99A???-? Wa                                           -     -  - ?24 9  LuIm M1 V           
+1702 Iski Kuu             ?563???-?                                              -     -  - ?02 14 LuIm M2 V           
+1703 Irkhedi              ?645???-?                                              -     -  - ?00 8  LuIm M0 V           
+1707 Erdi                 ?686???-? Ga                                           -     -  - ?00 13 LuIm M1 V           
+1708 Unnagilu             ?000???-? As Va                                        -     -  - ?04 8  LuIm G2 V           
+1710 Kherip Ag            ?000???-? As Va                                        -     -  - ?11 11 LuIm M3 V M2 V      
+1801 Kinned               ?551???-? Po                                           -     -  - ?25 11 LuIm K2 V M4 V      
+1808 Gamiigela            ?100???-? Va                                           -     -  - ?23 12 LuIm K2 V           
+1901 Zaniin               ?694???-?                                              -     -  - ?00 10 LuIm A3 V M7 V      
+1902 Irbi                 ?889???-?                                              -     -  - ?03 9  LuIm M2 V M9 V      
+1909 Iiska Ashgi          ?433???-? Po                                           -     -  - ?00 7  LuIm K5 V M4 V M3 V 
+2006 Amur Isark           ?310???-?                                              -     -  - ?12 10 LuIm M2 V           
+2008 Ameros               ?310???-?                                              -     -  - ?05 12 LuIm M1 V M7 V      
+2010 Mashaa               ?8B7???-? Fl                                           -     -  - ?05 8  LuIm G3 V           
+2101 Khizuun              ?85A???-? Wa                                           -     -  - ?03 8  LuIm M2 V           
+2102 Ravla                ?554???-?                                              -     -  - ?10 10 LuIm G5 V           
+2103 Inlun Ra             ?000???-? As Va                                        -     -  - ?05 9  LuIm K2 V           
+2104 Nuudle               ?884???-?                                              -     -  - ?02 11 LuIm K5 V M0 V      
+2105 Shiza                ?561???-?                                              -     -  - ?03 16 LuIm M2 V M9 V      
+2203 Andkag Pa            ?438???-?                                              -     -  - ?00 14 LuIm K2 V           
+2205 Daash                ?538???-?                                              -     -  - ?23 15 LuIm G3 V           
+2206 Edirkisdii           ?544???-?                                              -     -  - ?13 7  LuIm A8 V           
+2209 Nimluin              ?576???-?                                              -     -  - ?10 6  LuIm M1 V M9 V      
+2210 Gis                  ?562???-?                                              -     -  - ?05 15 LuIm M2 V M1 V      
+2306 Erem Dash            ?645???-?                                              -     -  - ?03 6  LuIm M0 V M8 V      
+2401 Erkiim               ?52A???-?                                              -     -  - ?03 15 LuIm M3 V M2 V      
+2403 Aaruu Zi             ?569???-?                                              -     -  - ?23 8  LuIm K1 V           
+2404 Gemi                 ?400???-? Va                                           -     -  - ?04 15 LuIm M2 V           
+2405 Luunni Miu           ?576???-?                                              -     -  - ?13 7  LuIm M0 V M0 V      
+2407 Lagaashin            ?767???-? Ga                                           -     -  - ?10 15 LuIm K3 V           
+2408 Arnaki               ?200???-? Va                                           -     -  - ?13 11 LuIm M1 V           
+2410 Uungip               ?000???-? As Va                                        -     -  - ?12 15 LuIm M7 III D       
+2501 Erani                ?000???-? As Va                                        -     -  - ?00 12 LuIm M0 V           
+2503 Gigi                 ?000???-? As Va                                        -     -  - ?04 8  LuIm M2 V K1 V      
+2507 Ninua                ?986???-?                                              -     -  - ?10 11 LuIm M1 V K3 V      
+2602 Sagaku               ?544???-?                                              -     -  - ?01 8  LuIm M1 V M6 V      
+2603 Arunde               ?AAA???-? Fl                                           -     -  - ?03 8  LuIm K4 V           
+2606 Margish Liir         ?547???-?                                              -     -  - ?05 11 LuIm K2 V           
+2608 Dureija              ?557???-?                                              -     -  - ?13 7  LuIm M3 V M7 V      
+2609 Ebba                 ?599???-?                                              -     -  - ?13 14 LuIm M3 V           
+2610 Kerliar              ?594???-?                                              -     -  - ?05 16 LuIm M2 V           
+2703 Derku                ?611???-? Ic                                           -     -  - ?03 7  LuIm M2 V M4 V      
+2705 Roska                ?556???-?                                              -     -  - ?01 13 LuIm M1 V           
+2706 Sekwon               ?564???-?                                              -     -  - ?14 9  LuIm K1 V           
+2707 Kalendae             ?525???-?                                              -     -  - ?00 8  LuIm M1 V           
+2709 Kimvle               ?000???-? As Va                                        -     -  - ?03 7  LuIm M0 V           
+2802 Gekhuu               ?678???-?                                              -     -  - ?25 13 LuIm G2 V           
+2803 Kersi Am             ?427???-?                                              -     -  - ?04 9  LuIm M2 V           
+2904 Ishnuunar            ?572???-? He                                           -     -  - ?20 7  LuIm M2 V M6 V      
+2906 Damki Im             ?200???-? Va                                           -     -  - ?03 13 LuIm G4 V M9 V      
+2910 Shusa Liishli        ?311???-? Ic                                           -     -  - ?23 10 LuIm K2 V M0 V      
+3002 Isuur                ?544???-?                                              -     -  - ?20 15 LuIm K0 V           
+3003 Iidsha               ?665???-? Ga                                           -     -  - ?10 16 LuIm M0 V           
+3005 Aarza Kand           ?304???-? Ic Va                                        -     -  - ?22 15 LuIm K1 V M4 V      
+3008 Minos                ?400???-? Va                                           -     -  - ?01 7  LuIm G2 V           
+3101 Edza                 ?73A???-? Wa                                           -     -  - ?04 7  LuIm G2 V M8 V      
+3103 Garen                ?439???-?                                              -     -  - ?14 12 LuIm K4 V M4 V      
+3104 Aadkha Na            ?200???-? Va                                           -     -  - ?31 12 LuIm G0 V M6 V      
+3105 Kir                  ?300???-? Va                                           -     -  - ?10 13 LuIm M3 V           
+3106 Hreowan              ?425???-?                                              -     -  - ?03 12 LuIm K8 V           
+3203 Maeghen              ?668???-?                                              -     -  - ?11 7  LuIm G3 V           
+3205 Fluere               ?765???-? Ga                                           -     -  - ?13 10 LuIm K9 V M6 V      
+3206 Dim                  ?646???-?                                              -     -  - ?04 11 LuIm M0 V           
+3207 Imkhag Guu           ?567???-?                                              -     -  - ?00 16 LuIm G2 V M4 V      
+3208 Agduu                ?400???-? Va                                           -     -  - ?04 10 LuIm M1 V M7 V      
+3210 Enkaiein             ?965???-?                                              -     -  - ?05 9  LuIm K6 V           
+0112 Per                  ?673???-?                                              -     -  - ?03 13 LuIm M0 V M0 V      
+0113 Khishi               ?798???-?                                              -     -  - ?03 11 LuIm M0 V           
+0114 Khid                 ?550???-? De Po                                        -     -  - ?20 14 LuIm M1 V           
+0116 Idpuu                ?585???-?                                              -     -  - ?11 8  LuIm M2 V           
+0117 Neki                 ?664???-?                                              -     -  - ?10 13 LuIm M0 V M9 V M4 V 
+0120 Kein                 ?544???-?                                              -     -  - ?00 11 LuIm K2 V           
+0212 Gir                  ?645???-?                                              -     -  - ?03 13 LuIm K6 V M7 V      
+0216 Emuuis               ?422???-? He Po                                        -     -  - ?04 11 LuIm M3 V M0 V      
+0218 Darnii Kimi          ?878???-?                                              -     -  - ?14 8  LuIm M0 V           
+0220 Inir                 ?88A???-? Wa                                           -     -  - ?03 7  LuIm G2 V           
+0313 Maish Akush          ?432???-? Po                                           -     -  - ?03 11 LuIm M2 V           
+0314 Maarshigervlig       ?8A5???-? Fl                                           -     -  - ?14 8  LuIm K6 V M5 V      
+0315 Dankahlas            ?685???-? Ga                                           -     -  - ?04 11 LuIm M3 V M1 V      
+0316 Dudin                ?528???-?                                              -     -  - ?24 10 LuIm M3 V           
+0319 Uurze                ?434???-?                                              -     -  - ?14 12 LuIm M2 V K7 V      
+0411 Kash                 ?584???-?                                              -     -  - ?03 9  LuIm M0 V           
+0414 Shiinaua             ?561???-?                                              -     -  - ?13 7  LuIm M1 V           
+0416 Sanches              ?654???-?                                              -     -  - ?13 11 LuIm M0 V           
+0418 Shardi               ?433???-? Po                                           -     -  - ?03 9  LuIm M2 V           
+0420 Nirgem               ?6A7???-? Fl                                           -     -  - ?04 9  LuIm K3 V M5 V      
+0511 Gaadir               ?586???-?                                              -     -  - ?12 14 LuIm G1 V           
+0512 Arla Un              ?513???-? Ic                                           -     -  - ?02 11 LuIm A5 IV K9 V     
+0513 Kaman                ?772???-? He                                           -     -  - ?03 13 LuIm K0 V           
+0516 Rundan               ?76A???-? Wa                                           -     -  - ?04 9  LuIm K0 V           
+0517 Shiga Sha            ?726???-?                                              -     -  - ?02 12 LuIm M2 V           
+0519 Zan                  ?100???-? Va                                           -     -  - ?14 8  LuIm M5 III         
+0612 Khukhi               ?667???-? Ga                                           -     -  - ?00 3  LuIm F3 V M7 V      
+0619 Iggaar               ?758???-?                                              -     -  - ?15 9  LuIm K3 V           
+0713 Ruuni                ?433???-? Po                                           -     -  - ?03 17 LuIm M2 V           
+0714 Kiishad              ?6A7???-? Fl                                           -     -  - ?21 9  LuIm K3 V M1 V      
+0718 Uupig                ?797???-?                                              -     -  - ?05 10 LuIm K4 V           
+0811 Alekvadin            ?675???-?                                              -     -  - ?02 15 LuIm M3 V           
+0812 Kakhu Gash           ?845???-?                                              -     -  - ?14 9  LuIm G4 V M4 V      
+0816 Keshi                ?792???-? He                                           -     -  - ?12 11 LuIm K4 V M4 V      
+0820 Iruukzi              ?776???-?                                              -     -  - ?00 16 LuIm K3 V M5 V      
+0911 Kiked Iig            ?545???-?                                              -     -  - ?03 6  LuIm M3 V           
+0915 Muskoxah             ?577???-?                                              -     -  - ?13 13 LuIm M3 V           
+0916 Irshiish             ?95A???-? Wa                                           -     -  - ?01 5  LuIm G3 V           
+0919 Coppelia             ?550???-? De Po                                        -     -  - ?04 8  LuIm M1 V           
+1012 Uurmu Kuu            ?424???-?                                              -     -  - ?24 12 LuIm M2 V M0 V      
+1016 Ushra                ?561???-?                                              -     -  - ?03 13 LuIm M3 V           
+1019 Liga Ka              ?783???-?                                              -     -  - ?03 13 LuIm M1 V M1 V      
+1112 Kish                 ?310???-?                                              -     -  - ?22 11 LuIm M2 V M3 V      
+1114 Adguu Uun            ?520???-? De He Po                                     -     -  - ?03 15 LuIm M1 V M3 V      
+1116 Vlaagesh Iirki       ?783???-?                                              -     -  - ?00 15 LuIm K1 V M4 V      
+1120 Shuunkha             ?540???-? De He Po                                     -     -  - ?03 12 LuIm M2 V M2 V      
+1214 Guun                 ?585???-?                                              -     -  - ?12 7  LuIm K4 V           
+1219 Amed                 ?310???-?                                              -     -  - ?20 7  LuIm G0 V M8 V      
+1220 Rhuan                ?100???-? Va                                           -     -  - ?04 8  LuIm M2 V           
+1314 Mukiid               ?859???-?                                              -     -  - ?02 13 LuIm K2 V           
+1316 Shiirand             ?85A???-? Wa                                           -     -  - ?02 9  LuIm K7 V M5 V      
+1317 Gipkikhar            ?203???-? Ic Va                                        -     -  - ?12 14 LuIm K4 V M7 V      
+1320 Adkaash              ?422???-? He Po                                        -     -  - ?02 11 LuIm M1 V           
+1416 Imdi Mi              ?68A???-? Wa                                           -     -  - ?04 10 LuIm M2 V M8 V      
+1418 Kishdush             ?646???-?                                              -     -  - ?03 13 LuIm M3 V M1 V      
+1511 Aman Urk             ?545???-?                                              -     -  - ?23 13 LuIm M2 V M6 V      
+1512 Ansham               ?8C3???-? Fl                                           -     -  - ?04 15 LuIm M1 V           
+1518 Depot                A86A56A-F Ni Wa Pr Da Mr         { 2 }  (946+4) [777H] Bc    D  A 420 11 LuIm M4 V           
+1519 Sher                 ?9D4???-?                                              -     -  - ?03 14 LuIm M2 V M7 V      
+1611 Shauug               ?964???-?                                              -     -  - ?14 11 LuIm K0 V           
+1615 Marlakasi            ?779???-?                                              -     -  - ?04 14 LuIm M0 V           
+1616 Vluurvlash           ?9B4???-? Fl                                           -     -  - ?14 8  LuIm M2 V           
+1711 N'dao                ?100???-? Va                                           -     -  - ?12 11 LuIm M0 V           
+1713 Rison                ?9D4???-?                                              -     -  - ?14 8  LuIm M1 V           
+1715 Fornol               ?581???-?                                              -     -  - ?12 11 LuIm K3 V M9 V      
+1717 Curast               ?9B7???-? Fl                                           -     -  - ?24 10 LuIm M2 V           
+1812 Ances                ?583???-?                                              -     -  - ?05 8  LuIm M2 V           
+1813 Lectorsen            ?554???-?                                              -     -  - ?00 12 LuIm M2 V M1 V      
+1815 Thass                ?510???-?                                              -     -  - ?13 8  LuIm M3 V           
+1819 Balpan               ?505???-? Ic Va                                        -     -  - ?00 13 LuIm M1 V           
+1912 Sistar               ?430???-? De Po                                        -     -  - ?12 14 LuIm M0 V           
+1916 Ankod                ?544???-?                                              -     -  - ?14 9  LuIm M3 V           
+1917 Ploiqu               ?422???-? He Po                                        -     -  - ?04 7  LuIm K4 V           
+1918 Traak                ?624???-?                                              -     -  - ?04 16 LuIm K1 V M4 V      
+1919 Crompton             ?776???-?                                              -     -  - ?00 12 LuIm G2 V           
+1920 Shion                ?410???-?                                              -     -  - ?03 13 LuIm M0 V M9 V      
+2011 Dudaka               ?544???-?                                              -     -  - ?03 10 LuIm G1 V M7 V      
+2012 Tiwath               ?651???-? Po                                           -     -  - ?33 13 LuIm M3 V M7 V      
+2014 Morii                ?62A???-?                                              -     -  - ?14 8  LuIm M0 V M7 V      
+2016 Ion                  ?877???-?                                              -     -  - ?04 10 LuIm M2 V           
+2017 Onon                 ?576???-?                                              -     -  - ?21 7  LuIm M1 V           
+2020 Tertha               ?200???-? Va                                           -     -  - ?13 9  LuIm G4 V           
+2111 Siduka               ?546???-?                                              -     -  - ?00 6  LuIm M3 V M3 V      
+2112 Romstand             ?428???-?                                              -     -  - ?20 11 LuIm M3 V           
+2115 Knabbib              ?431???-? Po                                           -     -  - ?04 8  LuIm M2 V           
+2118 Capital              ?586???-? Cx (Syleans)?                                -     -  - ?05 15 LuIm G2 V           
+2211 Shushan              ?655???-? Ga                                           -     -  - ?24 9  LuIm K2 V M8 V      
+2213 Nesdo                ?541???-? He Po                                        -     -  - ?14 8  LuIm G9 V           
+2214 Shudusham            ?849???-?                                              -     -  - ?04 12 LuIm M1 V           
+2216 Rhylea               ?8A6???-? Fl                                           -     -  - ?23 11 LuIm F4 V           
+2218 Syroe                ?436???-?                                              -     -  - ?04 10 LuIm K0 V M5 V      
+2219 Ase                  ?420???-? De He Po                                     -     -  - ?10 11 LuIm M2 V M5 V      
+2220 Xalm                 ?562???-?                                              -     -  - ?13 14 LuIm M2 V M0 V      
+2312 Seku                 ?79A???-? Wa                                           -     -  - ?03 8  LuIm K3 V           
+2314 Rib                  ?559???-?                                              -     -  - ?04 11 LuIm M1 V           
+2316 Ercan                ?544???-?                                              -     -  - ?02 12 LuIm M0 V M5 V      
+2317 Codsen               ?571???-? He                                           -     -  - ?10 11 LuIm M2 V M8 V      
+2318 Yirsh Poy            ?310???-?                                              -     -  - ?13 7  LuIm M2 V M7 V M5 V 
+2319 Crystalan            ?979???-?                                              -     -  - ?14 12 LuIm K1 V           
+2320 Umgadin              ?6B5???-? Fl                                           -     -  - ?22 15 LuIm M3 III         
+2413 Capion               ?651???-? Po                                           -     -  - ?01 11 LuIm M3 V M2 V M7 V 
+2414 First                ?A7A???-? Oc                                           -     -  - ?00 9  LuIm M0 V           
+2416 Sentark 4            ?755???-? Ga                                           -     -  - ?04 11 LuIm K2 V M6 V      
+2419 Sevan                ?544???-?                                              -     -  - ?00 15 LuIm G3 V M7 V      
+2511 Kuuir Am             ?577???-?                                              -     -  - ?02 8  LuIm M9 II D        
+2513 Khuir                ?89A???-? Wa                                           -     -  - ?02 14 LuIm K1 V           
+2517 Imaar Pa             ?544???-?                                              -     -  - ?02 10 LuIm M1 V M0 V      
+2519 Riid Irman           ?000???-? As Va                                        -     -  - ?04 7  LuIm G3 V           
+2611 Kishkeiim            ?201???-? Ic Va                                        -     -  - ?03 15 LuIm M8 III D       
+2615 Ispumer              ?581???-?                                              -     -  - ?05 18 LuIm M3 V M5 V K5 V 
+2616 Likhamii             ?536???-?                                              -     -  - ?03 10 LuIm M1 V M0 V      
+2720 Lir                  ?426???-?                                              -     -  - ?03 13 LuIm K8 IV M7 V     
+2814 Khuuma               ?423???-? Po                                           -     -  - ?04 13 LuIm K4 V M4 V      
+2816 Indshiim Ganme       ?869???-?                                              -     -  - ?03 8  LuIm G4 V           
+2912 Leer                 ?7B3???-? Fl                                           -     -  - ?25 10 LuIm G2 V           
+2913 Khiuur La            ?8B3???-? Fl                                           -     -  - ?03 11 LuIm M3 V M2 V      
+2914 Mikhag Kuu           ?668???-?                                              -     -  - ?13 9  LuIm G0 V           
+2916 Khiinra Ash          ?AE6???-?                                              -     -  - ?04 7  LuIm M2 V M1 V      
+3011 Laudum               ?552???-? Po                                           -     -  - ?01 15 LuIm M2 V M1 V      
+3015 Anuug                ?783???-?                                              -     -  - ?00 11 LuIm K6 V           
+3019 Kinekesh             ?422???-? He Po                                        -     -  - ?30 9  LuIm M3 V M7 V      
+3113 Ruigiur              ?542???-? He Po                                        -     -  - ?04 9  LuIm M2 V M4 V      
+3115 Markasher            ?100???-? Va                                           -     -  - ?20 9  LuIm K8 IV          
+3117 Khiiri               ?200???-? Va                                           -     -  - ?14 10 LuIm M1 V           
+3118 Lemiki               ?56A???-? Wa                                           -     -  - ?11 11 LuIm K1 V           
+3211 Zikhi                ?427???-?                                              -     -  - ?02 13 LuIm M0 V M7 V M6 V 
+3216 Shand                ?964???-?                                              -     -  - ?13 13 LuIm K4 V M0 V      
+3218 Kaskii               ?300???-? Va                                           -     -  - ?04 9  LuIm G4 V           
+0125 Trevor               ?664???-?                                              -     -  - ?10 4  LuIm M0 V M1 V      
+0126 Deseca               ?541???-? He Po                                        -     -  - ?13 12 LuIm G7 V M4 V      
+0127 Marsus               ?578???-?                                              -     -  - ?14 10 LuIm M1 V           
+0128 Protalus             ?559???-?                                              -     -  - ?23 13 LuIm K0 V           
+0129 Rollabon             ?984???-?                                              -     -  - ?22 13 LuIm M3 V           
+0130 Katock               ?200???-? Va                                           -     -  - ?02 8  LuIm M2 V M0 V      
+0221 Randar               ?789???-?                                              -     -  - ?05 14 LuIm G1 V           
+0222 Acmed                ?310???-?                                              -     -  - ?05 15 LuIm G1 V           
+0224 Domitar              ?434???-?                                              -     -  - ?03 14 LuIm M2 V           
+0228 Hektalus             ?565???-?                                              -     -  - ?20 13 LuIm M1 V           
+0322 Bentax               ?542???-? He Po                                        -     -  - ?04 8  LuIm M1 V           
+0324 Oorpic               ?413???-? Ic                                           -     -  - ?01 14 LuIm M3 V           
+0325 Ikarus               ?310???-?                                              -     -  - ?03 11 LuIm M2 V           
+0326 Bellum               ?540???-? De He Po                                     -     -  - ?04 13 LuIm M2 V M7 V      
+0328 Ferot                ?553???-? Po                                           -     -  - ?11 10 LuIm M3 V           
+0421 Gishalem             ?887???-? Ga                                           -     -  - ?22 14 LuIm G8 V           
+0423 Hellhole             ?400???-? Va                                           -     -  - ?00 11 LuIm K4 V           
+0428 Irlu                 ?535???-?                                              -     -  - ?13 9  LuIm K2 V M4 V      
+0429 Relle                ?9B9???-? Fl                                           -     -  - ?04 10 LuIm G4 V           
+0522 Simic                ?562???-?                                              -     -  - ?24 14 LuIm G2 V           
+0523 Dinhe                ?590???-? De He                                        -     -  - ?03 10 LuIm K1 IV          
+0526 Asalam               ?200???-? Va                                           -     -  - ?21 9  LuIm M2 V           
+0527 Rax                  ?557???-?                                              -     -  - ?15 9  LuIm G9 V M3 V      
+0529 Irdu                 ?586???-?                                              -     -  - ?12 15 LuIm M2 V M5 V      
+0530 Tarshii              ?433???-? Po                                           -     -  - ?04 8  LuIm M2 V M4 V      
+0622 Sketola              ?647???-?                                              -     -  - ?04 14 LuIm M1 V           
+0624 Ontar                ?100???-? Va                                           -     -  - ?04 10 LuIm M1 V           
+0721 Cromind              ?551???-? Po                                           -     -  - ?01 12 LuIm M0 V M0 V      
+0722 F'rnow               ?561???-?                                              -     -  - ?02 5  LuIm M0 V           
+0725 Antar                ?411???-? Ic                                           -     -  - ?03 18 LuIm M8 II          
+0727 Dral                 ?728???-?                                              -     -  - ?12 14 LuIm G3 V M3 V      
+0821 Lalandra             ?000???-? As Va                                        -     -  - ?04 13 LuIm G6 V           
+0822 Dunlek               ?540???-? De He Po                                     -     -  - ?14 14 LuIm G9 V M9 V      
+0827 Ess Nuur             ?550???-? De Po                                        -     -  - ?13 11 LuIm M2 V           
+0921 Wastam               ?6A7???-? Fl                                           -     -  - ?10 9  LuIm M2 V           
+0922 Celetron             ?575???-?                                              -     -  - ?02 8  LuIm M1 V           
+0929 Ur                   ?649???-?                                              -     -  - ?00 10 LuIm M3 V M6 V      
+1022 Drag                 ?573???-?                                              -     -  - ?13 7  LuIm G0 V           
+1023 Exod                 ?423???-? Po                                           -     -  - ?00 16 LuIm M3 V           
+1028 Shalam               ?550???-? De Po                                        -     -  - ?01 5  LuIm G3 V           
+1123 Ye-lu                ?100???-? Va                                           -     -  - ?25 14 LuIm M2 V           
+1124 Pixtome              ?8AA???-? Fl                                           -     -  - ?12 9  LuIm M1 V M4 V      
+1125 Meman                ?652???-? Po                                           -     -  - ?10 16 LuIm M1 V M3 V M9 V 
+1129 Gashil               ?6A4???-? Fl                                           -     -  - ?04 10 LuIm K3 V M2 V      
+1130 Evad                 ?79A???-? Wa                                           -     -  - ?01 9  LuIm M3 V           
+1221 Ehok-ta              ?AD5???-?                                              -     -  - ?13 7  LuIm K6 V           
+1222 Bendo                ?577???-?                                              -     -  - ?13 12 LuIm G4 V           
+1223 Dingus               ?556???-?                                              -     -  - ?30 13 LuIm K9 V M0 V      
+1225 Eshon                ?541???-? He Po                                        -     -  - ?10 15 LuIm M0 V           
+1226 Orguush              ?585???-?                                              -     -  - ?22 9  LuIm M0 V           
+1228 Lishiruud            ?697???-?                                              -     -  - ?13 12 LuIm M1 V           
+1229 Digitus              ?554???-?                                              -     -  - ?13 11 LuIm M3 V M5 V      
+1321 Renu                 ?664???-?                                              -     -  - ?00 9  LuIm M2 V           
+1322 Keplo                ?675???-?                                              -     -  - ?23 8  LuIm M2 V           
+1323 Bogustin             ?310???-?                                              -     -  - ?03 8  LuIm G3 V M8 V      
+1328 Ushtar               ?647???-?                                              -     -  - ?02 8  LuIm M2 V M0 V      
+1330 Calesson             ?685???-? Ga                                           -     -  - ?00 13 LuIm F3 V M7 V      
+1421 Eorvin               ?436???-?                                              -     -  - ?22 16 LuIm M0 V M0 V      
+1422 Chokta               ?7C2???-? Fl He                                        -     -  - ?11 12 LuIm G7 V M1 V M8 V 
+1424 Khusgurlu            ?652???-? Po                                           -     -  - ?14 10 LuIm M1 V           
+1428 Spirn                ?656???-? Ga                                           -     -  - ?00 7  LuIm K6 V M9 V M2 V 
+1430 Alton                ?100???-? Va                                           -     -  - ?03 14 LuIm F1 V M1 V      
+1522 Suhtlam              ?7C2???-? Fl He                                        -     -  - ?00 12 LuIm M1 V M0 V      
+1523 Belicose             ?596???-?                                              -     -  - ?13 11 LuIm M3 V M4 V      
+1524 Shibashliim          ?626???-?                                              -     -  - ?12 11 LuIm K4 V           
+1526 Noesh                ?403???-? Ic Va                                        -     -  - ?23 8  LuIm M1 V           
+1529 Biirke               ?310???-?                                              -     -  - ?24 11 LuIm F8 V M5 V      
+1530 Santar               ?563???-?                                              -     -  - ?02 12 LuIm M1 V M6 V      
+1622 Heraldia             ?420???-? De He Po                                     -     -  - ?01 15 LuIm M2 V M8 V M7 V 
+1623 Velpare              ?567???-?                                              -     -  - ?24 14 LuIm K4 V           
+1625 Kirkus               ?885???-? Ga                                           -     -  - ?14 11 LuIm K4 IV          
+1628 Shirg                ?633???-? Po                                           -     -  - ?04 8  LuIm M3 V           
+1630 Rashiuon             ?430???-? De Po                                        -     -  - ?03 11 LuIm M1 V           
+1721 Temra                ?565???-?                                              -     -  - ?04 11 LuIm G0 V M4 V      
+1724 Akeyolarix           ?675???-?                                              -     -  - ?24 12 LuIm M2 III         
+1725 C're                 ?545???-?                                              -     -  - ?03 11 LuIm M0 V           
+1726 Roustami             ?000???-? As Va                                        -     -  - ?04 9  LuIm M1 V M2 V      
+1727 Braned               ?8B3???-? Fl                                           -     -  - ?05 12 LuIm M0 II          
+1730 Waduuka              ?AB5???-? Fl                                           -     -  - ?04 8  LuIm M2 V M0 V      
+1821 Tell                 ?78A???-? Wa                                           -     -  - ?02 11 LuIm M2 V M5 V      
+1822 Holex                ?200???-? Va                                           -     -  - ?12 14 LuIm M3 V K2 V      
+1823 Citro                ?8B7???-? Fl                                           -     -  - ?04 14 LuIm M3 V           
+1824 Mandhem              ?554???-?                                              -     -  - ?04 7  LuIm M2 V           
+1825 Prempt               ?5A2???-? Fl He                                        -     -  - ?01 5  LuIm M3 V M9 V      
+1829 Rhydino              ?311???-? Ic                                           -     -  - ?13 15 LuIm G0 V           
+1921 Sorca                ?545???-?                                              -     -  - ?24 12 LuIm G4 V           
+1924 Tomaa                ?555???-?                                              -     -  - ?00 12 LuIm G4 V M3 V      
+1925 Vvrin                ?585???-?                                              -     -  - ?00 13 LuIm M0 V M5 V      
+1927 Wrebil               ?94A???-? Wa                                           -     -  - ?04 14 LuIm K2 V M5 V      
+1929 Farhome              ?628???-?                                              -     -  - ?24 13 LuIm M2 V           
+1930 Traa                 ?000???-? As Va                                        -     -  - ?04 8  LuIm A1 V           
+2021 Anther               ?300???-? Va                                           -     -  - ?15 11 LuIm K9 IV          
+2027 Prubisk              ?9A5???-? Fl                                           -     -  - ?00 13 LuIm K5 V           
+2028 Basilling            ?543???-? Po                                           -     -  - ?04 17 LuIm G1 V M2 V      
+2030 Rorpa Din            ?63A???-? Wa                                           -     -  - ?14 8  LuIm M2 V           
+2121 Affinity             ?98A???-? Wa                                           -     -  - ?13 10 LuIm G1 V           
+2122 Elinz                ?576???-?                                              -     -  - ?00 14 LuIm M3 V           
+2125 Eliograh             ?524???-?                                              -     -  - ?03 6  LuIm K4 V M9 V      
+2130 Kamodoo              ?565???-?                                              -     -  - ?03 11 LuIm G4 V           
+2221 Leystroak            ?998???-?                                              -     -  - ?15 12 LuIm K1 V M5 V      
+2222 Rek-shons            ?855???-? Ga                                           -     -  - ?13 11 LuIm M0 V           
+2223 Radd Caulo           ?866???-? Ga                                           -     -  - ?02 10 LuIm M2 V           
+2224 Chant                ?560???-? De                                           -     -  - ?03 10 LuIm K2 V           
+2225 Meiz                 ?512???-? Ic                                           -     -  - ?11 9  LuIm K4 V           
+2226 Skeen                ?591???-? He                                           -     -  - ?22 13 LuIm K1 V           
+2227 Port Away            ?557???-?                                              -     -  - ?03 12 LuIm K3 V M6 V      
+2322 Effinity             ?581???-?                                              -     -  - ?04 12 LuIm M2 V M5 V      
+2323 Merat                ?423???-? Po                                           -     -  - ?03 14 LuIm K4 V           
+2326 Akin Akun            ?410???-?                                              -     -  - ?10 13 LuIm K1 V           
+2327 Drivorea             ?759???-?                                              -     -  - ?13 13 LuIm M3 V           
+2330 Raami                ?522???-? He Po                                        -     -  - ?03 12 LuIm M2 V           
+2422 Ro Anii              ?573???-?                                              -     -  - ?04 13 LuIm M1 V M9 V      
+2425 Avthaus              ?200???-? Va                                           -     -  - ?23 8  LuIm G1 V M5 V      
+2429 Shurgiishulu         ?552???-? Po                                           -     -  - ?02 11 LuIm K2 V           
+2521 Shashuua             ?560???-? De                                           -     -  - ?01 13 LuIm K4 V           
+2524 Glimmer              ?576???-?                                              -     -  - ?03 8  LuIm M3 V           
+2526 Kisa                 ?7C6???-? Fl                                           -     -  - ?02 12 LuIm K6 V M1 V M4 V 
+2529 Udaa                 ?564???-?                                              -     -  - ?14 8  LuIm M0 V           
+2623 Gurdaan              ?310???-?                                              -     -  - ?14 9  LuIm M1 V           
+2624 Idas                 ?592???-? He                                           -     -  - ?01 16 LuIm G2 V M5 V      
+2625 Imsha                ?424???-?                                              -     -  - ?04 11 LuIm K1 V M3 V      
+2628 Gashkanan            ?74A???-? Wa                                           -     -  - ?14 8  LuIm K4 V K7 V      
+2630 Shesh                ?000???-? As Va                                        -     -  - ?04 7  LuIm M1 V           
+2721 Kiruuda              ?551???-? Po                                           -     -  - ?34 10 LuIm M1 V           
+2729 Gaar                 ?560???-? De                                           -     -  - ?20 10 LuIm M3 V           
+2730 Maan                 ?541???-? He Po                                        -     -  - ?03 10 LuIm K3 V           
+2821 Kuggar               ?552???-? Po                                           -     -  - ?04 7  LuIm M2 V           
+2823 Berumi               ?553???-? Po                                           -     -  - ?03 10 LuIm M0 V           
+2825 Bishaakuuka          ?683???-?                                              -     -  - ?23 11 LuIm M1 V           
+2829 Gishashum            ?100???-? Va                                           -     -  - ?24 12 LuIm M0 V M5 V      
+2830 Navla Sha            ?AC7???-? Fl                                           -     -  - ?14 14 LuIm M3 V M3 V      
+2922 Ekugush              ?652???-? Po                                           -     -  - ?04 11 LuIm M1 V M9 V      
+2924 Ushba Sind           ?564???-?                                              -     -  - ?05 16 LuIm F4 V M0 V      
+2928 Vilakhu              ?594???-?                                              -     -  - ?14 14 LuIm M2 V           
+2929 Danuuvlan            ?000???-? As Va                                        -     -  - ?13 7  LuIm M1 V           
+3021 Kamsii               ?557???-?                                              -     -  - ?24 14 LuIm K1 V M7 V      
+3022 Gurishi              ?756???-? Ga                                           -     -  - ?04 8  LuIm G0 V M3 V      
+3025 Manluushagi          ?200???-? Va                                           -     -  - ?21 8  LuIm M1 V           
+3026 Uumeshal             ?563???-?                                              -     -  - ?02 10 LuIm K0 V           
+3027 Guuza Bem            ?9D5???-?                                              -     -  - ?23 8  LuIm M3 V M5 V M1 V 
+3028 Durguu               ?573???-?                                              -     -  - ?01 9  LuIm M2 V           
+3121 Kagash               ?554???-?                                              -     -  - ?02 18 LuIm M2 V M9 V      
+3123 Kankuup Ir           ?424???-?                                              -     -  - ?14 10 LuIm M3 V           
+3125 Kadushii             ?695???-?                                              -     -  - ?13 13 LuIm M2 V           
+3127 Arkadkhi             ?779???-?                                              -     -  - ?04 15 LuIm K2 V           
+3128 Mish                 ?679???-?                                              -     -  - ?03 7  LuIm M0 V           
+3129 Keras Vla            ?867???-? Ga                                           -     -  - ?03 8  LuIm K0 V           
+3130 Agdam Gii            ?557???-?                                              -     -  - ?20 13 LuIm K8 V M9 V      
+3226 Duuka                ?686???-? Ga                                           -     -  - ?00 13 LuIm M2 V           
+3227 Ashash As            ?758???-?                                              -     -  - ?03 12 LuIm M2 V M6 V      
+0132 Brygella             ?76A???-? Wa                                           -     -  - ?21 14 LuIm K3 V M0 V      
+0133 Holt                 ?8D7???-?                                              -     -  - ?15 11 LuIm G5 V           
+0134 Blanum               ?421???-? He Po                                        -     -  - ?03 14 LuIm M1 V           
+0135 Erthun               ?667???-? Ga                                           -     -  - ?04 15 LuIm M2 V           
+0138 Azpun                ?873???-?                                              -     -  - ?02 10 LuIm M2 V           
+0139 Dashuu Aardir        ?87A???-? Wa                                           -     -  - ?13 7  LuIm M1 V M3 V      
+0140 Reference            ?100???-? Va Ab                                        -     -  - ?02 12 LuIm K0 V           
+0231 Rushugim             ?869???-?                                              -     -  - ?11 13 LuIm G1 V M8 V      
+0234 Zorzaa               ?667???-? Ga                                           -     -  - ?04 12 LuIm M2 V M8 V      
+0236 Tuurqa Gaash         ?671???-? He                                           -     -  - ?03 11 LuIm G9 V           
+0240 Brekin               ?587???-?                                              -     -  - ?00 7  LuIm M2 V M7 V      
+0331 Kiiris               ?100???-? Va                                           -     -  - ?24 9  LuIm K4 V M0 V      
+0332 Qungwyld             ?655???-? Ga                                           -     -  - ?03 12 LuIm M2 V M9 V      
+0334 Singing              ?999???-?                                              -     -  - ?23 12 LuIm M1 V M9 V M2 V 
+0338 Markun               ?887???-? Ga                                           -     -  - ?00 13 LuIm K0 V M2 V      
+0431 Betras               ?634???-?                                              -     -  - ?04 11 LuIm K5 V           
+0432 Reel                 ?550???-? De Po                                        -     -  - ?05 9  LuIm K2 V M4 V      
+0437 Lytras               ?400???-? Va                                           -     -  - ?05 15 LuIm M2 V           
+0439 Xamdas               ?310???-?                                              -     -  - ?03 12 LuIm M1 V M4 V      
+0440 Kysizi               ?53A???-? Wa                                           -     -  - ?03 6  LuIm G1 V M2 V      
+0531 Cadion               ?655???-? Ga                                           -     -  - ?00 8  LuIm K2 V M8 V      
+0537 Lia                  ?654???-?                                              -     -  - ?02 9  LuIm F4 V           
+0635 Double Star          ?642???-? He Po                                        -     -  - ?02 11 LuIm M1 V M1 V      
+0637 Patu                 ?796???-?                                              -     -  - ?03 11 LuIm M4 V           
+0731 Zzugep               ?553???-? Po                                           -     -  - ?00 7  LuIm M1 V           
+0734 Ferré                ?797???-?                                              -     -  - ?00 9  LuIm M3 V M3 V      
+0735 Megatina             ?584???-?                                              -     -  - ?04 11 LuIm M1 V           
+0737 L'rotuu              ?898???-?                                              -     -  - ?23 13 LuIm G1 V M3 V      
+0831 Delta 4              ?549???-?                                              -     -  - ?14 11 LuIm K1 V M1 V      
+0835 Baituu               ?438???-?                                              -     -  - ?03 14 LuIm M0 V           
+0839 Night                ?574???-?                                              -     -  - ?20 9  LuIm K8 V M4 V      
+0931 Siniir Sa            ?599???-?                                              -     -  - ?14 14 LuIm G0 V           
+0933 Hudmill              ?88A???-? Wa                                           -     -  - ?11 10 LuIm K2 V           
+1033 Gavin                ?556???-?                                              -     -  - ?04 9  LuIm M2 V M8 V      
+1034 Vala                 ?533???-? Po                                           -     -  - ?00 8  LuIm M2 V M9 V      
+1035 Okefir               ?581???-?                                              -     -  - ?03 12 LuIm G2 V M1 V      
+1037 Khuunish             ?542???-? He Po                                        -     -  - ?24 10 LuIm M1 V           
+1038 Maur Na              ?558???-?                                              -     -  - ?14 13 LuIm M3 V           
+1040 Davla                ?528???-?                                              -     -  - ?25 10 LuIm M1 V M7 V      
+1134 Aursis               ?545???-?                                              -     -  - ?00 12 LuIm K1 V           
+1140 Kaamind              ?AF5???-?                                              -     -  - ?00 11 LuIm K0 V           
+1232 Diam Kani            ?430???-? De Po                                        -     -  - ?22 7  LuIm K2 V           
+1233 Illappu              ?575???-?                                              -     -  - ?24 14 LuIm M2 V M0 V      
+1236 Ishmal               ?591???-? He                                           -     -  - ?03 13 LuIm M1 V M4 V      
+1237 Miikuu Ar            ?6A7???-? Fl                                           -     -  - ?03 11 LuIm K0 V           
+1239 Kirbarus             ?547???-?                                              -     -  - ?02 10 LuIm M0 V           
+1240 Allamu               ?423???-? Po                                           -     -  - ?14 15 LuIm K2 V M7 V      
+1334 Anshar               ?ACA???-? Fl                                           -     -  - ?12 8  LuIm G5 V M0 V      
+1335 Umkashuu             ?554???-?                                              -     -  - ?22 7  LuIm M2 V           
+1336 Krain                ?A97???-?                                              -     -  - ?03 6  LuIm M3 V M0 V      
+1338 Prin                 ?695???-?                                              -     -  - ?02 9  LuIm M2 V           
+1431 Saar                 ?594???-?                                              -     -  - ?03 6  LuIm M1 V           
+1434 Diirmuu              ?755???-? Ga                                           -     -  - ?03 14 LuIm M2 V           
+1436 Arvlessaish          ?6B1???-? Fl He                                        -     -  - ?01 5  LuIm G3 V           
+1437 Mirror               ?9A8???-? Fl                                           -     -  - ?13 7  LuIm M6 III         
+1440 Minduun Sammad       ?58A???-? Wa                                           -     -  - ?03 10 LuIm M2 V           
+1531 Emsha La             ?433???-? Po                                           -     -  - ?13 8  LuIm K3 V M3 V      
+1533 Zagi Uun             ?647???-?                                              -     -  - ?02 13 LuIm M3 V M0 V      
+1534 Gidekis              ?76A???-? Wa                                           -     -  - ?03 15 LuIm K1 V M6 V      
+1536 Shueshlar            ?435???-?                                              -     -  - ?02 14 LuIm M3 V M3 V      
+1538 Ekhuurme             ?543???-? Po                                           -     -  - ?01 6  LuIm K0 V           
+1539 Dimanaam             ?583???-?                                              -     -  - ?04 13 LuIm K6 V M1 V      
+1633 Gandar               ?300???-? Va                                           -     -  - ?01 9  LuIm K4 III         
+1635 Hiilev               ?627???-?                                              -     -  - ?14 8  LuIm K0 V           
+1638 Malaash              ?759???-?                                              -     -  - ?12 10 LuIm K2 V M2 V      
+1732 Maasaanin            ?758???-?                                              -     -  - ?04 13 LuIm M2 V M7 V      
+1733 Zimmel               ?865???-? Ga                                           -     -  - ?14 11 LuIm K3 V           
+1736 Santry               ?420???-? De He Po                                     -     -  - ?00 8  LuIm M1 V M6 V      
+1737 Minamulam Kirak      ?574???-?                                              -     -  - ?00 15 LuIm M2 V           
+1738 Ginna                ?8A6???-? Fl                                           -     -  - ?13 8  LuIm M1 V M6 V      
+1739 Enshuukkar           ?6A6???-? Fl                                           -     -  - ?12 7  LuIm M2 V           
+1831 Girrik               ?663???-?                                              -     -  - ?25 10 LuIm M2 V M8 V      
+1833 Shaaram              ?564???-?                                              -     -  - ?04 11 LuIm M2 II          
+1836 Khea                 ?540???-? De He Po                                     -     -  - ?03 12 LuIm K1 V M0 V      
+1837 Anlumir              ?A9A???-? Oc                                           -     -  - ?00 10 LuIm G6 V           
+1838 Bellham              ?989???-?                                              -     -  - ?03 12 LuIm K0 V           
+1839 Rilik Aash           ?782???-?                                              -     -  - ?01 15 LuIm G5 V           
+1840 Saruumdiiush         ?743???-? Po                                           -     -  - ?00 12 LuIm M1 V           
+1933 Kuushruu             ?599???-?                                              -     -  - ?04 15 LuIm M1 V M5 V      
+1934 Zishma Kha           ?886???-? Ga                                           -     -  - ?00 12 LuIm M2 V           
+1938 Keshi                ?566???-?                                              -     -  - ?14 10 LuIm K3 V M1 V M0 V 
+1940 Nadir                ?548???-?                                              -     -  - ?20 9  LuIm K6 V           
+2034 Dindakhara           ?424???-?                                              -     -  - ?03 12 LuIm M1 V           
+2036 Uundizi              ?410???-?                                              -     -  - ?04 12 LuIm G8 III D       
+2037 Daaud Urle           ?433???-? Po                                           -     -  - ?20 10 LuIm M1 V           
+2038 Gimmi Uusshaa        ?576???-?                                              -     -  - ?02 10 LuIm K0 V           
+2040 Khii Isis            ?540???-? De He Po                                     -     -  - ?02 9  LuIm M3 V M2 V      
+2133 Degkak Uun           ?88A???-? Wa                                           -     -  - ?10 16 LuIm K4 V           
+2135 Diliig               ?749???-?                                              -     -  - ?13 10 LuIm K6 V           
+2136 Kiir                 ?77A???-? Wa                                           -     -  - ?04 10 LuIm M3 V M6 V      
+2138 Adkhi                ?888???-?                                              -     -  - ?00 5  LuIm M3 V M3 V      
+2139 Ginnakar             ?565???-?                                              -     -  - ?02 16 LuIm M2 V M5 V      
+2140 Sidzer               ?200???-? Va                                           -     -  - ?10 16 LuIm M2 III M1 V    
+2232 Kuuma                ?538???-?                                              -     -  - ?02 10 LuIm M1 V M7 V      
+2237 Mirezi               ?203???-? Ic Va                                        -     -  - ?00 9  LuIm F9 V           
+2334 Bussirka             ?433???-? Po                                           -     -  - ?03 14 LuIm G7 V           
+2335 Gish                 ?555???-?                                              -     -  - ?03 11 LuIm M1 V           
+2336 Adan                 ?661???-?                                              -     -  - ?03 13 LuIm K1 V M2 V      
+2338 Shinzarkan           ?555???-?                                              -     -  - ?14 14 LuIm M2 V M0 V      
+2431 Kim                  ?7A8???-? Fl                                           -     -  - ?12 12 LuIm M1 V M1 V      
+2433 Uuramag              ?794???-?                                              -     -  - ?14 11 LuIm M2 V           
+2435 Iidkek               ?AB5???-? Fl                                           -     -  - ?00 16 LuIm M1 V M3 V      
+2437 Ligemum              ?636???-?                                              -     -  - ?02 12 LuIm M2 V K7 V      
+2439 Innameg              ?584???-?                                              -     -  - ?23 9  LuIm M1 V           
+2532 Mie Duur             ?310???-?                                              -     -  - ?03 13 LuIm K6 V           
+2534 Middena              ?648???-?                                              -     -  - ?02 13 LuIm M2 V           
+2536 Duunpigamuur         ?511???-? Ic                                           -     -  - ?24 9  LuIm M2 V K9 V      
+2538 Duudin               ?768???-?                                              -     -  - ?02 8  LuIm K6 V           
+2540 Bumina               ?553???-? Po                                           -     -  - ?20 12 LuIm K3 V           
+2631 Uurkuumluu           ?545???-?                                              -     -  - ?13 18 LuIm M3 V M5 V      
+2635 Arvlaa Gam           ?889???-?                                              -     -  - ?04 11 LuIm M3 V           
+2636 Valed                ?998???-?                                              -     -  - ?14 8  LuIm K7 V           
+2639 Suurashuur           ?100???-? Va                                           -     -  - ?03 10 LuIm G9 V           
+2640 Dishadshii           ?614???-? Ic                                           -     -  - ?04 8  LuIm M1 V           
+2731 Milpa                ?631???-? Po                                           -     -  - ?04 14 LuIm G0 V           
+2732 Shimaraak            ?9E7???-?                                              -     -  - ?02 16 LuIm G4 V           
+2736 Gaen Luum            ?424???-?                                              -     -  - ?13 12 LuIm K2 V           
+2832 Sinad                ?558???-?                                              -     -  - ?02 13 LuIm M2 V M5 V      
+2836 Khuir                ?578???-?                                              -     -  - ?04 13 LuIm M3 V           
+2837 Igla                 ?414???-? Ic                                           -     -  - ?04 7  LuIm M2 V M9 V      
+2839 Gaeshme              ?783???-?                                              -     -  - ?03 10 LuIm M1 V M1 V      
+2840 Gumir Gaeg           ?8C3???-? Fl                                           -     -  - ?14 10 LuIm M8 III D       
+2931 Dinenruum            ?432???-? Po                                           -     -  - ?22 10 LuIm K1 IV M3 V M4 V
+2933 Ganad                ?656???-? Ga                                           -     -  - ?04 13 LuIm M0 V           
+2934 Dishe                ?778???-?                                              -     -  - ?15 14 LuIm K9 V           
+2935 Amuur Keiir          ?572???-? He                                           -     -  - ?13 14 LuIm M1 V           
+2936 Saregon              ?584???-?                                              -     -  - ?14 11 LuIm M3 V M6 V      
+2937 Uurigger             ?434???-?                                              -     -  - ?03 11 LuIm M1 V M9 V      
+2938 Shakiiga             ?867???-? Ga                                           -     -  - ?10 10 LuIm K4 V           
+3033 Ashmelam             ?424???-?                                              -     -  - ?03 6  LuIm K2 V           
+3034 Iishaanka            ?554???-?                                              -     -  - ?03 9  LuIm K3 V M3 V      
+3037 Lashupii             ?665???-? Ga                                           -     -  - ?22 8  LuIm M3 V           
+3039 Kiiggura             ?8B4???-? Fl                                           -     -  - ?01 18 LuIm G0 V           
+3040 Unlakhar             ?629???-?                                              -     -  - ?03 10 LuIm K3 V           
+3131 Ashga                ?7C3???-? Fl                                           -     -  - ?13 12 LuIm K2 V M6 V      
+3132 Kinuri               ?562???-?                                              -     -  - ?10 15 LuIm G0 V M5 V      
+3133 Nindakir             ?562???-?                                              -     -  - ?02 13 LuIm M1 V M3 V      
+3135 Arla                 ?58A???-? Wa                                           -     -  - ?00 16 LuIm K2 V           
+3137 Iimdii               ?593???-?                                              -     -  - ?03 8  LuIm M1 V           
+3140 Kergumir             ?562???-?                                              -     -  - ?10 15 LuIm G0 V           
+3234 Gau                  ?433???-? Po                                           -     -  - ?20 8  LuIm K5 V M2 V      
+3235 Taliyan              ?75A???-? Wa                                           -     -  - ?13 10 LuIm M1 V           
+3238 Lishide              ?560???-? De                                           -     -  - ?03 10 LuIm M2 V M4 V      

--- a/res/Sectors/M1120/1120_Core.xml
+++ b/res/Sectors/M1120/1120_Core.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0"?>
+<Sector xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Name>Core</Name>
+  <Name Lang="vi">Ukan</Name>
+  <Credits>
+
+             &lt;b&gt;Core&lt;/b&gt; sector was designed by Marc W. Miller and
+             appears in &lt;cite&gt;Atlas of the Imperium&lt;/cite&gt; (GDW,
+             1984).
+
+             Rebellion Era borders were designed by James Holden, Joe D. Fugate Jr. and Terry McInnes
+             and appeared in The MegaTraveller Alien, Volume 1: Vilani & Vargr (
+             Digest Group Publications, 1990).
+
+    </Credits>
+  <Product Title="MegaTraveller Alien Vol. 1: Vilani %29 Vargr" Publisher="Digest Group Publications" Ref="http://wiki.travellerrpg.com/Alien_-_Vilani_%26_Vargr"/>
+  <Subsectors>
+    <Subsector Index="A">Apge</Subsector>
+    <Subsector Index="B">Perite</Subsector>
+    <Subsector Index="C">Ameros</Subsector>
+    <Subsector Index="D">Shinkan</Subsector>
+    <Subsector Index="E">Sanches</Subsector>
+    <Subsector Index="F">Mekee</Subsector>
+    <Subsector Index="G">Core</Subsector>
+    <Subsector Index="H">Kaskii</Subsector>
+    <Subsector Index="I">Bunkeria</Subsector>
+    <Subsector Index="J">Cemplas</Subsector>
+    <Subsector Index="K">Chant</Subsector>
+    <Subsector Index="L">Dingtra</Subsector>
+    <Subsector Index="M">Cadion</Subsector>
+    <Subsector Index="N">Ch'naar</Subsector>
+    <Subsector Index="O">Dunea</Subsector>
+    <Subsector Index="P">Saregon</Subsector>
+  </Subsectors>
+  <Allegiances>
+    <Allegiance Code="LuIm">Lucan's Imperium</Allegiance>
+    <Allegiance Code="ImSy"> Sylean Worlds</Allegiance>
+  </Allegiances>
+  <Borders>
+    <Border ShowLabel="false" WrapLabel="false" Allegiance="LuIm" LabelPosition="1721" Color="DarkRed" Label="Lucan's Imperium">0000 0100 0200 0300 0400 0500 0600 0700 0800 0900 1000 1100 1200 1300 1400 1500 1600 1700 1800 1900 2000 2100 2200 2300 2400 2500 2600 2700 2800 2900 3000 3100 3200 3300 3301 3302 3303 3304 3305 3306 3307 3308 3309 3310 3311 3312 3313 3314 3315 3316 3317 3318 3319 3320 3321 3322 3323 3324 3325 3326 3327 3328 3329 3330 3331 3332 3333 3334 3335 3336 3337 3338 3339 3340 3341 3241 3141 3041 2941 2841 2741 2641 2541 2441 2341 2241 2141 2041 1941 1841 1741 1641 1541 1441 1341 1241 1141 1041 0941 0841 0741 0641 0541 0441 0341 0241 0141 0041 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030 0029 0028 0027 0026 0025 0024 0023 0022 0021 0020 0019 0018 0017 0016 0015 0014 0013 0012 0011 0010 0009 0008 0007 0006 0005 0004 0003 0002 0001 0000</Border>
+    <Border WrapLabel="true" Allegiance="ImSy" LabelPosition="2614" Label="Sylean Worlds">2118 2217 2216 2215 2214 2213 2314 2413 2513 2613 2714 2813 2913 3013 3113 3114 3115 3116 3216 3117 3016 2916 2816 2716 2616 2517 2417 2318 2217 2118</Border>
+  </Borders>
+  <Routes>
+    <Route Start="0106" End="3206" EndOffsetX="-1" />
+    <Route Start="0112" End="3111" EndOffsetX="-1" />
+    <Route Start="0112" End="3114" EndOffsetX="-1" />
+    <Route Start="0135" End="0138" />
+    <Route Start="0138" End="0139" />
+    <Route Start="0139" End="3202" EndOffsetX="-1" EndOffsetY="1" />
+    <Route Start="0202" End="0203" />
+    <Route Start="0203" End="0305" />
+    <Route Start="0210" End="0112" />
+    <Route Start="0210" End="3110" EndOffsetX="-1" />
+    <Route Start="0216" End="3115" EndOffsetX="-1" />
+    <Route Start="0221" End="3120" EndOffsetX="-1" />
+    <Route Start="0221" End="3222" EndOffsetX="-1" />
+    <Route Start="0302" End="0202" />
+    <Route Start="0302" End="0338" EndOffsetY="-1" />
+    <Route Start="0302" End="0402" />
+    <Route Start="0305" End="0106" />
+    <Route Start="0305" End="0308" />
+    <Route Start="0305" End="0505" />
+    <Route Start="0308" End="0210" />
+    <Route Start="0332" End="0334" />
+    <Route Start="0334" End="0135" />
+    <Route Start="0334" End="0635" />
+    <Route Start="0402" End="0505" />
+    <Route Start="0416" End="0216" />
+    <Route Start="0420" End="0421" />
+    <Route Start="0421" End="0221" />
+    <Route Start="0421" End="0622" />
+    <Route Start="0428" End="0332" />
+    <Route Start="0428" End="0527" />
+    <Route Start="0505" End="0806" />
+    <Route Start="0512" End="0112" />
+    <Route Start="0517" End="0416" />
+    <Route Start="0517" End="0519" />
+    <Route Start="0519" End="0420" />
+    <Route Start="0527" End="0624" />
+    <Route Start="0529" End="0428" />
+    <Route Start="0622" End="0922" />
+    <Route Start="0624" End="0622" />
+    <Route Start="0635" End="0737" />
+    <Route Start="0737" End="0839" />
+    <Route Start="0737" End="1035" />
+    <Route Start="0806" End="1009" />
+    <Route Start="0811" End="0812" />
+    <Route Start="0812" End="0512" />
+    <Route Start="0812" End="0915" />
+    <Route Start="0901" End="1039" EndOffsetY="-1" />
+    <Route Start="0901" End="1102" />
+    <Route Start="0915" End="0517" />
+    <Route Start="0915" End="1114" />
+    <Route Start="0922" End="1123" />
+    <Route Start="0931" End="0529" />
+    <Route Start="1009" End="0811" />
+    <Route Start="1012" End="0812" />
+    <Route Start="1035" End="1134" />
+    <Route Start="1102" End="1204" />
+    <Route Start="1108" End="1309" />
+    <Route Start="1114" End="1012" />
+    <Route Start="1116" End="0915" />
+    <Route Start="1123" End="1124" />
+    <Route Start="1123" End="1219" />
+    <Route Start="1124" End="1226" />
+    <Route Start="1134" End="1233" />
+    <Route Start="1204" End="1205" />
+    <Route Start="1205" End="1108" />
+    <Route Start="1219" End="1418" />
+    <Route Start="1226" End="1328" />
+    <Route Start="1233" End="0931" />
+    <Route Start="1233" End="1430" />
+    <Route Start="1309" End="1410" />
+    <Route Start="1317" End="1116" />
+    <Route Start="1323" End="1123" />
+    <Route Start="1328" End="1428" />
+    <Route Start="1410" End="1009" />
+    <Route Start="1418" End="1518" />
+    <Route Start="1424" End="1226" />
+    <Route Start="1424" End="1623" />
+    <Route Start="1428" End="1424" />
+    <Route Start="1430" End="1428" />
+    <Route Start="1518" End="1317" />
+    <Route Start="1518" End="1819" />
+    <Route Start="1534" End="1233" />
+    <Route Start="1534" End="1536" />
+    <Route Start="1536" End="1538" />
+    <Route Start="1538" End="1601" EndOffsetY="1" />
+    <Route Start="1605" End="1204" />
+    <Route Start="1605" End="2006" />
+    <Route Start="1623" End="1323" />
+    <Route Start="1623" End="1523" />
+    <Route Start="1703" End="1605" />
+    <Route Start="1703" End="1640" EndOffsetY="-1" />
+    <Route Start="1715" End="1518" />
+    <Route Start="1715" End="1812" />
+    <Route Start="1732" End="1534" />
+    <Route Start="1812" End="1410" />
+    <Route Start="1819" End="2021" />
+    <Route Start="1822" End="1623" />
+    <Route Start="1916" End="1715" />
+    <Route Start="1930" End="1732" />
+    <Route Start="2006" End="2008" />
+    <Route Start="2008" End="2211" />
+    <Route Start="2021" End="1822" />
+    <Route Start="2021" End="1925" />
+    <Route Start="2021" End="2224" />
+    <Route Start="2021" End="2322" />
+    <Route Start="2028" End="1930" />
+    <Route Start="2101" End="2040" EndOffsetY="-1" />
+    <Route Start="2101" End="2240" EndOffsetY="-1" />
+    <Route Start="2115" End="1812" />
+    <Route Start="2115" End="1916" />
+    <Route Start="2115" End="2211" />
+    <Route Start="2118" End="1916" />
+    <Route Start="2118" End="2021" />
+    <Route Start="2118" End="2115" />
+    <Route Start="2118" End="2216" />
+    <Route Start="2118" End="2218" />
+    <Route Start="2125" End="2028" />
+    <Route Start="2211" End="2408" />
+    <Route Start="2216" End="2414" />
+    <Route Start="2218" End="2419" />
+    <Route Start="2224" End="2125" />
+    <Route Start="2322" End="2419" />
+    <Route Start="2401" End="2540" EndOffsetY="-1" />
+    <Route Start="2403" End="2401" />
+    <Route Start="2408" End="2507" />
+    <Route Start="2414" End="2115" />
+    <Route Start="2419" End="2422" />
+    <Route Start="2419" End="2616" />
+    <Route Start="2419" End="2720" />
+    <Route Start="2422" End="2322" />
+    <Route Start="2422" End="2526" />
+    <Route Start="2507" End="2403" />
+    <Route Start="2526" End="2928" />
+    <Route Start="2608" End="2507" />
+    <Route Start="2608" End="2910" />
+    <Route Start="2616" End="2414" />
+    <Route Start="2706" End="2608" />
+    <Route Start="2720" End="3021" />
+    <Route Start="2730" End="2928" />
+    <Route Start="2803" End="2706" />
+    <Route Start="2803" End="3040" EndOffsetY="-1" />
+    <Route Start="2816" End="2616" />
+    <Route Start="2816" End="2914" />
+    <Route Start="2910" End="3008" />
+    <Route Start="2910" End="3210" />
+    <Route Start="2912" End="2914" />
+    <Route Start="2914" End="3015" />
+    <Route Start="2928" End="3028" />
+    <Route Start="2933" End="2730" />
+    <Route Start="2933" End="2936" />
+    <Route Start="2933" End="3034" />
+    <Route Start="2936" End="2938" />
+    <Route Start="2938" End="3140" />
+    <Route Start="3008" End="3106" />
+    <Route Start="3015" End="0214" EndOffsetX="1" />
+    <Route Start="3015" End="2816" />
+    <Route Start="3021" End="3218" />
+    <Route Start="3028" End="3131" />
+    <Route Start="3034" End="0136" EndOffsetX="1" />
+    <Route Start="3131" End="2933" />
+    <Route Start="3140" End="0140" EndOffsetX="1" />
+    <Route Start="3140" End="3003" EndOffsetY="1" />
+    <Route Start="3210" End="0113" EndOffsetX="1" />
+    <Route Start="3210" End="0209" EndOffsetX="1" />
+    <Route Start="3210" End="2912" />
+    <Route Start="3218" End="0318" EndOffsetX="1" />
+  </Routes>
+</Sector>

--- a/res/Sectors/M1120/1120_Dagu.sec
+++ b/res/Sectors/M1120/1120_Dagu.sec
@@ -1,0 +1,561 @@
+Hex  Name                 UWP       Remarks                            {Ix}   (Ex)    [Cx]   N    B  Z PBG W  A    Stellar        
+---- -------------------- --------- ---------------------------------- ------ ------- ------ ---- -- - --- -- ---- ---------------
+0103 Kashmiir             ?968???-?                                                          -    -  - ?13 10 StIm M1 V M2 V      
+0105 Kedaa                ?551???-? Po                                                       -    -  - ?02 6  ImLc M0 V           
+0106 Akimu                ?9B6???-? Fl                                                       -    -  - ?03 8  ImLc K9 V           
+0108 Zukchurukh           ?582???-?                                                          -    -  - ?15 9  ImLc M2 V           
+0109 Tscho                ?685???-? Ga                                                       -    -  - ?04 12 ImLc K2 V M3 V      
+0110 Kaza                 ?542???-? He Po                                                    -    -  - ?24 10 ImLc G4 V           
+0201 Nuikh                ?310???-?                                                          -    -  - ?10 12 StIm K9 V           
+0202 Osakis               ?675???-?                                                          -    -  - ?03 7  StIm M2 V           
+0208 Mimu                 ?583???-? (S'mrii)?                                                -    -  - ?14 8  ImLc F8 V           
+0210 Rathas               ?95A???-? Wa                                                       -    -  - ?03 10 ImLc M2 V M6 V      
+0301 Halimaa              ?6B8???-? Fl An                                                    -    -  - ?12 8  StIm F7 V           
+0302 Karrana'ch           ?555???-? Di(Corsettin)                                            -    -  - ?03 6  StIm M0 V M7 V      
+0307 Manoh                ?000???-? As Va                                                    -    -  - ?13 10 ImLc M7 V           
+0401 Ges                  ?868???-?                                                          -    -  - ?03 12 StIm G4 V M9 V      
+0402 Serpent's Reach      ?669???-?                                                          -    -  - ?14 8  StIm K1 V M0 V      
+0405 Tree'chuakh          ?789???-?                                                          -    -  - ?10 12 ImLc M3 V M1 V      
+0406 Muikha               ?000???-? As Va                                                    -    -  - ?22 11 ImLc K4 V M0 V      
+0407 Kaldi                ?947???-?                                                          -    -  - ?13 11 ImLc M2 V M0 V      
+0408 Tae                  ?552???-? Po                                                       -    -  - ?04 17 ImLc M2 V K0 V      
+0502 Ushkhuur             ?A7A???-? Oc                                                       -    -  - ?10 11 StIm G2 V M2 V      
+0503 Geka                 ?311???-? Ic                                                       -    -  - ?04 10 StIm M9 III M0 V    
+0504 Gushnemasha          ?888???-? Sa                                                       -    -  - ?13 14 ImLc M2 V           
+0505 Iiu                  ?5A6???-? Fl                                                       -    -  - ?02 6  ImLc M4 V M5 V      
+0506 Siakmasfa            ?540???-? De He Po                                                 -    -  - ?04 13 ImLc K2 V           
+0509 Refuge               ?578???-?                                                          -    -  - ?24 9  ImLc K1 V           
+0601 Ninaan               ?544???-?                                                          -    -  - ?35 12 StIm M2 V M1 V      
+0604 Seminary             ?422???-? He Po                                                    -    -  - ?00 11 ImLc M1 V           
+0610 Zishku               ?7A5???-? Fl                                                       -    -  - ?24 9  LuIm K0 V           
+0705 Zuiar                ?550???-? De Po                                                    -    -  - ?23 8  ImLc K0 V           
+0707 Khumara              ?561???-?                                                          -    -  - ?00 12 ImLc M2 V M1 V      
+0708 Ssi                  ?758???-?                                                          -    -  - ?03 6  ImLc K6 V M9 V      
+0709 Irshe                ?94A???-? Wa                                                       -    -  - ?13 13 ImLc M2 V M6 V      
+0801 Shéaniki             ?612???-? Ic Sa                                                    -    -  - ?04 7  StIm M2 V           
+0802 Khan                 ?89A???-? Wa                                                       -    -  - ?02 11 ImLc K2 V M1 V M7 V 
+0803 Chiauk               ?431???-? Po An                                                    -    -  - ?03 10 ImLc M2 V M4 V      
+0810 Andalusia            ?572???-? He                                                       -    -  - ?00 8  LuIm G4 V           
+0901 Ediishudir           ?9B0???-? He                                                       -    -  - ?04 10 StIm M2 V M7 V      
+0902 Amnuus               ?AAA???-? Fl                                                       -    -  - ?20 11 ImLc G3 V           
+0904 Lenkaa               ?403???-? Ic Va                                                    -    -  - ?04 10 ImLc A3 V G7 V      
+0905 Uushagkir            ?552???-? Po                                                       -    -  - ?04 11 ImLc M1 V           
+0906 Gvadh                ?867???-? Ga                                                       -    -  - ?03 9  ImLc G0 V M5 V      
+0909 Shukain              ?6B1???-? Fl He                                                    -    -  - ?22 7  LuIm M4 II          
+0910 Luuar                ?653???-? Po                                                       -    -  - ?22 7  LuIm M2 V           
+1004 Ikiir                ?5A4???-? Fl                                                       -    -  - ?10 13 StIm M1 V           
+1005 Birkhi               ?437???-?                                                          -    -  - ?05 10 StIm K1 V M0 V      
+1007 Adaim                ?427???-? Sa                                                       -    -  - ?01 4  LuIm M0 V M4 V      
+1010 Shurkikhi            ?527???-?                                                          -    -  - ?21 6  LuIm K6 V M9 V      
+1102 Ekuu                 ?546???-?                                                          -    -  - ?02 9  StIm M2 V M2 V      
+1105 Kadgishbur           ?540???-? De He Po                                                 -    -  - ?01 16 StIm M3 V M4 V      
+1107 Ha'arn               ?420???-? De He Po                                                 -    -  - ?04 8  LuIm M3 V           
+1108 Asashluu             ?8B6???-? Fl                                                       -    -  - ?02 9  LuIm M3 V           
+1110 Kii'Kii              ?743???-? Po                                                       -    -  - ?10 9  LuIm M0 V           
+1202 Miam                 ?567???-?                                                          -    -  - ?04 16 StIm M0 V           
+1204 Ziruushda            ?977???-? Di(Gograhhah)                                            -    -  - ?00 10 StIm M1 V           
+1206 Mirkigli             ?310???-?                                                          -    -  - ?03 7  LuIm G3 V           
+1207 Imau                 ?564???-?                                                          -    -  - ?02 10 LuIm M1 V           
+1208 Gurgesgu             ?5A4???-? Fl                                                       -    -  - ?13 14 LuIm M7 V           
+1302 Degushush            ?9C5???-? Fl Sa (Ziriduluush)?                                     -    -  - ?02 13 StIm K4 V           
+1401 Misir                ?425???-?                                                          -    -  - ?25 12 StIm M0 V           
+1406 Shidu                ?565???-?                                                          -    -  - ?14 8  LuIm M0 V           
+1409 Imgaa                ?769???-?                                                          -    -  - ?24 9  LuIm M0 V M2 V      
+1502 Giinashkhid          ?697???-?                                                          -    -  - ?03 14 StIm M3 V           
+1503 Edaridur             ?667???-? Ga                                                       -    -  - ?04 10 StIm M2 V M4 V      
+1506 Kimalad              ?785???-? Ga                                                       -    -  - ?03 7  LuIm K2 V M2 V      
+1507 Bastion              ?957???-?                                                          -    -  - ?00 12 LuIm M2 V M2 V      
+1602 Kiuur                ?435???-?                                                          -    -  - ?05 10 StIm K3 V M0 V      
+1604 Aam                  ?562???-?                                                          -    -  - ?03 12 LuIm K9 V M0 V      
+1605 Daridura             ?550???-? De Po                                                    -    -  - ?23 9  LuIm G1 V M5 V      
+1702 Manshuruk            ?6A4???-? Fl                                                       -    -  - ?05 10 StIm M2 V M3 V      
+1703 Diu                  ?835???-?                                                          -    -  - ?03 7  StIm M2 V M3 V      
+1705 Liikirba             ?687???-? Ga Sa                                                    -    -  - ?04 11 LuIm M3 V M0 V      
+1709 Rusadaa              ?555???-?                                                          -    -  - ?04 8  LuIm M1 V           
+1710 Line's End           ?557???-?                                                          -    -  - ?14 13 LuIm K5 IV          
+1801 Gursa                ?547???-?                                                          -    -  - ?03 12 StIm K2 V           
+1803 Kilasir              ?200???-? Va                                                       -    -  - ?04 14 StIm K1 V M6 V      
+1809 Kimarla              ?543???-? Po                                                       -    -  - ?14 8  LuIm M2 IV M1 V M9 V
+1901 Imga                 ?663???-?                                                          -    -  - ?02 12 StIm M1 V           
+1903 Khruel               ?9B4???-? Fl                                                       -    -  - ?20 13 StIm M9 III D       
+1904 Kemnagii             ?553???-? Po Sa                                                    -    -  - ?12 10 LuIm K9 V           
+1905 Morian Khama         ?77A???-? Wa (Neiikhi)?                                            -    -  - ?00 11 LuIm M0 V           
+1906 Nukaush              ?684???-?                                                          -    -  - ?23 8  LuIm M2 V           
+1910 Sadiikashe           ?7C4???-? Fl                                                       -    -  - ?23 8  LuIm K3 V M9 V      
+2002 Arkhuu               ?549???-?                                                          -    -  - ?20 10 StIm K0 V           
+2005 Guru                 ?510???-?                                                          -    -  - ?00 12 LuIm M1 V           
+2007 Khalan               ?677???-?                                                          -    -  - ?21 9  LuIm G1 V           
+2010 Shakuur              ?523???-? Po                                                       -    -  - ?04 8  LuIm M1 V M2 V      
+2104 Dilaaii              ?420???-? De He Po                                                 -    -  - ?13 14 LuIm K5 V           
+2106 Masiruu              ?000???-? As Va                                                    -    -  - ?11 14 LuIm K4 V M9 V      
+2108 Umnudar              ?430???-? De Po                                                    -    -  - ?13 10 LuIm K2 V           
+2110 Kua                  ?572???-? He                                                       -    -  - ?20 16 LuIm M1 V           
+2202 Misaruu              ?527???-? Sa (Feime)?                                              -    -  - ?13 11 StIm M1 V           
+2203 Khumsada             ?769???-?                                                          -    -  - ?21 6  LuIm G1 V M3 V      
+2204 Likhukam             ?200???-? Va Sa                                                    -    -  - ?01 9  LuIm M5 III         
+2205 Ki                   ?627???-?                                                          -    -  - ?04 10 LuIm M0 V           
+2208 Ninlakim             ?100???-? Va                                                       -    -  - ?01 11 LuIm K3 V M8 V      
+2302 Anka                 ?546???-?                                                          -    -  - ?03 10 StIm M0 V M2 V      
+2304 Drogheda             ?8A8???-? Fl                                                       -    -  - ?10 10 LuIm M3 V           
+2308 Oracle               ?551???-? Po                                                       -    -  - ?11 12 LuIm M1 V M6 V      
+2309 Ishkaa               ?433???-? Po                                                       -    -  - ?01 10 LuIm M1 V           
+2402 Rabir                ?540???-? De He Po                                                 -    -  - ?02 10 StIm K3 V           
+2405 Uurku                ?986???-? Sa (Ashdak Meshukiiba)?                                  -    -  - ?22 8  LuIm K1 V           
+2406 Khaem                ?300???-? Va                                                       -    -  - ?04 7  LuIm K2 V M2 V      
+2408 Anshir               ?565???-?                                                          -    -  - ?24 9  LuIm K0 V M6 V      
+2409 Eshsii               ?562???-?                                                          -    -  - ?24 11 LuIm M1 V           
+2410 Suakan               ?591???-? He                                                       -    -  - ?12 11 LuIm M0 V           
+2505 Urpa                 ?776???-? (Urpayans)?                                              -    -  - ?03 14 LuIm K4 V           
+2506 Shuakhuar            ?572???-? He                                                       -    -  - ?00 12 LuIm M2 V           
+2601 Arna                 ?8B8???-? Fl                                                       -    -  - ?03 15 StIm M0 V M8 V      
+2602 Aashma               ?000???-? As Va                                                    -    -  - ?03 9  LuIm M1 V G1 V      
+2603 Khi                  ?685???-? Ga                                                       -    -  - ?04 12 LuIm M0 V           
+2604 Irsaar               ?884???-?                                                          -    -  - ?02 10 LuIm M2 V           
+2605 Shigkhu              ?643???-? Po                                                       -    -  - ?20 11 LuIm G1 V           
+2609 Kagur                ?628???-?                                                          -    -  - ?03 10 LuIm G3 V M1 V      
+2703 Irdiish              ?649???-?                                                          -    -  - ?03 14 LuIm M1 V           
+2706 Khiradu              ?542???-? He Po Sa                                                 -    -  - ?14 11 LuIm G2 V           
+2708 Akher                ?420???-? De He Po                                                 -    -  - ?20 12 LuIm G3 IV          
+2709 Larmige              ?775???-?                                                          -    -  - ?10 6  LuIm M0 V           
+2710 Zugaa                ?96A???-? Wa                                                       -    -  - ?12 8  LuIm M0 V M1 V      
+2801 Gisi                 ?430???-? De Po                                                    -    -  - ?04 7  LuIm M1 V           
+2802 Mikakesh             ?300???-? Va                                                       -    -  - ?04 9  LuIm M3 V           
+2803 Jarsae               ?569???-?                                                          -    -  - ?13 7  LuIm G0 V M4 V      
+2807 Piirgu               ?200???-? Va                                                       -    -  - ?00 10 LuIm M3 V           
+2904 Oumuu                ?97A???-? Wa                                                       -    -  - ?00 10 LuIm M0 V           
+2908 Lemkhi               ?200???-? Va                                                       -    -  - ?12 10 LuIm M0 III D       
+3001 Ersharsa             ?89A???-? Wa Sa                                                    -    -  - ?02 13 LuIm K3 V           
+3004 Aadshas              ?571???-? He                                                       -    -  - ?00 3  LuIm M2 V           
+3005 Dana                 ?689???-?                                                          -    -  - ?22 13 LuIm F0 V M9 V      
+3006 Kurdeshu             ?544???-?                                                          -    -  - ?15 9  LuIm M1 V K9 V      
+3008 Iiradu               ?542???-? He Po                                                    -    -  - ?00 9  LuIm M3 V           
+3101 Iimkhir              ?552???-? Po                                                       -    -  - ?03 13 LuIm M2 V           
+3103 Karsa                ?7A8???-? Fl                                                       -    -  - ?02 15 LuIm K6 IV          
+3107 Daas                 ?768???-?                                                          -    -  - ?01 14 LuIm K1 V M1 V      
+3110 Anshu                ?567???-?                                                          -    -  - ?24 12 LuIm G3 V M4 V      
+3202 Lir                  ?576???-?                                                          -    -  - ?01 13 LuIm M3 V M6 V      
+3205 Duukhaa              ?000???-? As Va                                                    -    -  - ?14 12 LuIm K1 V M6 V      
+3206 Aska                 ?201???-? Ic Va                                                    -    -  - ?03 13 LuIm M3 V M7 V M1 V 
+3208 Kassandra            ?898???-?                                                          -    -  - ?12 10 LuIm K7 V           
+3209 Gishmarkash          ?536???-?                                                          -    -  - ?25 13 LuIm K8 V           
+0111 Upag                 ?310???-?                                                          -    -  - ?14 8  ImLc M0 V           
+0113 Teoech               ?977???-?                                                          -    -  - ?02 11 StIm M1 V           
+0115 Chathi               ?8C3???-? Fl                                                       -    -  - ?10 15 StIm K4 V           
+0117 Gwi                  ?563???-?                                                          -    -  - ?12 14 StIm M0 V M7 V      
+0211 Iliika               ?436???-?                                                          -    -  - ?24 11 ImLc M0 V M7 V      
+0212 Khikaeg              ?565???-?                                                          -    -  - ?04 11 StIm M1 V           
+0213 Aaki                 ?434???-?                                                          -    -  - ?23 9  StIm G7 V           
+0214 Cablu                ?548???-?                                                          -    -  - ?00 13 StIm K1 V           
+0216 Oewni                ?564???-?                                                          -    -  - ?22 7  StIm K5 V M2 V M5 V 
+0217 Fau                  ?423???-? Po                                                       -    -  - ?00 9  StIm K5 V M7 V      
+0311 Unishpiir            ?86A???-? Wa                                                       -    -  - ?04 9  ImLc G1 V M4 V      
+0319 Sagikii              ?100???-? Va                                                       -    -  - ?02 13 LuIm K4 V M5 V      
+0320 Adaskaglu            ?544???-?                                                          -    -  - ?23 8  LuIm K9 V M9 V      
+0412 Amigu                ?436???-?                                                          -    -  - ?14 12 LuIm K0 V M9 V      
+0419 Oeth                 ?310???-?                                                          -    -  - ?22 9  LuIm K0 IV          
+0420 Cleci                ?561???-?                                                          -    -  - ?14 15 LuIm K0 V           
+0513 Gishi                ?555???-?                                                          -    -  - ?00 15 LuIm M3 V M4 V      
+0514 Tarterus             ?000???-? As Va                                                    -    -  - ?01 15 LuIm A2 V K3 V      
+0515 Irphothe             ?679???-?                                                          -    -  - ?00 9  LuIm M0 V           
+0517 Station One          ?668???-?                                                          -    -  - ?02 16 LuIm K5 V           
+0518 Dakushan             ?200???-? Va                                                       -    -  - ?00 13 LuIm K5 V           
+0519 Osha                 ?625???-?                                                          -    -  - ?04 10 LuIm M2 V           
+0520 Sloethu              ?69A???-? Wa Sa                                                    -    -  - ?13 13 LuIm M2 V           
+0613 Niirkhi              ?657???-? Ga                                                       -    -  - ?05 9  LuIm G1 V M2 V      
+0614 Gladsheim            ?9D5???-?                                                          -    -  - ?00 9  LuIm K9 V           
+0615 Gaae                 ?540???-? De He Po (Ka Kelaree)?                                   -    -  - ?00 13 LuIm K4 V M1 V      
+0619 Kaelm'katwi          ?553???-? Po                                                       -    -  - ?25 10 LuIm G1 V           
+0620 Glachith             ?6A4???-? Fl                                                       -    -  - ?03 10 LuIm M3 V M3 V      
+0711 Kima                 ?522???-? He Po                                                    -    -  - ?03 11 LuIm M3 V M5 V      
+0714 Diishalum            ?420???-? De He Po                                                 -    -  - ?13 8  LuIm M3 V           
+0716 Hourara              ?578???-?                                                          -    -  - ?03 8  LuIm M0 V M1 V M8 V 
+0718 Ekli                 ?543???-? Po An                                                    -    -  - ?20 10 LuIm M1 V M5 V      
+0719 Ziamr                ?310???-?                                                          -    -  - ?00 11 LuIm K2 V           
+0811 Kashki               ?541???-? He Po                                                    -    -  - ?14 11 LuIm G9 V           
+0812 Lau                  ?541???-? He Po                                                    -    -  - ?24 14 LuIm K3 V           
+0815 Diraan               ?676???-?                                                          -    -  - ?00 15 LuIm M2 V           
+0816 Ufesk                ?9AA???-? Fl                                                       -    -  - ?01 15 LuIm K3 III         
+0818 Miku                 ?666???-? Ga                                                       -    -  - ?04 9  LuIm G0 V           
+0819 Ardchi               ?100???-? Va Sa                                                    -    -  - ?04 9  LuIm M3 V           
+0820 Drya                 ?99A???-? Wa                                                       -    -  - ?02 12 LuIm G2 V           
+0914 Undim                ?000???-? As Va Di(Shassahhrhi)                                    -    -  - ?14 14 LuIm K7 V M4 V      
+0916 Lauyesyeh            ?767???-? Ga                                                       -    -  - ?04 8  LuIm K0 V           
+0920 Congress             ?545???-?                                                          -    -  - ?14 14 LuIm M0 V           
+1011 Lamadii              ?679???-?                                                          -    -  - ?04 14 LuIm G2 V M1 V      
+1016 Ushra                ?625???-?                                                          -    -  - ?33 11 LuIm M2 V           
+1017 Talnes'ra            ?565???-?                                                          -    -  - ?20 11 LuIm M0 V M9 V      
+1020 Maamkumar            ?535???-?                                                          -    -  - ?04 10 LuIm K3 V           
+1113 Laruu                ?521???-? He Po                                                    -    -  - ?04 16 LuIm M1 V           
+1114 Tethys               ?89A???-? Wa (Hamaran)?                                            -    -  - ?11 11 LuIm M1 V M0 V      
+1115 Nox                  ?9A5???-? Fl                                                       -    -  - ?20 13 LuIm M2 V           
+1117 Antioch              ?545???-?                                                          -    -  - ?00 9  LuIm K3 V M8 V      
+1118 Kaurga               ?686???-? Ga                                                       -    -  - ?01 7  LuIm M2 V M6 V      
+1212 Khemelov             ?772???-? He                                                       -    -  - ?12 15 LuIm G1 V           
+1218 Lasiimshim           ?421???-? He Po                                                    -    -  - ?01 13 LuIm G5 V M1 V      
+1220 Katris               ?410???-?                                                          -    -  - ?02 15 LuIm M2 V M5 V      
+1314 Hakukuk              ?594???-?                                                          -    -  - ?11 12 LuIm M0 V           
+1317 Argiluu              ?68A???-? Wa Sa                                                    -    -  - ?14 10 LuIm K8 V           
+1318 Aberlocht            ?544???-?                                                          -    -  - ?04 7  LuIm M2 V           
+1319 Kaagashgiir          ?553???-? Po                                                       -    -  - ?04 13 LuIm M3 V M3 V      
+1320 Jekyll               ?430???-? De Po                                                    -    -  - ?24 9  LuIm K7 V M6 V      
+1414 Mote                 ?100???-? Va                                                       -    -  - ?10 14 LuIm K2 V           
+1416 Hellas               ?555???-?                                                          -    -  - ?03 6  LuIm M3 V           
+1418 Nafud                ?430???-? De Po (Inchok)?                                          -    -  - ?14 9  LuIm K4 V M9 V      
+1420 Nakharpii            ?755???-? Ga                                                       -    -  - ?14 12 LuIm K2 V           
+1511 Cimmeria             ?310???-?                                                          -    -  - ?03 10 LuIm M0 V           
+1516 Adele                ?676???-?                                                          -    -  - ?04 11 LuIm M2 V M6 V M6 V 
+1520 Elysium              ?765???-? Ga                                                       -    -  - ?14 8  LuIm M2 V           
+1612 Lemuria              ?689???-?                                                          -    -  - ?03 11 LuIm M1 V M7 V M3 V 
+1613 Nguma                ?9E4???-?                                                          -    -  - ?22 11 LuIm M1 V M7 V      
+1615 Kikaduum             ?551???-? Po                                                       -    -  - ?10 14 LuIm M2 V           
+1618 Station Four         ?545???-?                                                          -    -  - ?02 7  LuIm M1 V           
+1711 Lupigaa              ?550???-? De Po                                                    -    -  - ?04 11 LuIm M0 V M3 V      
+1712 Iesha                ?7AA???-? Fl (Eliyoh)?                                             -    -  - ?13 11 LuIm M1 V           
+1713 Folly                ?300???-? Va An                                                    -    -  - ?23 12 LuIm M1 V           
+1717 McKenzie             ?200???-? Va Sa                                                    -    -  - ?04 17 LuIm G2 V           
+1718 Shuada               ?100???-? Va                                                       -    -  - ?01 11 LuIm K9 IV M9 V     
+1813 Cruachan             ?7AA???-? Fl                                                       -    -  - ?20 12 LuIm M2 V M3 V      
+1816 Mahonri              ?411???-? Ic                                                       -    -  - ?01 6  LuIm M2 V M6 V      
+1911 Fhaia                ?000???-? As Va                                                    -    -  - ?13 9  LuIm G1 V           
+1912 Eaunna               ?300???-? Va                                                       -    -  - ?21 13 LuIm M0 V           
+1913 Tiffany              ?558???-?                                                          -    -  - ?22 9  LuIm K4 V           
+1918 Rukhigu              ?410???-?                                                          -    -  - ?10 9  LuIm F4 V M7 V      
+1919 Dehkaim              ?A75???-?                                                          -    -  - ?03 13 LuIm K5 V           
+1920 Iunda                ?8B3???-? Fl                                                       -    -  - ?03 8  LuIm K1 V M5 V      
+2013 Dishalu              ?553???-? Po                                                       -    -  - ?24 9  LuIm M1 V M4 V      
+2015 Shibishlim           ?566???-?                                                          -    -  - ?01 12 LuIm M3 V           
+2020 Dauni                ?310???-?                                                          -    -  - ?23 16 LuIm K4 V           
+2111 Tomb                 ?000???-? As Va                                                    -    -  - ?04 14 LuIm K0 V           
+2113 Mirnaa               ?543???-? Po                                                       -    -  - ?24 11 LuIm M2 V           
+2119 Khandi               ?422???-? He Po                                                    -    -  - ?12 13 LuIm M3 V           
+2216 Urdi                 ?310???-?                                                          -    -  - ?02 10 LuIm K0 V M4 V M6 V 
+2317 Arnakhish            ?75A???-? Wa                                                       -    -  - ?04 7  LuIm G3 V M0 V      
+2318 Zaankhid             ?300???-? Va                                                       -    -  - ?11 8  LuIm M1 V M3 V      
+2320 Karbi                ?8D3???-?                                                          -    -  - ?25 10 LuIm M1 V M3 V      
+2412 Edsham               ?426???-?                                                          -    -  - ?03 10 LuIm M0 V           
+2413 Gakhir               ?400???-? Va                                                       -    -  - ?04 8  LuIm M4 III         
+2415 Irlu                 ?000???-? As Va                                                    -    -  - ?24 11 LuIm K2 V M9 V      
+2416 Dua                  ?431???-? Po An                                                    -    -  - ?02 10 LuIm M0 V           
+2418 Kishgakhir           ?554???-?                                                          -    -  - ?14 12 LuIm M2 V M7 V      
+2512 Lashgaiika           ?420???-? De He Po                                                 -    -  - ?00 14 LuIm K2 V           
+2513 Luguk                ?8A4???-? Fl                                                       -    -  - ?02 17 LuIm G4 V M4 V      
+2514 Aibeshma             ?437???-?                                                          -    -  - ?02 9  LuIm M0 V M7 V      
+2515 Nikhuskir            ?310???-?                                                          -    -  - ?00 12 LuIm K0 IV          
+2517 Giku                 ?436???-?                                                          -    -  - ?13 10 LuIm M1 V           
+2518 Duunkhan             ?423???-? Po                                                       -    -  - ?23 15 LuIm G2 V           
+2612 Diablo               ?8C8???-? Fl                                                       -    -  - ?10 12 LuIm K1 III M3 V D  
+2615 Gesiisha             ?000???-? As Va                                                    -    -  - ?13 8  LuIm M2 V M8 V      
+2617 Hasoi'aohalaiko      ?876???-?                                                          -    -  - ?00 10 LuIm M3 V           
+2618 Shirlukam            ?573???-?                                                          -    -  - ?04 13 LuIm G9 V M7 V      
+2711 Remanec              ?577???-?                                                          -    -  - ?00 15 LuIm K0 V           
+2714 Negev                ?540???-? De He Po                                                 -    -  - ?04 14 LuIm M3 V M0 V      
+2715 Dupusirlu            ?95A???-? Wa                                                       -    -  - ?00 11 LuIm K4 V M7 V      
+2717 Kuriishe             ?631???-? Po                                                       -    -  - ?00 11 LuIm G4 V           
+2719 Gareesh Ra           ?565???-?                                                          -    -  - ?12 11 LuIm K2 V           
+2817 Mudupas              ?8B3???-? Fl                                                       -    -  - ?00 6  LuIm M0 V M0 V      
+2819 Khashpel             ?553???-? Po                                                       -    -  - ?04 11 LuIm M1 V           
+2918 Quuira               ?A9A???-? Oc                                                       -    -  - ?00 9  LuIm G2 V M6 V      
+2919 Amgagiga             ?554???-?                                                          -    -  - ?04 14 LuIm M2 V           
+2920 Eraki                ?989???-?                                                          -    -  - ?03 14 LuIm M3 V           
+3012 Ander's Moon         ?310???-?                                                          -    -  - ?04 9  LuIm K1 V M8 V      
+3013 Cyrene               ?402???-? Ic Va                                                    -    -  - ?24 14 LuIm M2 V           
+3014 Kherse               ?200???-? Va                                                       -    -  - ?00 7  LuIm M0 II          
+3015 Akhashmaas           ?786???-? Ga                                                       -    -  - ?23 8  LuIm G1 V           
+3016 Larmai               ?797???-?                                                          -    -  - ?04 9  LuIm M0 V           
+3018 Saffron              ?646???-?                                                          -    -  - ?01 9  LuIm M1 V           
+3019 Urkesh               ?574???-?                                                          -    -  - ?04 7  LuIm M0 V M3 V      
+3111 Luramsum             ?7A7???-? Fl                                                       -    -  - ?05 13 LuIm M3 V           
+3114 Imsu                 ?588???-?                                                          -    -  - ?00 11 LuIm K2 V M4 V      
+3115 Amiikhuk             ?555???-?                                                          -    -  - ?00 7  LuIm M2 V M8 V      
+3117 Umeeshe              ?542???-? He Po                                                    -    -  - ?00 5  LuIm M1 V           
+3120 Sivvista             ?428???-?                                                          -    -  - ?13 10 LuIm K0 V M8 V      
+3220 Zashe                ?634???-?                                                          -    -  - ?03 10 LuIm M0 V M5 V      
+0123 Nueva Esperanza      ?555???-?                                                          -    -  - ?23 14 LuIm M1 V M8 V      
+0126 Coroico              ?665???-? Ga                                                       -    -  - ?14 13 ImAp K5 V M7 V      
+0129 Ushkhir              ?724???-?                                                          -    -  - ?03 12 ImAp M0 V           
+0222 Maq'appav            ?200???-? Va                                                       -    -  - ?14 9  ImAp M2 V           
+0223 Shammud              ?546???-?                                                          -    -  - ?03 10 ImAp K5 IV M1 V     
+0227 Ekhor                ?7A8???-? Fl                                                       -    -  - ?03 8  ImAp M2 V           
+0228 Kaattji              ?545???-?                                                          -    -  - ?03 12 ImAp M2 V           
+0229 Hu                   ?8B6???-? Fl                                                       -    -  - ?03 11 ImAp M3 V           
+0230 Dudin                ?9CA???-? Fl                                                       -    -  - ?00 8  ImAp M2 V           
+0321 Hoaz                 ?545???-? Di(Ancari)                                               -    -  - ?00 14 LuIm M2 V           
+0322 Tsuchi               ?310???-?                                                          -    -  - ?15 15 ImAp M2 V           
+0323 Biik                 ?557???-?                                                          -    -  - ?23 11 LuIm K1 V M2 V      
+0324 Khadda               ?421???-? He Po                                                    -    -  - ?03 12 LuIm K4 V M3 V      
+0325 Giirakh              ?986???-?                                                          -    -  - ?20 13 LuIm G0 V           
+0329 Syrna                ?966???-?                                                          -    -  - ?13 14 ImAp M2 V           
+0421 Mirkan               ?422???-? He Po                                                    -    -  - ?21 10 LuIm G9 V M2 V      
+0423 Maudhii              ?550???-? De Po Sa                                                 -    -  - ?04 9  LuIm M3 V           
+0425 Sagan                ?877???-?                                                          -    -  - ?04 10 LuIm K3 V M1 V      
+0426 Aksa                 ?8C3???-? Fl                                                       -    -  - ?02 17 LuIm K1 V           
+0521 Ashes                ?540???-? De He Po                                                 -    -  - ?03 11 LuIm M2 V           
+0523 Bhuur                ?899???-? An                                                       -    -  - ?02 9  LuIm M2 V           
+0524 Ghaedzaekh           ?315???-? Ic                                                       -    -  - ?14 11 LuIm M3 V           
+0526 Bh'ai                ?86A???-? Wa                                                       -    -  - ?04 11 LuIm M3 V M7 V      
+0528 Nidavellir           ?683???-?                                                          -    -  - ?20 8  ImAp M0 V           
+0530 T'azhqava            ?430???-? De Po                                                    -    -  - ?02 10 ImAp G6 V           
+0621 Rias'qanaa           ?420???-? De He Po                                                 -    -  - ?04 12 LuIm K2 IV          
+0622 Mai                  ?530???-? De Po                                                    -    -  - ?22 7  LuIm M2 V M2 V      
+0625 Keshga               ?666???-? Ga                                                       -    -  - ?24 9  LuIm G4 V           
+0628 Iur                  ?796???-?                                                          -    -  - ?02 8  ImAp M3 V           
+0721 Zeda                 ?873???-? (Ziadd)?                                                 -    -  - ?24 14 LuIm K4 V           
+0723 A'niaqoro            ?9AA???-? Fl                                                       -    -  - ?04 8  LuIm M2 V K4 V      
+0724 Guan                 ?510???-?                                                          -    -  - ?01 9  LuIm M0 V           
+0725 Sumuu                ?300???-? Va                                                       -    -  - ?13 11 LuIm K2 V           
+0729 Shogun               ?89A???-? Wa                                                       -    -  - ?11 8  ImAp M1 V           
+0821 Derla                ?8B3???-? Fl                                                       -    -  - ?13 10 LuIm F2 V           
+0823 Urgu                 ?A8A???-? Oc                                                       -    -  - ?15 10 LuIm K4 V           
+0825 Akish                ?575???-?                                                          -    -  - ?05 10 LuIm M0 V M0 V      
+0828 Asimidiske           ?100???-? Va Sa (Calipha)?                                         -    -  - ?12 15 ImAp M0 V M0 V      
+0921 Wilderness           ?540???-? De He Po                                                 -    -  - ?01 10 LuIm G6 V M9 V      
+0924 D'Artur              ?AE7???-?                                                          -    -  - ?20 8  LuIm K1 V M5 V      
+0926 Kirusis              ?533???-? Po                                                       -    -  - ?23 13 LuIm K3 V           
+0927 Perkurshir           ?566???-?                                                          -    -  - ?03 8  LuIm M2 V           
+0928 Iushush              ?7B0???-? He                                                       -    -  - ?20 9  ImAp G0 V M5 V      
+0930 Lemimamur            ?8B4???-? Fl                                                       -    -  - ?21 8  ImAp M3 V M9 V      
+1021 Muruk                ?651???-? Po                                                       -    -  - ?21 10 LuIm G3 V M5 V      
+1023 Kulisaan             ?424???-?                                                          -    -  - ?13 10 LuIm M1 V           
+1025 Reshumirak           ?400???-? Va Sa (Domination)?                                      -    -  - ?03 14 LuIm K8 V           
+1026 Darzii               ?674???-?                                                          -    -  - ?00 9  LuIm K3 V           
+1027 Giarkhesa            ?542???-? He Po                                                    -    -  - ?10 11 LuIm M0 V           
+1029 Liikiir              ?664???-?                                                          -    -  - ?02 9  LuIm G8 V M1 V      
+1121 Naruppesh            ?688???-?                                                          -    -  - ?03 8  LuIm M1 V M4 V      
+1124 Arlim Dusiru         ?552???-? Po                                                       -    -  - ?00 5  LuIm M1 V M8 V      
+1126 Madingik             ?588???-?                                                          -    -  - ?03 9  LuIm M1 V           
+1129 Akigir               ?664???-?                                                          -    -  - ?05 11 LuIm G4 V M6 V      
+1222 Ispumer              ?434???-?                                                          -    -  - ?13 8  LuIm M2 V           
+1223 Nurashimu            ?100???-? Va                                                       -    -  - ?04 16 LuIm G4 V           
+1227 Nuaam Igzur          ?541???-? He Po                                                    -    -  - ?00 4  LuIm M3 V           
+1228 Darusush             ?426???-?                                                          -    -  - ?05 12 LuIm M2 V           
+1321 Shankida             ?552???-? Po                                                       -    -  - ?32 13 LuIm M1 V M2 V      
+1323 Khiishpur            ?8A5???-? Fl                                                       -    -  - ?01 8  LuIm G1 V           
+1325 Ipkur                ?564???-?                                                          -    -  - ?05 8  LuIm M1 V           
+1422 Urshushur            ?563???-?                                                          -    -  - ?04 15 LuIm M0 V M9 V      
+1424 Omegindus            ?587???-?                                                          -    -  - ?13 10 LuIm M3 V           
+1428 Station Three        ?735???-?                                                          -    -  - ?25 12 LuIm K5 V M8 V      
+1430 Gesrakur             ?AAA???-? Fl                                                       -    -  - ?14 8  LuIm M3 V           
+1523 Ussine               ?A5A???-? Oc                                                       -    -  - ?05 8  LuIm M2 V M3 V      
+1525 Parendis             ?639???-?                                                          -    -  - ?03 8  LuIm M1 V           
+1526 Larsen               ?565???-?                                                          -    -  - ?03 11 LuIm M1 V M9 V      
+1528 Calobrur             ?560???-? De                                                       -    -  - ?10 10 LuIm K0 V           
+1529 Iilenkhis            ?551???-? Po                                                       -    -  - ?03 10 LuIm M0 V           
+1530 Cr'cpuc              ?564???-?                                                          -    -  - ?00 7  LuIm K0 V M5 V      
+1622 Apemkir              ?8A8???-? Fl                                                       -    -  - ?00 8  LuIm K3 V           
+1625 Zukalis              ?421???-? He Po                                                    -    -  - ?03 8  LuIm M1 V M6 V      
+1626 Beleperan            ?788???-?                                                          -    -  - ?05 15 LuIm M2 V M2 V M9 V 
+1629 Kuuranse             ?534???-?                                                          -    -  - ?04 13 LuIm M3 V           
+1630 Haven's Gate         ?548???-?                                                          -    -  - ?14 12 LuIm G5 V           
+1722 Campbell             ?99A???-? Wa                                                       -    -  - ?04 7  LuIm M1 V           
+1723 Dashi                ?550???-? De Po                                                    -    -  - ?04 11 LuIm M2 V           
+1726 New Titan            ?AAA???-? Fl                                                       -    -  - ?14 8  LuIm M1 V           
+1728 Ekhugush             ?636???-?                                                          -    -  - ?12 8  LuIm M2 V M9 V      
+1729 Ushmegili            ?86A???-? Wa                                                       -    -  - ?22 14 LuIm G1 V           
+1730 Iash                 ?203???-? Ic Va Sa                                                 -    -  - ?04 7  LuIm K2 V           
+1821 Aiaiyal              ?572???-? He                                                       -    -  - ?10 12 LuIm K2 V           
+1822 Bradley              ?546???-?                                                          -    -  - ?03 15 LuIm M3 V M3 V M9 V 
+1823 Iinir                ?557???-?                                                          -    -  - ?01 11 LuIm M1 V           
+1824 Kamgikiik            ?436???-? (Kamgik)?                                                -    -  - ?04 10 LuIm K1 V M3 V      
+1829 Pr'Geehr             ?583???-? (Geehrtahe)?                                             -    -  - ?05 8  LuIm G3 V           
+1830 Clan Home            ?789???-?                                                          -    -  - ?11 11 LuIm M3 V           
+1924 No Hope              ?541???-? He Po                                                    -    -  - ?13 11 LuIm K1 V           
+1926 Shakhii              ?200???-? Va Sa                                                    -    -  - ?04 11 LuIm M2 V           
+1927 Junivaar             ?586???-?                                                          -    -  - ?00 13 LuIm K6 V           
+1928 Asii                 ?435???-?                                                          -    -  - ?05 10 LuIm G0 V           
+1929 Ikabi                ?000???-? As Va                                                    -    -  - ?00 11 LuIm K4 V           
+1930 Vipac                ?401???-? Ic Va                                                    -    -  - ?03 10 LuIm M1 V           
+2022 Janssen              ?420???-? De He Po                                                 -    -  - ?13 9  LuIm G7 V M9 V      
+2023 Draskeran            ?311???-? Ic Sa                                                    -    -  - ?12 13 LuIm M2 V M5 V      
+2024 Jarmael              ?512???-? Ic                                                       -    -  - ?32 9  LuIm M0 V           
+2026 Sennirak             ?401???-? Ic Va                                                    -    -  - ?14 13 LuIm A3 V           
+2028 Kakhirusar           ?664???-?                                                          -    -  - ?03 9  LuIm M2 V           
+2030 Cocor                ?6B2???-? Fl He                                                    -    -  - ?03 7  LuIm M3 V M5 V      
+2122 Chandra's World      ?996???-?                                                          -    -  - ?03 8  LuIm K4 V           
+2123 Kediiga              ?778???-?                                                          -    -  - ?20 9  LuIm G6 V           
+2124 Medurma              ?9D7???-? An Di(Miyavine) Cs                                       -    -  - ?23 12 LuIm G0 V           
+2127 Thalassa             ?56A???-? Wa                                                       -    -  - ?23 11 LuIm K8 V           
+2130 Maiden               ?430???-? De Po                                                    -    -  - ?14 13 LuIm M0 V M7 V      
+2223 Dipa                 ?200???-? Va                                                       -    -  - ?01 12 LuIm A4 V M5 V      
+2225 Nexus                ?666???-? Ga                                                       -    -  - ?23 12 LuIm G4 V           
+2226 Theetasigni          ?424???-?                                                          -    -  - ?02 10 LuIm F4 V           
+2227 A'a'suni             ?546???-? (Athar)?                                                 -    -  - ?00 10 LuIm M2 V           
+2228 Kurkhi               ?401???-? Ic Va                                                    -    -  - ?14 9  LuIm M0 V           
+2322 Ishigumam            ?100???-? Va                                                       -    -  - ?02 9  LuIm K2 V M6 V      
+2324 Tilmea               ?433???-? Po                                                       -    -  - ?00 11 LuIm M1 V K8 V      
+2327 Station Two          ?560???-? De                                                       -    -  - ?02 11 LuIm M4 V           
+2424 Mo'line              ?435???-?                                                          -    -  - ?13 7  LuIm M2 V           
+2426 For'star             ?623???-? Po                                                       -    -  - ?05 8  LuIm M2 V M9 V      
+2521 Proctonir            ?424???-?                                                          -    -  - ?23 11 LuIm M1 V M4 V      
+2522 Emarkus              ?555???-?                                                          -    -  - ?04 7  LuIm M2 V           
+2525 Khusgulur            ?573???-? (Morlocks)?                                              -    -  - ?13 10 LuIm G3 V M7 V      
+2526 Rraeghzoez           ?775???-?                                                          -    -  - ?12 7  LuIm K3 V M3 V      
+2529 Dummur               ?529???-?                                                          -    -  - ?01 11 LuIm M4 V           
+2623 Niishulam            ?432???-? Po                                                       -    -  - ?14 11 LuIm M0 V           
+2624 Imern                ?748???-?                                                          -    -  - ?01 10 LuIm K0 V           
+2625 Serusi               ?540???-? De He Po                                                 -    -  - ?02 6  LuIm G3 V           
+2627 Khasha               ?672???-? He                                                       -    -  - ?00 5  LuIm M8 V           
+2721 Inshaam              ?669???-?                                                          -    -  - ?04 8  LuIm G4 V           
+2725 Collette             ?542???-? He Po                                                    -    -  - ?14 11 LuIm M3 V           
+2727 Pukh                 ?535???-?                                                          -    -  - ?14 14 LuIm M2 V           
+2728 Shershe              ?540???-? De He Po                                                 -    -  - ?02 10 LuIm K9 V M0 V      
+2729 Denisol              ?655???-? Ga                                                       -    -  - ?03 15 LuIm M1 V           
+2821 Mimsur               ?424???-?                                                          -    -  - ?22 8  LuIm K1 V           
+2822 Khuulush             ?651???-? Po                                                       -    -  - ?22 14 LuIm M0 V M2 V      
+2827 Laeris               ?100???-? Va                                                       -    -  - ?20 13 LuIm M2 V           
+2828 Quinarim             ?98A???-? Wa                                                       -    -  - ?03 12 LuIm G4 V M3 V      
+2830 Khiishi              ?77A???-? Wa                                                       -    -  - ?03 10 LuIm K8 V           
+2922 Baladine             ?303???-? Ic Va Sa                                                 -    -  - ?03 7  LuIm M3 V           
+2923 Anpanaar             ?543???-? Po                                                       -    -  - ?23 8  LuIm M1 V M3 V      
+2927 Shea                 ?651???-? Po                                                       -    -  - ?03 6  LuIm M0 V M5 V      
+2928 Shurkig              ?434???-?                                                          -    -  - ?10 6  LuIm M0 V M1 V M8 V 
+3024 Pamnagagur           ?785???-? Ga                                                       -    -  - ?15 13 LuIm M0 V M5 V      
+3027 Kestona              ?576???-?                                                          -    -  - ?10 12 LuIm M3 V           
+3028 Dashgurus            ?768???-?                                                          -    -  - ?12 12 LuIm M0 V           
+3029 Frey                 ?561???-?                                                          -    -  - ?00 5  LuIm K1 V           
+3030 Khaammumlar          ?430???-? De Po                                                    -    -  - ?20 6  LuIm M0 V M5 V      
+3121 Depot                A310244-D Lo Da                              { 2 }  (711+4) [647H] B    D  A 310 13 LuIm M1 V           
+3122 Zerpekush            ?420???-? De He Po                                                 -    -  - ?04 15 LuIm K0 V M0 V      
+3124 Zhummuuki            ?74A???-? Wa                                                       -    -  - ?22 9  LuIm M1 V M1 V      
+3126 Kan                  ?433???-? Po                                                       -    -  - ?04 7  LuIm G2 V           
+3221 Dupligi              ?76A???-? Wa                                                       -    -  - ?13 10 LuIm M1 V           
+3222 Dinzur               ?420???-? De He Po                                                 -    -  - ?10 15 LuIm G9 V           
+3223 Kedden               ?585???-?                                                          -    -  - ?13 10 LuIm M2 V M2 V      
+3227 Namkigem             ?665???-? Ga                                                       -    -  - ?00 9  LuIm M3 V M8 V      
+3228 Ishmurish            ?000???-? As Va                                                    -    -  - ?00 7  LuIm F6 V M1 V      
+0137 Ekha                 ?568???-?                                                          -    -  - ?04 17 FdIl K2 V           
+0138 Altamachi            ?201???-? Ic Va                                                    -    -  - ?12 16 FdIl K0 V           
+0232 Danse                ?9B4???-? Fl                                                       -    -  - ?02 10 LuIm K3 V           
+0235 Gaad                 ?778???-?                                                          -    -  - ?03 16 FdIl M0 V M1 V      
+0236 Feym'n               ?435???-?                                                          -    -  - ?24 10 FdIl M0 V M3 V      
+0240 Bolivar              ?786???-? Ga                                                       -    -  - ?14 11 FdIl K1 V M9 V      
+0331 Kinhe                ?79A???-? Wa                                                       -    -  - ?04 11 ImAp K2 V           
+0440 Cobija               ?775???-?                                                          -    -  - ?03 13 FdIl K3 V           
+0531 Eddum                ?797???-?                                                          -    -  - ?02 9  ImAp M0 V M2 V      
+0535 Khaguu               ?310???-?                                                          -    -  - ?12 15 FdIl K4 V           
+0539 Tarija               ?200???-? Va                                                       -    -  - ?10 13 FdIl M1 III         
+0540 Shanim               ?000???-? As Va                                                    -    -  - ?03 7  FdIl G1 V           
+0631 Shumuu               ?300???-? Va                                                       -    -  - ?02 18 ImAp M5 V           
+0633 Anshaar              ?637???-?                                                          -    -  - ?24 13 ImAp G7 V           
+0635 Khika                ?500???-? Va                                                       -    -  - ?02 13 FdIl M1 V M3 V      
+0636 Gya                  ?546???-?                                                          -    -  - ?12 10 FdIl G0 V           
+0638 Lamdas               ?541???-? He Po                                                    -    -  - ?04 12 FdIl K7 V M7 V      
+0639 Ascension            ?420???-? De He Po                                                 -    -  - ?10 13 FdIl M2 V           
+0733 Mindahm              ?436???-? Sa                                                       -    -  - ?04 12 LuIm M1 V M6 V      
+0734 Apolo                ?9AA???-? Fl                                                       -    -  - ?20 8  LuIm M0 V           
+0735 Khimkaa              ?595???-?                                                          -    -  - ?02 12 LuIm M0 V           
+0736 Nimluin              ?753???-? Po                                                       -    -  - ?04 12 FdIl K0 V           
+0738 Rruekhsik            ?866???-? Ga                                                       -    -  - ?00 3  FdIl G5 V           
+0739 Hana's Soujourn      ?100???-? Va                                                       -    -  - ?02 5  FdIl M9 V           
+0831 Mimku                ?200???-? Va                                                       -    -  - ?00 11 ImAp M3 III         
+0832 Shashankhu           ?424???-?                                                          -    -  - ?32 10 ImAp G2 V           
+0833 Argo                 ?553???-? Po                                                       -    -  - ?23 14 LuIm M0 V M3 V      
+0839 Tureis               ?748???-?                                                          -    -  - ?04 13 FdIl G3 V M9 V      
+0840 Uushar               ?561???-?                                                          -    -  - ?02 13 FdIl M2 V           
+0931 Liishuga             ?663???-?                                                          -    -  - ?00 4  LuIm K1 V           
+0932 Sii                  ?888???-?                                                          -    -  - ?12 12 LuIm M1 V           
+0933 Mishu                ?AD5???-?                                                          -    -  - ?03 14 LuIm G7 V           
+0935 Akiva                ?98A???-? Wa (Scanian)?                                            -    -  - ?05 16 LuIm G8 V M2 V      
+0936 Abbayi               ?682???-?                                                          -    -  - ?04 7  LuIm K2 V M0 V      
+0940 Uaam                 ?579???-? (Jala'Lak)?                                              -    -  - ?14 8  LuIm M2 V           
+1032 Shidka               ?564???-?                                                          -    -  - ?01 14 LuIm F3 V           
+1039 Khulim               ?554???-?                                                          -    -  - ?24 10 LuIm M1 V M8 V      
+1040 Lushanuma            ?425???-?                                                          -    -  - ?13 11 LuIm M3 V           
+1134 Adakhem              ?434???-?                                                          -    -  - ?03 12 LuIm M1 V           
+1138 Gukhemuuka           ?564???-?                                                          -    -  - ?04 13 LuIm K4 V           
+1234 Umri                 ?9C4???-? Fl                                                       -    -  - ?01 11 LuIm K1 V           
+1235 Rashiki              ?678???-?                                                          -    -  - ?23 11 LuIm M2 V           
+1331 Gateway              ?98A???-? Wa                                                       -    -  - ?01 13 LuIm M1 V M9 V      
+1333 Ashmasa              ?550???-? De Po                                                    -    -  - ?04 7  LuIm M5 V           
+1335 Kiirishi             ?6A4???-? Fl Sa                                                    -    -  - ?04 9  LuIm K7 V           
+1336 Luushama             ?585???-?                                                          -    -  - ?02 16 LuIm M2 V M9 V M9 V 
+1339 Arlu                 ?A8A???-? Oc                                                       -    -  - ?04 10 LuIm M3 V           
+1431 Argi                 ?430???-? De Po Sa                                                 -    -  - ?04 9  LuIm G0 V M1 V      
+1432 Lumnu                ?568???-?                                                          -    -  - ?11 11 LuIm K7 V           
+1433 Gigi                 ?693???-?                                                          -    -  - ?00 12 LuIm M1 V           
+1437 Shabamiir            ?7C2???-? Fl He                                                    -    -  - ?00 8  LuIm K5 V M2 V      
+1532 Ur                   ?400???-? Va                                                       -    -  - ?04 10 LuIm M0 V M1 V      
+1534 Miir                 ?65A???-? Wa                                                       -    -  - ?24 9  LuIm M3 V M5 V      
+1535 Aiish                ?201???-? Ic Va Sa                                                 -    -  - ?04 7  LuIm K3 V           
+1537 Zalaana              ?410???-? Sa                                                       -    -  - ?02 6  LuIm M3 V M6 V      
+1538 Muukhim              ?97A???-? Wa                                                       -    -  - ?23 8  LuIm K4 V M9 V      
+1539 Sharaa               ?432???-? Po Sa                                                    -    -  - ?03 7  LuIm K0 IV M4 V     
+1631 Gaesh                ?594???-?                                                          -    -  - ?04 12 LuIm M1 V           
+1633 Anomaly              ?9E7???-? An                                                       -    -  - ?12 12 LuIm M2 V           
+1635 Sh'si                ?554???-?                                                          -    -  - ?13 9  LuIm M3 V M6 V      
+1636 Shulasgu             ?430???-? De Po Sa                                                 -    -  - ?10 10 LuIm M0 V M1 V M7 V 
+1638 Zish                 ?310???-?                                                          -    -  - ?13 10 LuIm G3 V           
+1640 Lenashuuk            ?7A8???-? Fl                                                       -    -  - ?00 12 LuIm K7 III         
+1732 Kashni               ?422???-? He Po                                                    -    -  - ?12 10 LuIm M1 V           
+1733 Bakhuma              ?536???-?                                                          -    -  - ?03 11 LuIm M1 V M4 V M9 V 
+1735 Durgaarur            ?434???-?                                                          -    -  - ?04 12 LuIm G1 V M2 V      
+1736 Amshu                ?674???-?                                                          -    -  - ?00 9  LuIm K1 V           
+1737 Irrii                ?000???-? As Va                                                    -    -  - ?02 7  LuIm K1 V           
+1738 Lamamni              ?437???-?                                                          -    -  - ?02 8  LuIm M0 V           
+1833 Piileir              ?784???-?                                                          -    -  - ?14 10 LuIm F4 V M8 V      
+1836 Riimsha              ?502???-? Ic Va                                                    -    -  - ?24 9  LuIm K4 V M8 V      
+1839 Uki                  ?558???-?                                                          -    -  - ?14 8  LuIm G4 V M2 V      
+1840 Mashuu               ?725???-?                                                          -    -  - ?01 16 LuIm M0 V           
+1931 Dante                ?403???-? Ic Va                                                    -    -  - ?13 11 LuIm M7 II M8 V     
+1934 Bountiful            ?547???-?                                                          -    -  - ?04 12 LuIm K1 V M0 V      
+1935 Haakhai              ?8D5???-?                                                          -    -  - ?24 12 LuIm M2 V           
+1936 Linara               ?8B6???-? Fl                                                       -    -  - ?03 11 LuIm M3 V           
+1939 Shuulikh             ?88A???-? Wa                                                       -    -  - ?02 12 LuIm M2 V           
+1940 Troy                 ?A9A???-? Oc                                                       -    -  - ?02 8  LuIm K5 V M2 V      
+2035 Riiya                ?558???-?                                                          -    -  - ?05 11 LuIm M2 V M6 V      
+2036 Sabhaash             ?799???-?                                                          -    -  - ?03 12 LuIm K1 V           
+2037 Hadraach             ?AE5???-?                                                          -    -  - ?23 9  LuIm M2 V           
+2038 Ya'uiya-ko           ?520???-? De He Po                                                 -    -  - ?04 7  LuIm K1 V           
+2135 Harlequin            ?433???-? Po                                                       -    -  - ?23 13 LuIm K4 V M4 V      
+2137 Sapphyre             ?977???-?                                                          -    -  - ?04 15 LuIm M3 V K0 V      
+2139 Shaida               ?521???-? He Po                                                    -    -  - ?15 10 LuIm M2 V M8 V      
+2140 Miana                ?649???-?                                                          -    -  - ?13 8  LuIm M2 V           
+2232 Guurdim              ?681???-?                                                          -    -  - ?24 10 LuIm G1 V M1 V      
+2234 Emishuun             ?538???-?                                                          -    -  - ?24 14 LuIm K5 V M2 V      
+2235 Mukira               ?540???-? De He Po                                                 -    -  - ?24 11 LuIm M3 V M8 V      
+2237 Luukha               ?657???-? Ga                                                       -    -  - ?04 13 LuIm G7 V           
+2239 Aalimru              ?430???-? De Po                                                    -    -  - ?03 13 LuIm F8 V M6 V      
+2331 Hashiikhi            ?575???-?                                                          -    -  - ?00 8  LuIm G0 V           
+2339 E'khua               ?655???-? Ga                                                       -    -  - ?04 15 LuIm M2 V           
+2433 Eikhoifiruah         ?567???-?                                                          -    -  - ?13 15 LuIm M2 V           
+2434 Shaakhish            ?100???-? Va                                                       -    -  - ?01 4  LuIm M1 V           
+2436 Amamni               ?430???-? De Po                                                    -    -  - ?11 8  LuIm M5 V           
+2437 Ghesaak              ?100???-? Va                                                       -    -  - ?03 12 LuIm G4 V           
+2439 Gesalt               ?663???-?                                                          -    -  - ?23 9  LuIm G4 V           
+2440 Silk                 ?554???-?                                                          -    -  - ?03 11 LuIm K9 V           
+2531 Keshurlim            ?527???-?                                                          -    -  - ?04 10 LuIm M2 V           
+2533 Mianda               ?552???-? Po                                                       -    -  - ?24 9  LuIm M2 V M8 V      
+2536 Zaamish              ?8A7???-? Fl                                                       -    -  - ?13 12 LuIm K4 V           
+2631 Daskine              ?742???-? He Po                                                    -    -  - ?00 10 LuIm G7 IV          
+2634 Laraa                ?527???-?                                                          -    -  - ?02 9  LuIm K8 V           
+2635 Gishu Amkhir         ?552???-? Po Sa                                                    -    -  - ?14 8  LuIm M3 V M9 V      
+2637 Urdanis              ?611???-? Ic                                                       -    -  - ?22 9  LuIm M3 V M8 V      
+2734 Khanirlu             ?547???-?                                                          -    -  - ?02 9  LuIm M3 V M6 V      
+2735 Dempukish            ?99A???-? Wa                                                       -    -  - ?03 11 LuIm M2 V           
+2736 Sima                 ?9D6???-?                                                          -    -  - ?04 7  LuIm M0 V M9 V      
+2737 Basikiil'r           ?894???-?                                                          -    -  - ?00 10 LuIm G2 V K1 V      
+2738 Gulishi              ?203???-? Ic Va                                                    -    -  - ?12 10 LuIm K3 V M4 V      
+2739 Ashush               ?645???-?                                                          -    -  - ?03 16 LuIm K3 V M2 V      
+2831 Ushiik               ?768???-?                                                          -    -  - ?03 12 LuIm M0 V           
+2836 Mikhid               ?777???-? Sa (Mikhidians)?                                         -    -  - ?03 11 LuIm M2 V           
+2837 Khuuniish            ?582???-?                                                          -    -  - ?05 12 LuIm K9 V M8 V      
+2838 Mimishka             ?543???-? Po                                                       -    -  - ?23 10 LuIm G9 V           
+2932 Perekir              ?310???-?                                                          -    -  - ?03 17 LuIm M3 V           
+2935 Lumzashgu            ?788???-?                                                          -    -  - ?03 6  LuIm K2 V           
+2936 Ursimga              ?687???-? Ga                                                       -    -  - ?03 9  LuIm M2 V           
+2937 Kakar                ?100???-? Va                                                       -    -  - ?30 11 LuIm M0 V M5 V      
+2938 Pediica              ?758???-?                                                          -    -  - ?03 6  LuIm K9 V M5 V      
+3031 Narkur'le            ?85A???-? Wa                                                       -    -  - ?01 12 LuIm G1 V           
+3032 Uumirsa              ?000???-? As Va                                                    -    -  - ?04 13 LuIm K2 V           
+3035 Napu                 ?8B5???-? Fl                                                       -    -  - ?03 9  LuIm G1 III         
+3037 Luken                ?543???-? Po                                                       -    -  - ?03 14 LuIm K2 V           
+3039 Bechant              ?571???-? He (M'nengi)?                                            -    -  - ?11 11 LuIm K1 V           
+3135 Amluamii             ?425???-?                                                          -    -  - ?04 16 LuIm G0 V           
+3136 Kadushi              ?889???-?                                                          -    -  - ?04 9  LuIm M3 V           
+3138 Andula               ?542???-? He Po                                                    -    -  - ?21 9  LuIm G4 V           
+3139 Newport              ?433???-? Po                                                       -    -  - ?03 12 LuIm G8 V           
+3231 Mershemu             ?580???-? De                                                       -    -  - ?03 12 LuIm G2 V           
+3235 Edraconis            ?594???-?                                                          -    -  - ?03 12 LuIm M1 V M5 V      
+3236 Shardi               ?426???-?                                                          -    -  - ?04 10 LuIm M0 V           
+3238 Proytheyath          ?558???-?                                                          -    -  - ?13 16 LuIm K1 V M5 V      
+3239 Tutrii               ?A7A???-? Oc                                                       -    -  - ?02 7  LuIm G9 V M4 V      
+3240 Saven                ?5A0???-? He                                                       -    -  - ?13 11 LuIm G2 IV          

--- a/res/Sectors/M1120/1120_Dagu.xml
+++ b/res/Sectors/M1120/1120_Dagu.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0"?>
+<Sector xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Name>Dagudashaag</Name>
+  <Name>Dagudashag</Name>
+  <Credits>
+
+             &lt;b&gt;Dagudashaag&lt;/b&gt; sector was designed by Marc W. Miller
+             and appears in &lt;cite&gt;Atlas of the Imperium&lt;/cite&gt; (GDW,
+             1984).
+
+             It was refined by Duncan Law-Green, Leighton Piper and
+             Jae Campbell. Portions appear in &lt;cite&gt;Signal GK
+             Magazine&lt;/cite&gt;.
+
+             Rebellion Era borders were designed by James Holden, Joe D. Fugate Jr. and Terry McInnes
+             and appeared in The MegaTraveller Alien, Volume 1: Vilani & Vargr (
+             Digest Group Publications, 1990).
+
+    </Credits>
+  <Product Title="MegaTraveller Alien Vol. 1: Vilani %29 Vargr" Publisher="Digest Group Publications" Ref="http://wiki.travellerrpg.com/Alien_-_Vilani_%26_Vargr"/>
+  <Subsectors>
+    <Subsector Index="A">Mimu</Subsector>
+    <Subsector Index="B">Old Suns</Subsector>
+    <Subsector Index="C">Arnakhish</Subsector>
+    <Subsector Index="D">Iiradu</Subsector>
+    <Subsector Index="E">Shallows</Subsector>
+    <Subsector Index="F">Ushra</Subsector>
+    <Subsector Index="G">Khandi</Subsector>
+    <Subsector Index="H">Kuriishe</Subsector>
+    <Subsector Index="I">Zeda</Subsector>
+    <Subsector Index="J">Remnants</Subsector>
+    <Subsector Index="K">Pact</Subsector>
+    <Subsector Index="L">Gadde</Subsector>
+    <Subsector Index="M">Bolivar</Subsector>
+    <Subsector Index="N">Argi</Subsector>
+    <Subsector Index="O">Sapphyre</Subsector>
+    <Subsector Index="P">Laraa</Subsector>
+  </Subsectors>
+  <Allegiances>
+    <Allegiance Code="FdIl">Federation of Ilelish</Allegiance>
+    <Allegiance Code="ImAp">Third Imperium, Amec Protectorate</Allegiance>
+    <Allegiance Code="ImLc">Third Imperium, Lancian Cultural Region</Allegiance>
+    <Allegiance Code="LuIm">Lucan's Imperium</Allegiance>
+    <Allegiance Code="StIm">Strephon's Imperium</Allegiance>
+  </Allegiances>
+  <Borders>
+    <Border Allegiance="FdIl" Color="Purple" LabelPosition="0437">0035 0136 0235 0336 0435 0535 0635 0736 0737 0738 0739 0839 0840 0841 0741 0641 0541 0441 0341 0241 0141 0041 0040 0039 0038 0037 0036 0035 </Border>
+    <Border Allegiance="LuIm" Color="DarkRed">0018 0118 0218 0318 0317 0316 0315 0314 0313 0312 0411 0410 0409 0510 0609 0710 0809 0808 0807 0806 0907 1006 1106 1205 1305 1304 1303 1403 1504 1603 1704 1804 1904 2003 2104 2203 2303 2403 2503 2602 2702 2701 2800 2900 3000 3100 3200 3300 3301 3302 3303 3304 3305 3306 3307 3308 3309 3310 3311 3312 3313 3314 3315 3316 3317 3318 3319 3320 3321 3322 3323 3324 3325 3326 3327 3328 3329 3330 3331 3332 3333 3334 3335 3336 3337 3338 3339 3340 3341 3241 3141 3041 2941 2841 2741 2641 2541 2441 2341 2241 2141 2041 1941 1841 1741 1641 1541 1441 1341 1241 1141 1041 0941 0940 0939 0838 0837 0836 0835 0735 0634 0534 0434 0335 0234 0135 0034 0033 0032 0031 0030 0029 0028 0027 0026 0025 0024 0023 0022 0021 0020 0019 0018</Border>
+    <Border Allegiance="StIm" Color="Crimson" LabelPosition="2301">0000 0100 0200 0300 0400 0500 0600 0700 0800 0900 1000 1100 1200 1300 1400 1500 1600 1700 1800 1900 2000 2100 2200 2300 2400 2500 2600 2700 2600 2601 2502 2402 2302 2202 2103 2002 1903 1803 1703 1602 1503 1402 1302 1202 1203 1204 1105 1005 0906 0805 0706 0707 0708 0709  0608 0509 0408 0309 0310 0311 0211 0212 0213 0214 0215 0216 0217 0117 0017 0016 0015 0014 0013 0012 0011 0010 0009 0008 0007 0006 0005 0004 0003 0002 0001 0000 </Border>
+    <Border WrapLabel="true" Allegiance="ImAp" LabelPosition="0730" Label="Amec Protectorate">0126 0225 0224 0223 0222 0223 0224 0225 0226 0227 0328 0428 0528 0628 0729 0828 0928 0929 0930 0830 0831 0832 0732 0632 0633 0632 0532 0431 0331 0230 0229 0129 0128 0127 0126</Border>
+    <Border WrapLabel="true" Allegiance="ImLc" LabelPosition="0410" Label="Lancian Cultural Region">0000 0001 0002 0003 0104 0204 0305 0404 0504 0603 0703 0802 0902 0903 0904 0905 0906 0806 0707 0708 0709 0609 0510 0410 0311 0211 0112 0012 0013 0014 0015 0016 0017 0018 0019 0018 0017 0016 0015 0014 0013 0012 0011 0010 0009 0008 0007 0006 0005 0004 0003 0002 0001 0000</Border>
+  </Borders>
+  <Routes>
+    <Route Start="0111" End="0208" />
+    <Route Start="0111" End="3211" EndOffsetX="-1" />
+    <Route Start="0201" End="3203" EndOffsetX="-1" />
+    <Route Start="0208" End="0311" />
+    <Route Start="0208" End="3208" EndOffsetX="-1" />
+    <Route Start="0240" End="0201" EndOffsetY="1" />
+    <Route Start="0311" End="0111" />
+    <Route Start="0320" End="0322" />
+    <Route Start="0320" End="0519" />
+    <Route Start="0322" End="0123" />
+    <Route Start="0322" End="0325" />
+    <Route Start="0322" End="0721" />
+    <Route Start="0325" End="0329" />
+    <Route Start="0329" End="0230" />
+    <Route Start="0402" End="0201" />
+    <Route Start="0506" End="0208" />
+    <Route Start="0506" End="0402" />
+    <Route Start="0613" End="0714" />
+    <Route Start="0613" End="0810" />
+    <Route Start="0639" End="0240" />
+    <Route Start="0639" End="0736" />
+    <Route Start="0705" End="0506" />
+    <Route Start="0714" End="0916" />
+    <Route Start="0721" End="0320" />
+    <Route Start="0721" End="0921" />
+    <Route Start="0833" End="0935" />
+    <Route Start="0840" End="0639" />
+    <Route Start="0840" End="1001" EndOffsetY="1" />
+    <Route Start="0916" End="1016" />
+    <Route Start="0920" End="1016" />
+    <Route Start="0921" End="0920" />
+    <Route Start="0921" End="0924" />
+    <Route Start="0921" End="1121" />
+    <Route Start="0924" End="1126" />
+    <Route Start="0935" End="1235" />
+    <Route Start="1004" End="0705" />
+    <Route Start="1016" End="1317" />
+    <Route Start="1029" End="1126" />
+    <Route Start="1114" End="1016" />
+    <Route Start="1121" End="1321" />
+    <Route Start="1202" End="1204" />
+    <Route Start="1202" End="1339" EndOffsetY="-1" />
+    <Route Start="1204" End="1004" />
+    <Route Start="1235" End="1339" />
+    <Route Start="1235" End="1635" />
+    <Route Start="1311" End="1114" />
+    <Route Start="1317" End="1416" />
+    <Route Start="1321" End="1420" />
+    <Route Start="1339" End="1001" EndOffsetY="1" />
+    <Route Start="1339" End="1640" />
+    <Route Start="1409" End="1311" />
+    <Route Start="1416" End="1613" />
+    <Route Start="1416" End="1816" />
+    <Route Start="1420" End="1317" />
+    <Route Start="1420" End="1722" />
+    <Route Start="1431" End="1029" />
+    <Route Start="1431" End="1433" />
+    <Route Start="1433" End="1235" />
+    <Route Start="1506" End="1409" />
+    <Route Start="1506" End="1705" />
+    <Route Start="1529" End="1431" />
+    <Route Start="1631" End="1431" />
+    <Route Start="1635" End="1833" />
+    <Route Start="1640" End="1902" EndOffsetY="1" />
+    <Route Start="1705" End="1905" />
+    <Route Start="1722" End="1823" />
+    <Route Start="1726" End="1529" />
+    <Route Start="1726" End="1929" />
+    <Route Start="1816" End="2015" />
+    <Route Start="1823" End="2124" />
+    <Route Start="1833" End="1631" />
+    <Route Start="1833" End="1931" />
+    <Route Start="1905" End="2205" />
+    <Route Start="1926" End="1726" />
+    <Route Start="1929" End="1931" />
+    <Route Start="1929" End="2028" />
+    <Route Start="2013" End="2111" />
+    <Route Start="2015" End="2317" />
+    <Route Start="2015" End="2413" />
+    <Route Start="2020" End="1722" />
+    <Route Start="2020" End="2119" />
+    <Route Start="2028" End="2130" />
+    <Route Start="2028" End="2225" />
+    <Route Start="2036" End="1833" />
+    <Route Start="2036" End="2038" />
+    <Route Start="2036" End="2137" />
+    <Route Start="2111" End="2208" />
+    <Route Start="2124" End="1926" />
+    <Route Start="2124" End="2223" />
+    <Route Start="2124" End="2225" />
+    <Route Start="2124" End="2322" />
+    <Route Start="2130" End="2531" />
+    <Route Start="2204" End="2205" />
+    <Route Start="2204" End="2602" />
+    <Route Start="2205" End="2208" />
+    <Route Start="2225" End="2525" />
+    <Route Start="2234" End="2036" />
+    <Route Start="2322" End="2020" />
+    <Route Start="2413" End="2615" />
+    <Route Start="2512" End="2413" />
+    <Route Start="2525" End="2725" />
+    <Route Start="2533" End="2234" />
+    <Route Start="2533" End="2734" />
+    <Route Start="2602" End="2706" />
+    <Route Start="2615" End="3014" />
+    <Route Start="2706" End="2807" />
+    <Route Start="2709" End="2512" />
+    <Route Start="2709" End="3008" />
+    <Route Start="2721" End="2322" />
+    <Route Start="2725" End="2727" />
+    <Route Start="2725" End="3126" />
+    <Route Start="2734" End="2937" />
+    <Route Start="2734" End="3032" />
+    <Route Start="2807" End="2709" />
+    <Route Start="2807" End="3005" />
+    <Route Start="2920" End="2721" />
+    <Route Start="2920" End="3018" />
+    <Route Start="2937" End="3136" />
+    <Route Start="2937" End="3139" />
+    <Route Start="3005" End="3004" />
+    <Route Start="3005" End="3206" />
+    <Route Start="3008" End="3110" />
+    <Route Start="3014" End="3111" />
+    <Route Start="3014" End="3114" />
+    <Route Start="3014" End="3115" />
+    <Route Start="3018" End="3120" />
+    <Route Start="3111" End="0112" EndOffsetX="1" />
+    <Route Start="3111" End="3008" />
+    <Route Start="3114" End="0112" EndOffsetX="1" />
+    <Route Start="3115" End="3018" />
+    <Route Start="3120" End="0221" EndOffsetX="1" />
+    <Route Start="3120" End="2920" />
+    <Route Start="3136" End="3236" />
+    <Route Start="3139" End="3240" />
+    <Route Start="3222" End="3223" />
+    <Route Start="3236" End="2937" />
+    <Route Start="3240" End="0139" EndOffsetX="1" />
+    <Route Start="3240" End="3202" EndOffsetY="1" />
+  </Routes>
+</Sector>

--- a/res/Sectors/M1120/1120_Gush.sec
+++ b/res/Sectors/M1120/1120_Gush.sec
@@ -1,0 +1,537 @@
+Hex  Name                 UWP       Remarks          {Ix}   (Ex)    [Cx]   N B Z PBG W  A    Stellar       
+---- -------------------- --------- ---------------- ------ ------- ------ - - - --- -- ---- --------------
+0610 Habelut              ?86A???-? Wa                                     - - - ?02 7  NaHu K3 V          
+0803 Menguno              ?7B2???-? Fl He                                  - - - ?00 7  CsIm K1 V M3 V     
+0810 Gelhhach             ?558???-? (Hhrachddrumm)?                        - - - ?01 13 NaHu M3 V M3 V     
+1209 Fementok             ?426???-?                                        - - - ?23 11 StIm G7 V          
+1308 Loskuuatav           ?544???-?                                        - - - ?04 13 StIm G3 V M0 V     
+1407 Assunne              ?AE7???-?                                        - - - ?21 7  StIm K0 V M8 V     
+1507 Puumariash           ?300???-? Va                                     - - - ?04 11 StIm M2 V K5 V     
+1510 Opiwiath             ?543???-? Po                                     - - - ?00 12 StIm K2 V          
+1605 Maa                  ?100???-? Va                                     - - - ?04 7  StIm M0 V M6 V     
+1702 Eesonwiy             ?547???-?                                        - - - ?22 7  StIm F6 V M0 V     
+1801 Roy                  ?430???-? De Po                                  - - - ?03 12 StIm M0 V          
+1810 Moseesi              ?310???-?                                        - - - ?00 9  StIm M1 V          
+1905 Trama                ?7B2???-? Fl He                                  - - - ?03 6  StIm G0 II         
+2007 Ranant               ?551???-? Po                                     - - - ?02 7  ImLc G1 V          
+2008 Sypny                ?552???-? Po                                     - - - ?04 13 ImLc M3 V M7 V     
+2105 Mishiin              ?432???-? Po                                     - - - ?03 7  ImLc G4 V M2 V     
+2106 Ivto                 ?425???-?                                        - - - ?04 11 ImLc M1 V M7 V     
+2107 K'ketopan            ?432???-? Po                                     - - - ?24 9  ImLc M2 V          
+2108 Hilcaa               ?540???-? De He Po                               - - - ?22 12 ImLc M2 V M3 V     
+2110 Brice                ?899???-?                                        - - - ?00 14 ImLc M2 V          
+2202 Mestitela            ?555???-?                                        - - - ?03 11 ImLc K2 V M5 V     
+2205 Uurkhi               ?421???-? He Po                                  - - - ?12 8  ImLc K3 V          
+2206 Painntu              ?547???-?                                        - - - ?01 6  ImLc M3 V          
+2207 Irkhi                ?678???-?                                        - - - ?22 13 ImLc K2 V          
+2210 Sehnaihal            ?658???-?                                        - - - ?13 18 ImLc M2 V          
+2301 Ecolette             ?432???-? Po                                     - - - ?23 18 ImLc G3 V          
+2303 Kiind                ?868???-?                                        - - - ?12 18 ImLc G0 V M6 V     
+2305 Sharenga             ?684???-?                                        - - - ?02 6  ImLc K3 V M4 V     
+2306 Mulanje              ?797???-? (Edlun)?                               - - - ?24 13 ImLc K1 V          
+2307 Penelasse            ?421???-? He Po                                  - - - ?00 10 ImLc M1 V M4 V     
+2308 Choma                ?540???-? De He Po                               - - - ?01 8  ImLc G3 V          
+2309 Oroth                ?672???-? He                                     - - - ?01 14 ImLc M2 V          
+2310 Viskka               ?794???-?                                        - - - ?00 13 ImLc M1 V M1 V     
+2404 Hannbrous            ?759???-?                                        - - - ?20 6  ImLc K3 V M5 V     
+2406 Ellus                ?73A???-? Wa                                     - - - ?03 10 ImLc M2 V          
+2408 Cirsel               ?538???-?                                        - - - ?23 13 ImLc M3 V          
+2410 Admalaknii           ?88A???-? Wa                                     - - - ?04 13 ImLc K0 V M9 V     
+2501 Kell                 ?76A???-? Wa                                     - - - ?02 11 ImLc M3 V M0 V     
+2502 Sayayr               ?735???-?                                        - - - ?10 8  ImLc K1 V M0 V     
+2503 Bradt Landing        ?8B9???-? Fl                                     - - - ?23 12 ImLc M2 V          
+2504 Routeburn            ?570???-? De He                                  - - - ?01 8  ImLc M3 V M7 V     
+2507 Shiramuunir          ?544???-?                                        - - - ?31 13 ImLc K1 V M7 V     
+2509 Jonosva              ?9C7???-? Fl                                     - - - ?03 9  ImLc G0 III D      
+2609 Ellje                ?796???-?                                        - - - ?15 13 ImLc K2 V          
+2610 Tosiv                ?525???-?                                        - - - ?10 11 ImLc K4 V M6 V     
+2701 Fubanan              ?A9A???-? Oc                                     - - - ?00 9  ImLc K4 V          
+2704 Kyla                 ?A7A???-? Oc                                     - - - ?00 14 ImLc K1 V M9 V     
+2705 Xenicus              ?AE5???-?                                        - - - ?04 7  ImLc M8 III        
+2706 Sinish Giken         ?431???-? Po                                     - - - ?20 13 ImLc G0 V G3 V     
+2707 Hunnan               ?560???-? De                                     - - - ?03 9  ImLc M2 V M6 V     
+2709 Minev                ?540???-? De He Po                               - - - ?04 14 ImLc M0 V M5 V     
+2801 Aakmi                ?765???-? Ga                                     - - - ?00 4  ImLc K2 V          
+2802 Trindewranda         ?422???-? He Po                                  - - - ?03 9  ImLc K1 V          
+2804 Giikika              ?544???-?                                        - - - ?10 9  ImLc K1 V          
+2806 Sahee                ?96A???-? Wa                                     - - - ?02 7  ImLc M2 V          
+2807 Ka Maz               ?580???-? De                                     - - - ?04 7  ImLc M0 V          
+2809 Luuen                ?421???-? He Po                                  - - - ?04 11 ImLc M3 V          
+2810 Mekar                ?584???-?                                        - - - ?00 8  ImLc M0 V          
+2904 Pucuro               ?642???-? He Po                                  - - - ?01 7  ImLc K9 V M9 V     
+2905 Beheld               ?557???-?                                        - - - ?14 10 ImLc K4 V          
+2906 Tasazhas             ?898???-?                                        - - - ?11 9  ImLc M3 V          
+2907 Lishan               ?310???-?                                        - - - ?13 7  ImLc M2 V          
+2910 Muidmu               ?AE7???-?                                        - - - ?00 7  ImLc K6 V          
+3002 Fuqui                ?533???-? Po                                     - - - ?00 8  ImLc K3 V          
+3003 Nyamuleju            ?540???-? De He Po                               - - - ?04 10 ImLc M2 V          
+3004 Raoh                 ?555???-?                                        - - - ?00 13 ImLc M2 V M2 V     
+3006 Upaniv               ?567???-?                                        - - - ?03 13 ImLc M1 V M9 V     
+3007 Ivahllo              ?756???-? Ga                                     - - - ?00 11 ImLc K7 V M1 V     
+3008 Suhho                ?300???-? Va                                     - - - ?03 16 ImLc K4 V          
+3009 Miz*rskua'mr         ?553???-? Po                                     - - - ?02 13 ImLc M0 V          
+3101 Inkia                ?794???-?                                        - - - ?10 11 ImLc M3 V M8 V     
+3103 Yta Akat             ?8B3???-? Fl (Lumu)?                             - - - ?03 11 ImLc G0 V M9 V     
+3104 Tullyree             ?435???-?                                        - - - ?04 10 ImLc K3 V M8 V     
+3105 Kukhun               ?658???-? (Lancians)?                            - - - ?03 12 ImLc K0 V          
+3106 Aphu                 ?795???-?                                        - - - ?25 11 ImLc M3 V          
+3107 Llaet                ?587???-?                                        - - - ?11 8  ImLc K4 V M4 V     
+3110 Urssursfa'           ?565???-?                                        - - - ?03 13 ImLc M2 V          
+3202 Kumkhap              ?78A???-? Wa                                     - - - ?02 12 ImLc G8 V M6 V     
+3203 Miha                 ?779???-?                                        - - - ?12 6  ImLc M1 V          
+3205 Bearnagh             ?643???-? Po                                     - - - ?23 10 ImLc G5 IV M9 V    
+3206 Hillalk              ?100???-? Va                                     - - - ?05 11 ImLc A1 V          
+3208 Chzaar               ?638???-?                                        - - - ?24 9  ImLc G1 V M7 V     
+3210 Sadetha              ?504???-? Ic Va                                  - - - ?24 11 ImLc K0 V M3 V     
+0517 Imaniik              ?968???-? An                                     - - - ?24 9  StIm M0 V          
+0614 Deychavilosta        ?200???-? Va                                     - - - ?24 9  StIm M2 V          
+0617 Bubenel              ?779???-?                                        - - - ?12 6  StIm M3 V M7 V     
+0718 Pannolk              ?79A???-? Wa                                     - - - ?00 14 StIm M0 V          
+0813 Kkoymjirad           ?555???-?                                        - - - ?00 7  StIm K4 V          
+0820 Asshashur            ?576???-?                                        - - - ?20 8  StIm M3 V          
+0912 Gakhamesh            ?683???-?                                        - - - ?00 6  StIm K7 V          
+0914 Chulesh              ?575???-?                                        - - - ?13 12 StIm K4 V M9 V     
+0920 Drayrk               ?550???-? De Po                                  - - - ?03 9  StIm M2 V M0 V     
+1013 Munnarn              ?410???-?                                        - - - ?02 11 StIm M3 V M5 V     
+1015 Usdiki               ?664???-? Cx                                     - - - ?03 10 StIm M0 V M0 V M9 V
+1018 Toraago              ?544???-?                                        - - - ?00 10 StIm M0 V M3 V     
+1019 Lishuggi             ?565???-?                                        - - - ?14 13 StIm M0 V M2 V     
+1020 Shir                 ?100???-? Va                                     - - - ?04 7  StIm M2 V          
+1118 Heffone              ?433???-? Po                                     - - - ?00 9  StIm K5 V          
+1119 Aintrin              ?637???-?                                        - - - ?14 9  StIm M3 V M6 V     
+1120 Vlu'da'rin           ?504???-? Ic Va                                  - - - ?04 10 StIm M1 V M2 V M8 V
+1213 Ushamdidishar        ?8C3???-? Fl                                     - - - ?25 11 StIm M1 III        
+1319 Chansingol           ?570???-? De He                                  - - - ?12 10 StIm K3 V          
+1412 Platon               ?83A???-? Wa                                     - - - ?20 7  StIm M3 V          
+1414 Lanaas               ?999???-?                                        - - - ?04 10 StIm K0 V          
+1417 Guzrin               ?836???-?                                        - - - ?25 12 StIm K8 V          
+1512 Gagushilaag          ?571???-? He                                     - - - ?02 14 StIm G1 V          
+1518 Divkar               ?582???-?                                        - - - ?14 10 StIm M3 V          
+1519 Higli                ?561???-?                                        - - - ?00 14 StIm M3 V M7 V     
+1520 Mentule              ?651???-? Po                                     - - - ?03 8  StIm K4 V M1 V     
+1612 Booce                ?899???-?                                        - - - ?00 12 StIm M2 V          
+1613 Lendaarii            ?798???-?                                        - - - ?02 11 StIm M4 V          
+1615 Abir                 ?545???-?                                        - - - ?03 8  StIm M0 V          
+1616 Imaparlu             ?556???-?                                        - - - ?04 10 StIm G1 V          
+1618 Gabradio             ?611???-? Ic                                     - - - ?35 12 StIm M0 V M7 V     
+1619 Engallent            ?550???-? De Po                                  - - - ?21 12 StIm K9 V          
+1620 Kerek                ?000???-? As Va                                  - - - ?03 10 StIm G5 III D      
+1712 Gaanriigashii        ?757???-? Ga                                     - - - ?04 7  StIm K8 V          
+1715 Vehko                ?665???-? Ga                                     - - - ?15 12 StIm M2 V M1 V     
+1717 Arsuch               ?566???-?                                        - - - ?04 8  StIm G0 V M8 V     
+1718 Iktaakas             ?74A???-? Wa                                     - - - ?10 12 StIm M3 V M3 V     
+1811 Crufra               ?583???-?                                        - - - ?04 12 StIm M2 V          
+1814 Apay Maru            ?557???-?                                        - - - ?04 10 StIm M2 V          
+1815 Temom                ?423???-? Po                                     - - - ?20 12 StIm M1 V M5 V     
+1816 Lumuiimshi           ?311???-? Ic                                     - - - ?10 14 StIm M1 V          
+1818 Windcrest            ?568???-?                                        - - - ?12 6  StIm M2 V          
+1911 Shirkii              ?556???-?                                        - - - ?14 13 StIm M0 V          
+1914 Edjbaston            ?76A???-? Wa                                     - - - ?02 9  StIm M2 V          
+1915 Dukshii Em           ?88A???-? Wa                                     - - - ?01 8  StIm K2 V          
+1916 Oyuch                ?550???-? De Po                                  - - - ?00 11 StIm M2 V          
+2015 Sadguumishmak        ?585???-?                                        - - - ?10 11 StIm K2 V          
+2018 Rellblud             ?540???-? De He Po                               - - - ?02 12 StIm M1 V M3 V M4 V
+2019 Buggar               ?9A6???-? Fl                                     - - - ?00 12 StIm G3 V M5 V M8 V
+2020 Oukictach            ?564???-?                                        - - - ?00 12 StIm K4 V          
+2113 Eennusinak           ?551???-? Po                                     - - - ?03 13 StIm K0 V M5 V     
+2115 Pihkiit              ?420???-? De He Po                               - - - ?02 13 StIm M0 V          
+2119 Nogo                 ?A9A???-? Oc                                     - - - ?01 9  StIm M2 V M7 V     
+2120 Esh Purshuur         ?570???-? De He                                  - - - ?30 8  StIm M1 V M0 V     
+2213 Vilir's World        ?9B4???-? Fl                                     - - - ?34 10 StIm K1 V M3 V     
+2215 Murshen              ?585???-?                                        - - - ?10 11 StIm G1 V          
+2216 Seaport              ?595???-? (Giiguuglum)?                          - - - ?14 8  StIm M2 V          
+2217 Ashsha               ?422???-? He Po                                  - - - ?03 12 StIm M1 V          
+2313 Ed                   ?57A???-? Wa                                     - - - ?13 10 StIm M0 V          
+2316 Tu Tandi             ?647???-?                                        - - - ?00 14 StIm G3 V M3 V     
+2318 Mimip                ?876???-?                                        - - - ?00 10 StIm M1 V          
+2320 Bleayn               ?674???-?                                        - - - ?00 13 StIm K3 V          
+2411 Cerell               ?78A???-? Wa                                     - - - ?02 5  ImLc M0 V          
+2414 Wolstene             ?000???-? As Va                                  - - - ?03 10 ImLc M2 V M6 V     
+2415 Kikhi Zun            ?77A???-? Wa                                     - - - ?00 11 ImLc M2 V M1 V     
+2418 Liebing              ?621???-? He Po                                  - - - ?00 12 StIm M1 V M4 V     
+2511 Gurdadusu            ?736???-?                                        - - - ?03 10 ImLc M0 V M6 V     
+2512 Andelech             ?436???-?                                        - - - ?04 9  ImLc K9 V          
+2513 Masa                 ?421???-? He Po                                  - - - ?00 9  ImLc M3 V          
+2514 Rutkowski            ?637???-?                                        - - - ?03 10 ImLc M1 V M2 V     
+2517 Royef                ?542???-? He Po                                  - - - ?05 12 ImLc K5 V          
+2612 Maru                 ?8C5???-? Fl                                     - - - ?24 12 ImLc M3 V          
+2613 Nourm                ?647???-?                                        - - - ?02 8  ImLc K8 V M0 V     
+2614 Upllor               ?558???-?                                        - - - ?20 9  ImLc K1 V          
+2615 Erdousse             ?785???-? Ga                                     - - - ?24 14 ImLc M2 V          
+2617 Une                  ?438???-?                                        - - - ?04 14 ImLc G9 V          
+2618 Courtesy             ?647???-?                                        - - - ?04 8  ImLc M1 V M1 V     
+2619 Guumishmak           ?434???-?                                        - - - ?14 11 ImLc M0 V M6 V     
+2620 Akushis              ?000???-? As Va                                  - - - ?04 18 ImLc M1 V          
+2713 Kinshasa             ?868???-?                                        - - - ?12 11 ImLc K2 V M8 V     
+2715 Bruyrkna             ?8B3???-? Fl                                     - - - ?04 8  ImLc K3 V          
+2716 Shakhamash           ?94A???-? Wa (Hanen)?                            - - - ?03 8  ImLc M3 V K0 V     
+2717 Lallvi               ?587???-?                                        - - - ?04 9  ImLc K3 V          
+2812 Koinunmatie          ?566???-?                                        - - - ?04 11 ImLc M2 V          
+2813 Lumu                 ?553???-? Po                                     - - - ?03 15 ImLc K6 V M7 V     
+2814 Tuuttka              ?876???-?                                        - - - ?02 15 ImLc M0 V          
+2815 Liigash              ?688???-? (Graytch)?                             - - - ?02 12 ImLc G3 Ib BD      
+2820 Teklemos             ?895???-?                                        - - - ?03 8  ImLc M2 V          
+2912 Lohme                ?848???-?                                        - - - ?01 11 ImLc M3 V M4 V     
+2914 Twele                ?000???-? As Va                                  - - - ?10 14 ImLc K7 V M5 V     
+2915 Jasper               ?563???-?                                        - - - ?00 13 ImLc G2 V M4 V     
+2916 Tinisutta            ?679???-?                                        - - - ?03 14 ImLc M2 V M1 V     
+2917 Aran                 ?542???-? He Po                                  - - - ?02 12 ImLc K1 IV         
+2919 Oneria               ?544???-?                                        - - - ?00 11 ImLc M2 V          
+2920 Mezregh              ?8B9???-? Fl                                     - - - ?14 12 ImLc M3 V M8 V     
+3012 Fuqui                ?789???-?                                        - - - ?14 17 ImLc M2 V M7 V     
+3013 Amda                 ?632???-? Po                                     - - - ?00 13 ImLc K4 V          
+3014 Vell                 ?667???-? Ga                                     - - - ?04 11 ImLc K8 V M2 V     
+3015 Asylum               ?6B3???-? Fl                                     - - - ?24 11 ImLc G6 V          
+3016 Depot                A5406AB-C De He Ni Po Da   { 2 }  (E56+4) [887E] B D A 124 9  ImLc G4 V          
+3017 Kaagaarkha           ?835???-?                                        - - - ?03 8  ImLc K0 IV         
+3112 Sykell               ?310???-?                                        - - - ?10 17 ImLc M1 V          
+3116 Alp                  ?403???-? Ic Va                                  - - - ?13 14 ImLc K3 V M4 V     
+3117 Eskstant             ?9B7???-? Fl                                     - - - ?03 10 ImLc M3 V M8 V     
+3118 Koustorm             ?537???-?                                        - - - ?10 16 ImLc K4 V          
+3211 Gudak                ?557???-?                                        - - - ?00 10 ImLc M2 V          
+3212 Sktrassui'ia         ?561???-?                                        - - - ?04 9  ImLc K4 V M7 V     
+3214 Leut                 ?310???-?                                        - - - ?00 9  ImLc K1 V M5 V     
+3217 Salliatt             ?886???-? Ga                                     - - - ?13 9  ImLc G5 V M6 V     
+3218 Senlis               ?547???-?                                        - - - ?03 10 ImLc M2 V M2 V     
+3219 Merchant             ?544???-?                                        - - - ?03 11 ImLc M0 V          
+0125 Hannrii              ?565???-?                                        - - - ?04 9  StIm M2 V          
+0126 Egurgadi             ?65A???-? Wa                                     - - - ?03 9  StIm K1 V          
+0130 Praodelf             ?AB6???-? Fl                                     - - - ?00 13 LuIm G4 V M1 V     
+0222 Daze                 ?776???-?                                        - - - ?00 6  StIm K7 V          
+0223 Abalesk              ?433???-? Po                                     - - - ?13 13 StIm M0 V          
+0227 Stoend               ?86A???-? Wa                                     - - - ?24 13 StIm M2 V          
+0228 Barren               ?652???-? Po                                     - - - ?00 14 StIm M2 V M1 V     
+0229 Foussough            ?653???-? Po                                     - - - ?00 14 LuIm K0 V M5 V     
+0230 Estos                ?425???-?                                        - - - ?05 15 LuIm K2 V M6 V M1 V
+0327 Fay                  ?540???-? De He Po                               - - - ?22 8  StIm M0 V M7 V     
+0328 Manuri               ?543???-? Po                                     - - - ?02 9  StIm K8 V M8 V     
+0329 Somit                ?55A???-? Wa                                     - - - ?00 12 StIm M0 V          
+0422 Rucciset             ?514???-? Ic                                     - - - ?12 7  StIm K0 V          
+0428 Charlotte            ?565???-?                                        - - - ?00 11 StIm K6 V          
+0526 Kinurgii             ?200???-? Va                                     - - - ?22 9  StIm K3 V          
+0527 Armec-Zamaa          ?895???-?                                        - - - ?03 11 StIm G3 V M7 V     
+0529 Priinargh            ?584???-?                                        - - - ?10 11 StIm M2 V M4 V     
+0530 Burle's Point        ?662???-?                                        - - - ?02 7  StIm K3 V M2 V     
+0623 Hartesh              ?657???-? Ga                                     - - - ?05 10 StIm M1 V          
+0626 Thelkourd            ?560???-? De                                     - - - ?13 9  StIm K4 V M5 V     
+0627 Guhnesh              ?757???-? Ga                                     - - - ?00 13 StIm M2 V M2 V     
+0628 Norton               ?571???-? He                                     - - - ?02 5  StIm K3 V M2 V M1 V
+0630 Orren Station        ?545???-?                                        - - - ?24 10 StIm G4 V M6 V     
+0722 Younis               ?310???-?                                        - - - ?04 8  StIm K3 V          
+0723 Inapiirn             ?542???-? He Po (Vapethi)?                       - - - ?10 12 StIm G2 V          
+0725 Tungohl              ?411???-? Ic                                     - - - ?14 16 StIm M3 V M4 V     
+0727 Hulr                 ?73A???-? Wa                                     - - - ?14 8  StIm M2 V M5 V     
+0728 Wenton               ?433???-? Po                                     - - - ?00 7  StIm M2 V          
+0729 Jousta               ?300???-? Va                                     - - - ?22 12 StIm M3 V          
+0824 Nonescue             ?547???-?                                        - - - ?05 10 StIm M1 V K1 V     
+0826 Delaag               ?8B3???-? Fl                                     - - - ?13 10 StIm M3 V M5 V     
+0827 Loniva               ?203???-? Ic Va                                  - - - ?05 11 StIm M2 V          
+0829 Query                ?645???-?                                        - - - ?02 12 StIm K2 V          
+0921 Obarr                ?534???-?                                        - - - ?04 7  StIm M3 V          
+0922 Chang                ?775???-?                                        - - - ?03 9  StIm K2 V          
+0923 Liini                ?A9A???-? Oc                                     - - - ?02 10 StIm M0 V M0 V     
+0924 Zilu                 ?426???-?                                        - - - ?01 5  StIm M2 V M6 V     
+0925 Tamesh               ?87A???-? Wa                                     - - - ?02 7  StIm M1 V          
+0926 Igamaal              ?557???-?                                        - - - ?03 13 StIm M2 V M6 V M7 V
+0927 Saol                 ?678???-?                                        - - - ?21 13 StIm G5 V          
+0928 Ongelbal             ?692???-? He                                     - - - ?13 13 StIm M2 V          
+0930 Dehruu               ?542???-? He Po                                  - - - ?23 10 StIm M2 V          
+1021 Bragg                ?571???-? He                                     - - - ?00 6  StIm K9 V M9 V     
+1023 Lorris               ?420???-? De He Po                               - - - ?15 15 StIm K3 V          
+1025 Ienda                ?767???-? Ga                                     - - - ?04 11 StIm M2 V M8 V     
+1026 Fiaf                 ?78A???-? Wa                                     - - - ?00 9  StIm M3 V          
+1027 Taluu                ?200???-? Va                                     - - - ?22 7  StIm M0 V M9 V     
+1029 Justine              ?570???-? De He                                  - - - ?02 7  StIm M2 V          
+1122 Panisse              ?436???-?                                        - - - ?13 15 StIm M2 V          
+1123 Rumulaar             ?88A???-? Wa                                     - - - ?01 6  StIm M2 V          
+1124 Creca                ?524???-?                                        - - - ?12 12 StIm K2 V          
+1125 Hanseat              ?300???-? Va                                     - - - ?00 14 StIm K4 V          
+1127 Unuv                 ?423???-? Po Di(minor)                           - - - ?02 6  StIm M2 V M9 V     
+1128 Kaakaa               ?550???-? De Po                                  - - - ?02 8  StIm K4 V          
+1129 Intnalta             ?420???-? De He Po                               - - - ?13 11 StIm M1 V M4 V     
+1221 Coernelf             ?410???-?                                        - - - ?02 6  StIm M2 V          
+1223 Syrol                ?563???-?                                        - - - ?03 10 StIm F5 V          
+1225 Forgane              ?421???-? He Po                                  - - - ?24 11 StIm M3 V          
+1227 Iest                 ?431???-? Po                                     - - - ?24 9  StIm M2 V          
+1228 Indurain             ?555???-?                                        - - - ?03 9  StIm M2 V          
+1321 Lish                 ?665???-? Ga                                     - - - ?21 13 StIm M0 V M5 V     
+1322 Berall               ?587???-?                                        - - - ?04 9  StIm G9 V          
+1328 Vesuata              ?430???-? De Po                                  - - - ?03 7  StIm K4 V M9 V M9 V
+1422 Yellsar              ?562???-?                                        - - - ?03 13 StIm G2 V M8 V     
+1423 Fairbriar            ?411???-? Ic                                     - - - ?04 11 StIm M0 V          
+1425 Diro                 ?000???-? As Va                                  - - - ?03 10 StIm G8 V          
+1426 Tikav                ?563???-?                                        - - - ?04 13 StIm M1 V M2 V     
+1430 Xerxes               ?526???-?                                        - - - ?00 13 StIm M2 V M7 V     
+1521 Haysher              ?764???-?                                        - - - ?03 8  StIm G9 V M0 V     
+1522 Cervantes            ?567???-?                                        - - - ?11 11 StIm M2 V          
+1523 Colehco              ?AE7???-?                                        - - - ?23 10 StIm M3 V M7 V     
+1525 Andonin              ?410???-?                                        - - - ?03 15 StIm K9 V          
+1526 Griissound           ?562???-?                                        - - - ?12 6  StIm M0 V          
+1528 Whiapluur            ?598???-?                                        - - - ?13 10 StIm G2 V M5 V     
+1529 Twahoy               ?541???-? He Po                                  - - - ?04 10 StIm M1 V M1 V     
+1530 Hemster              ?420???-? De He Po                               - - - ?05 14 StIm M0 V          
+1622 Blullaygh            ?648???-?                                        - - - ?03 10 StIm K1 V          
+1623 Fraynj               ?848???-?                                        - - - ?00 9  StIm K3 IV         
+1624 Leraag               ?520???-? De He Po                               - - - ?03 6  StIm M1 V M0 V     
+1625 Emur                 ?564???-?                                        - - - ?14 9  StIm G0 V          
+1627 Nuuhlam              ?400???-? Va                                     - - - ?22 13 StIm M3 V          
+1629 Pesuune              ?534???-?                                        - - - ?15 9  StIm M1 V K1 V     
+1721 Guslas               ?000???-? As Va                                  - - - ?00 9  StIm M2 V          
+1722 Ethbray              ?87A???-? Wa                                     - - - ?03 8  StIm M0 V          
+1723 Uurgikhushi          ?562???-?                                        - - - ?03 13 StIm M2 V M3 V     
+1724 Velte                ?772???-? He                                     - - - ?05 8  StIm M2 V K6 V     
+1727 Stedeng              ?424???-?                                        - - - ?20 10 StIm M0 V M2 V     
+1821 Iirshuur             ?544???-?                                        - - - ?34 10 StIm G2 V M4 V     
+1822 Ayltha               ?544???-?                                        - - - ?13 13 StIm G5 V          
+1823 Tire                 ?AE5???-?                                        - - - ?12 13 StIm G2 IV         
+1826 Dawru                ?89A???-? Wa                                     - - - ?00 14 StIm M2 V          
+1828 Khalun               ?200???-? Va                                     - - - ?05 12 StIm M2 V M5 V     
+1921 Mezregh              ?726???-?                                        - - - ?03 7  StIm M1 V          
+1923 Arcfest              ?A69???-?                                        - - - ?10 9  StIm K2 V M3 V     
+1924 Toyuysk              ?787???-? Ga                                     - - - ?03 11 StIm K8 V          
+1925 Fay                  ?778???-?                                        - - - ?21 13 StIm M1 V          
+1926 Howarth              ?562???-?                                        - - - ?13 9  StIm M1 V          
+1927 Yaektyu              ?75A???-? Wa                                     - - - ?03 7  StIm G4 V          
+1930 Unlardigard          ?310???-?                                        - - - ?04 9  StIm M2 V          
+2021 Vuyha                ?657???-? Ga                                     - - - ?02 6  StIm M0 V M5 V     
+2022 Tahnidse             ?421???-? He Po                                  - - - ?12 10 StIm K3 V M9 V     
+2029 Trill                ?784???-?                                        - - - ?15 10 StIm M1 V          
+2121 Oyrnigh              ?67A???-? Wa                                     - - - ?15 10 StIm K6 V M7 V M1 V
+2122 Thatbe               ?541???-? He Po                                  - - - ?04 15 StIm K4 V          
+2124 Mzimbe               ?420???-? De He Po                               - - - ?24 9  StIm M2 V          
+2125 Nchena               ?200???-? Va                                     - - - ?05 8  StIm M3 V          
+2127 Tlauwao              ?430???-? De Po                                  - - - ?04 10 StIm K0 V M9 V M7 V
+2128 Feaf                 ?549???-?                                        - - - ?04 13 StIm A3 V          
+2130 Fudaochoyrn          ?000???-? As Va                                  - - - ?03 8  StIm K0 V M1 V     
+2221 K'ke Say             ?683???-?                                        - - - ?20 10 StIm K4 V          
+2223 Deewaa               ?430???-? De Po                                  - - - ?03 13 StIm M1 V M5 V     
+2224 Kamurinmur           ?560???-? De                                     - - - ?13 11 StIm K0 V M8 V     
+2225 Elpple               ?310???-?                                        - - - ?03 11 StIm M3 V          
+2227 Helge                ?693???-?                                        - - - ?10 8  StIm M1 V M2 V     
+2228 Wrechner             ?432???-? Po                                     - - - ?05 10 StIm M1 V K5 V     
+2229 Xanten               ?593???-?                                        - - - ?22 9  StIm K1 V M5 V M2 V
+2323 Syss                 ?400???-? Va                                     - - - ?10 5  StIm M9 III D M5 V 
+2325 Droun                ?543???-? Po                                     - - - ?00 11 StIm K1 V          
+2326 Rashiidaa            ?655???-? Ga                                     - - - ?01 14 StIm G2 V M5 V     
+2330 Idull Ra             ?560???-? De                                     - - - ?24 11 StIm G2 V          
+2422 Vilk                 ?785???-? Ga                                     - - - ?10 12 StIm K5 V M0 V     
+2424 Plouraandva          ?432???-? Po                                     - - - ?00 5  StIm K3 V M0 V     
+2425 Kieaasu              ?430???-? De Po                                  - - - ?14 8  StIm G0 V          
+2426 Jazep                ?592???-? He                                     - - - ?34 10 StIm K1 V          
+2427 Twiga                ?502???-? Ic Va                                  - - - ?00 6  StIm M2 V          
+2428 Llalnair             ?429???-?                                        - - - ?02 12 StIm F9 V M8 V     
+2429 Chitete              ?420???-? De He Po                               - - - ?02 9  StIm M3 V M7 V     
+2430 Aawn                 ?434???-?                                        - - - ?05 13 StIm M2 V          
+2521 Joand                ?899???-?                                        - - - ?04 12 StIm K8 V M3 V     
+2523 Mapock               ?546???-?                                        - - - ?00 10 StIm G7 V          
+2525 Ioyx                 ?6B2???-? Fl He                                  - - - ?03 16 StIm G9 V          
+2526 Joffe's World        ?310???-?                                        - - - ?02 10 StIm F3 V          
+2527 Etwefrewa            ?566???-?                                        - - - ?20 15 StIm G3 V          
+2625 Khankaar             ?633???-? Po                                     - - - ?02 11 StIm M3 V          
+2626 Bliand               ?948???-?                                        - - - ?22 10 StIm M1 V          
+2627 Imarshas             ?9C6???-? Fl                                     - - - ?24 12 StIm M0 V M6 V M2 V
+2628 Kunggy               ?885???-? Ga                                     - - - ?11 5  StIm M0 V          
+2629 Nosy Be              ?69A???-? Wa                                     - - - ?00 13 StIm M0 V M2 V     
+2630 Majunga              ?89A???-? Wa                                     - - - ?10 11 StIm G1 V          
+2723 Doposeng             ?594???-?                                        - - - ?00 12 StIm M1 V          
+2724 Memern               ?540???-? De He Po                               - - - ?02 12 StIm K0 V M9 V     
+2725 Moytra               ?636???-?                                        - - - ?10 11 StIm M1 V M5 V     
+2726 Loholoka             ?556???-?                                        - - - ?00 12 StIm M2 V          
+2730 Irkhun               ?550???-? De Po                                  - - - ?00 12 StIm M2 V M1 V     
+2821 Fuch                 ?551???-? Po                                     - - - ?03 10 StIm M2 V          
+2822 Zomandao             ?688???-?                                        - - - ?00 7  StIm M0 V          
+2824 Anech Issan          ?564???-?                                        - - - ?02 11 StIm K1 V          
+2828 Ushuuri              ?83A???-? Wa                                     - - - ?13 7  StIm M0 V M6 V     
+2829 Sersoolm             ?420???-? De He Po                               - - - ?22 11 StIm M1 V M1 V     
+2830 Dendouth             ?200???-? Va                                     - - - ?01 10 StIm M2 V          
+2921 Edat                 ?437???-?                                        - - - ?02 8  StIm M2 V M4 V M9 V
+2923 Goye                 ?767???-? Ga                                     - - - ?10 16 StIm G3 V          
+2924 Oieakh               ?437???-?                                        - - - ?12 11 StIm M3 V          
+2925 Hkeakewoirea'        ?998???-?                                        - - - ?02 9  StIm G3 V M7 V     
+2930 Taeahtaho            ?887???-? Ga                                     - - - ?04 10 StIm K2 V          
+3023 Suysu                ?000???-? As Va                                  - - - ?12 13 StIm M2 V          
+3024 Brase                ?756???-? Ga                                     - - - ?04 7  StIm K1 V M3 V     
+3026 Beangub              ?786???-? Ga                                     - - - ?00 12 StIm M2 V K8 V     
+3027 Gier                 ?596???-?                                        - - - ?03 13 StIm G2 V M8 V     
+3028 Doucttru             ?798???-?                                        - - - ?05 11 StIm K8 V          
+3029 Phaln                ?420???-? De He Po                               - - - ?12 10 StIm K4 V M9 V     
+3122 Vammuun              ?200???-? Va                                     - - - ?00 12 StIm A1 V          
+3126 Bivaud               ?9C5???-? Fl                                     - - - ?03 12 StIm K1 V M7 V     
+3130 Akhudgir             ?A87???-?                                        - - - ?04 9  LuIm K7 V          
+3223 Vohitsara            ?310???-?                                        - - - ?03 14 StIm M3 V          
+3224 Ars                  ?656???-? Ga                                     - - - ?04 11 StIm M2 V          
+3226 Joyrest              ?546???-?                                        - - - ?04 9  StIm G0 V          
+3228 Moskett              ?200???-? Va                                     - - - ?25 11 LuIm M0 V          
+3230 Tsihombe             ?764???-?                                        - - - ?00 18 LuIm M2 V          
+0131 Sirir                ?796???-?                                        - - - ?23 12 LuIm K3 V          
+0132 Aapu                 ?560???-? De                                     - - - ?00 14 LuIm K1 V M2 V     
+0135 Maerol               ?200???-? Va                                     - - - ?02 9  FdIl K1 V          
+0136 Choltonrul           ?587???-?                                        - - - ?24 10 FdIl M0 V          
+0137 Ushulu               ?782???-?                                        - - - ?00 18 FdIl M0 V M4 V     
+0138 Roolyz               ?433???-? Po                                     - - - ?22 12 FdIl G8 V M3 V M0 V
+0140 Joutect              ?768???-?                                        - - - ?00 12 FdIl M0 V M7 V     
+0231 Hentor               ?503???-? Ic Va                                  - - - ?22 16 LuIm M3 V D        
+0233 Abaelou              ?695???-? (Loeskalth)?                           - - - ?03 11 LuIm M1 V          
+0236 Gihmentahlish        ?895???-?                                        - - - ?22 15 FdIl K7 V          
+0237 Strand               ?548???-?                                        - - - ?02 9  FdIl G4 V          
+0239 Ounash               ?420???-? De He Po                               - - - ?04 8  FdIl K9 V          
+0332 Blezon               ?572???-? He                                     - - - ?23 12 LuIm K2 V M8 V     
+0333 Vaelouf              ?537???-?                                        - - - ?11 8  LuIm M0 V          
+0334 Endran               ?515???-? Ic                                     - - - ?03 12 LuIm K3 IV M6 V    
+0338 Phoenaeg             ?560???-? De                                     - - - ?13 12 FdIl G0 V M1 V     
+0339 Sagal                ?887???-? Ga                                     - - - ?13 7  FdIl K1 V M0 V     
+0432 Trichach             ?573???-?                                        - - - ?04 13 LuIm K8 V M9 V     
+0433 Cemloch              ?646???-?                                        - - - ?05 8  LuIm M2 V          
+0434 Nemeet               ?430???-? De Po                                  - - - ?04 9  LuIm M2 V          
+0435 Gwelbyph             ?423???-? Po                                     - - - ?05 8  FdIl K3 V          
+0436 Flaslousk            ?543???-? Po                                     - - - ?10 12 FdIl M4 V          
+0437 Jaeyelya             ?584???-? (Ael Yael)?                            - - - ?02 10 FdIl K6 V          
+0438 Lem                  ?532???-? Po                                     - - - ?00 10 FdIl M3 V M1 V     
+0439 Dimkodrarn           ?553???-? Po                                     - - - ?03 13 FdIl G0 V          
+0531 Rake                 ?425???-?                                        - - - ?02 13 LuIm K3 V M4 V     
+0532 Soel                 ?8A5???-? Fl                                     - - - ?02 14 LuIm K0 V M1 V     
+0536 Imagalu              ?967???-?                                        - - - ?04 13 FdIl M0 V          
+0537 Wols                 ?764???-?                                        - - - ?00 11 FdIl M0 V M4 V     
+0631 Homage               ?594???-?                                        - - - ?12 6  LuIm M2 V          
+0632 Vipach               ?738???-?                                        - - - ?10 17 LuIm K4 V M5 V     
+0634 Sern                 ?AE6???-?                                        - - - ?00 10 FdIl M0 V          
+0639 Asiilish             ?565???-?                                        - - - ?14 13 FdIl K3 V M4 V M4 V
+0640 Chezpan              ?200???-? Va                                     - - - ?02 9  FdIl K4 V M2 V     
+0732 Th'dir               ?100???-? Va                                     - - - ?13 10 LuIm M4 V          
+0733 Dendaash             ?9C7???-? Fl                                     - - - ?04 15 LuIm A6 V M6 V     
+0737 Zamashuug            ?585???-?                                        - - - ?00 13 FdIl M3 V K6 V     
+0738 Dikaash              ?627???-?                                        - - - ?01 13 FdIl M4 V          
+0740 Wilson               ?100???-? Va                                     - - - ?00 13 FdIl M2 V M4 V     
+0831 Tenraash             ?79A???-? Wa                                     - - - ?02 8  StIm G4 V          
+0839 Ginupa               ?559???-?                                        - - - ?03 11 FdIl G0 V          
+0840 Teuterom             ?502???-? Ic Va                                  - - - ?13 7  FdIl M2 V M4 V     
+0933 Taalish              ?572???-? He                                     - - - ?03 12 LuIm M2 V M4 V     
+0934 Eycoltou             ?887???-? Ga                                     - - - ?01 9  LuIm M3 V M8 V     
+0935 Lemantine            ?865???-? Ga                                     - - - ?00 12 FdIl G1 V M6 V     
+0936 Baalaansh            ?561???-?                                        - - - ?04 10 FdIl G4 V M5 V     
+0937 Gamaliss             ?572???-? He                                     - - - ?00 12 FdIl F3 V          
+0940 Swinedune            ?000???-? As Va                                  - - - ?00 9  FdIl K3 V          
+1033 Nukyls               ?540???-? De He Po                               - - - ?11 10 LuIm K2 V          
+1036 Maernon              ?678???-?                                        - - - ?03 12 FdIl G0 V M3 V     
+1038 Sharim               ?435???-?                                        - - - ?00 7  FdIl M3 V          
+1039 He'alaan'drl         ?424???-?                                        - - - ?01 9  FdIl K0 V M8 V     
+1133 Kemshigesh           ?532???-? Po                                     - - - ?13 10 LuIm K2 V M8 V     
+1135 Podero               ?565???-?                                        - - - ?13 7  FdIl M0 V          
+1136 Uin                  ?543???-? Po                                     - - - ?03 14 FdIl K0 V          
+1137 Draerch              ?312???-? Ic                                     - - - ?00 12 FdIl M2 V M3 V M6 V
+1139 Weaf                 ?777???-?                                        - - - ?02 16 FdIl K0 V          
+1140 Rellena              ?898???-?                                        - - - ?10 11 FdIl K2 V M6 V M0 V
+1231 Find                 ?675???-?                                        - - - ?23 8  StIm M2 V          
+1233 Mercator             ?540???-? De He Po                               - - - ?03 8  LuIm G1 V          
+1234 Sidur Ishki          ?312???-? Ic (Sidurii)?                          - - - ?20 6  LuIm M0 V M0 V     
+1235 Icon                 ?434???-?                                        - - - ?15 9  FdIl K1 V          
+1236 Shiiki               ?551???-? Po                                     - - - ?10 12 FdIl G0 V          
+1237 Gumahler             ?655???-? Ga (Gumahl)?                           - - - ?05 8  FdIl K1 V M6 V     
+1239 Zalanor              ?100???-? Va                                     - - - ?24 9  FdIl M3 V G7 V     
+1331 Camal                ?421???-? He Po                                  - - - ?03 10 StIm G9 IV M6 V    
+1333 Wingate              ?877???-?                                        - - - ?00 9  LuIm M0 V          
+1334 Sidur Haski          ?786???-? Ga                                     - - - ?20 13 LuIm M0 V          
+1337 Thon                 ?745???-?                                        - - - ?10 17 FdIl K4 V          
+1340 Depsorn              ?543???-? Po                                     - - - ?03 12 FdIl F7 V M3 V     
+1431 Arailiur             ?500???-? Va                                     - - - ?00 12 StIm G8 V M4 V     
+1432 Confex               ?AC5???-? Fl                                     - - - ?20 13 LuIm M0 V          
+1433 Vueegmala            ?629???-?                                        - - - ?03 13 LuIm M2 V M6 V     
+1434 Tromiishur           ?626???-?                                        - - - ?24 12 LuIm M0 V M7 V     
+1439 Shupin               ?959???-?                                        - - - ?04 10 FdIl M2 V          
+1440 Ovchek               ?635???-?                                        - - - ?00 6  FdIl M0 V M9 V     
+1531 Oneria               ?787???-? Ga                                     - - - ?05 15 StIm M2 V          
+1532 Polygamy             ?549???-?                                        - - - ?00 13 LuIm K3 V          
+1534 Sinerhk              ?656???-? Ga                                     - - - ?04 8  LuIm G1 V M6 V M2 V
+1539 Here                 ?543???-? Po                                     - - - ?03 14 FdIl K4 V          
+1540 Chiras               ?555???-?                                        - - - ?03 8  FdIl M0 V          
+1637 Zinzan               ?433???-? Po                                     - - - ?04 17 FdIl K3 V          
+1638 Budeeshou            ?597???-?                                        - - - ?04 12 FdIl G2 V          
+1640 Llest                ?78A???-? Wa                                     - - - ?03 8  FdIl M0 V          
+1732 Muthi                ?873???-?                                        - - - ?14 8  StIm K6 V M2 V     
+1733 Arnuukara            ?560???-? De                                     - - - ?13 7  LuIm M2 V          
+1734 Arniche              ?427???-?                                        - - - ?02 17 LuIm K8 V M8 V     
+1735 Ushiia               ?200???-? Va                                     - - - ?30 9  LuIm M3 V          
+1737 Ceoth                ?595???-?                                        - - - ?14 12 FdIl M1 V M2 V     
+1739 Khii Sheik           ?433???-? Po                                     - - - ?00 16 FdIl K2 V M2 V     
+1740 Derry                ?100???-? Va                                     - - - ?24 9  FdIl M2 V          
+1832 Oaxaca               ?85A???-? Wa                                     - - - ?05 11 StIm M1 V M5 V     
+1833 Nimshikake           ?664???-?                                        - - - ?02 7  LuIm M1 V M5 V     
+1835 Rean                 ?567???-?                                        - - - ?03 7  LuIm M3 V M9 V     
+1839 Cholo                ?565???-?                                        - - - ?02 13 FdIl M2 V M8 V     
+1932 Hopkins              ?567???-?                                        - - - ?03 11 StIm K3 V          
+1933 Oyrayt               ?586???-?                                        - - - ?00 7  LuIm M0 V          
+1935 Aisteaya             ?563???-?                                        - - - ?20 9  LuIm M2 V          
+1936 Atu Ista             ?679???-?                                        - - - ?10 8  LuIm M2 V          
+2031 Sombani              ?422???-? He Po                                  - - - ?23 10 StIm M2 V M1 V     
+2036 Gushirdiimi          ?542???-? He Po                                  - - - ?23 11 FdIl M1 V          
+2037 Highbury             ?424???-?                                        - - - ?02 8  FdIl M3 V          
+2038 Yolai'               ?758???-?                                        - - - ?13 12 FdIl M0 V          
+2040 Tiirmmay             ?431???-? Po                                     - - - ?04 13 FdIl M1 V          
+2131 Glipli               ?525???-?                                        - - - ?20 13 StIm M2 V          
+2132 Edoy                 ?556???-?                                        - - - ?24 14 StIm M2 V M7 V     
+2134 Cledsetsaenn         ?000???-? As Va                                  - - - ?33 10 LuIm K1 V          
+2136 Bitesofrach          ?787???-? Ga                                     - - - ?25 11 FdIl M0 V          
+2139 Wesas                ?696???-?                                        - - - ?03 12 FdIl G4 V          
+2140 Kuwiru               ?510???-?                                        - - - ?10 9  FdIl G4 V          
+2231 Zanish               ?677???-?                                        - - - ?03 13 StIm M0 V          
+2233 Khugika              ?553???-? Po                                     - - - ?03 15 LuIm M3 V          
+2237 Thanarmoos           ?524???-?                                        - - - ?04 10 FdIl M1 V          
+2240 Lleska               ?622???-? He Po                                  - - - ?12 12 FdIl K1 V          
+2331 Aying                ?73A???-? Wa                                     - - - ?14 8  StIm G0 V M7 V     
+2332 Danla                ?672???-? He                                     - - - ?13 10 StIm M1 V          
+2333 Tethaym              ?000???-? As Va                                  - - - ?03 9  LuIm K2 V M0 V M4 V
+2334 Gerhardus            ?552???-? Po                                     - - - ?23 9  LuIm K4 V M7 V     
+2335 Chipoka              ?666???-? Ga                                     - - - ?24 12 FdIl M2 V M6 V     
+2336 Arapenpa             ?540???-? De He Po                               - - - ?25 12 FdIl G5 V M5 V     
+2337 Giffard              ?513???-? Ic                                     - - - ?23 8  FdIl M3 V          
+2339 Thulm                ?656???-? Ga                                     - - - ?04 7  FdIl M1 V M0 V     
+2340 Elk                  ?874???-?                                        - - - ?12 6  FdIl M1 V M3 V     
+2431 Kiaan                ?583???-?                                        - - - ?03 12 StIm M2 V M5 V M9 V
+2434 Muaash               ?565???-?                                        - - - ?12 7  FdIl M3 V M0 V     
+2438 Jars                 ?500???-? Va                                     - - - ?04 8  FdIl M0 V M6 V     
+2439 Susadi               ?8C3???-? Fl                                     - - - ?01 9  FdIl M3 V          
+2440 Oyrk                 ?557???-?                                        - - - ?13 7  FdIl M0 V M7 V     
+2532 Yntulk               ?889???-?                                        - - - ?24 13 StIm K4 V          
+2536 Sers                 ?540???-? De He Po                               - - - ?12 9  FdIl K4 V          
+2537 Stallfe              ?986???-?                                        - - - ?24 11 FdIl M1 V M0 V     
+2538 Thulm                ?87A???-? Wa                                     - - - ?03 13 FdIl M2 V M4 V     
+2539 Hate                 ?988???-?                                        - - - ?04 13 FdIl M3 V          
+2540 Temes                ?649???-?                                        - - - ?03 9  FdIl G2 V M4 V M0 V
+2632 Croft                ?550???-? De Po                                  - - - ?02 9  LuIm G0 V          
+2633 Pequan               ?543???-? Po                                     - - - ?10 6  FdIl K1 V M9 V     
+2634 Katsue               ?436???-?                                        - - - ?03 6  FdIl G3 V          
+2637 Darkaoul             ?425???-?                                        - - - ?10 14 FdIl G0 V          
+2639 Tudjman              ?687???-? Ga                                     - - - ?00 11 FdIl K3 V          
+2732 Khossfoy             ?430???-? De Po                                  - - - ?22 13 LuIm K7 V M9 V     
+2734 Traynor              ?434???-?                                        - - - ?13 12 FdIl K1 V          
+2735 Moy                  ?758???-?                                        - - - ?14 10 FdIl M2 V M1 V     
+2737 Chechen              ?597???-?                                        - - - ?22 9  FdIl M3 V M1 V     
+2738 Khalun               ?421???-? He Po                                  - - - ?04 10 FdIl K5 V          
+2740 Iishli               ?888???-?                                        - - - ?13 8  FdIl M1 V          
+2831 Abact                ?672???-? He                                     - - - ?04 8  LuIm M0 V          
+2833 Grebele              ?540???-? De He Po                               - - - ?05 12 FdIl M3 V M8 V     
+2834 Drigelm              ?666???-? Ga                                     - - - ?13 14 FdIl M2 V M9 V     
+2835 Muugegdan            ?424???-?                                        - - - ?03 9  FdIl M3 V M9 V     
+2837 Rashiidaa            ?580???-? De                                     - - - ?14 10 FdIl M0 V M7 V     
+2838 Trauch               ?783???-?                                        - - - ?02 10 FdIl M1 V          
+2839 Kadar                ?542???-? He Po                                  - - - ?20 10 FdIl M1 V M4 V M1 V
+2840 Odinga               ?431???-? Po                                     - - - ?04 15 FdIl M3 V M8 V     
+2931 Kikuyu               ?789???-?                                        - - - ?04 12 LuIm M2 V M4 V     
+2937 Eralt                ?AB8???-? Fl                                     - - - ?03 16 FdIl M9 III D      
+2938 Azwhew               ?577???-?                                        - - - ?00 15 FdIl M3 V          
+2939 Ann                  ?873???-?                                        - - - ?03 6  FdIl G2 V          
+3031 Teghde               ?560???-? De                                     - - - ?13 13 LuIm M2 V          
+3033 Sabhaash             ?665???-? Ga                                     - - - ?02 13 FdIl K0 V          
+3034 Ukham                ?310???-?                                        - - - ?23 9  FdIl K2 III        
+3035 Taleoo               ?957???-?                                        - - - ?03 10 FdIl M0 V          
+3038 Kieaasu              ?667???-? Ga                                     - - - ?20 5  FdIl K1 V          
+3039 Uskent               ?55A???-? Wa                                     - - - ?00 9  FdIl M3 V          
+3131 Leant                ?763???-?                                        - - - ?30 13 LuIm M2 V          
+3137 As On As             ?766???-? Ga                                     - - - ?00 6  FdIl G2 V M3 V     
+3139 Enturtepra           ?899???-?                                        - - - ?03 11 FdIl M2 V M7 V     
+3140 Ladi                 ?432???-? Po                                     - - - ?03 12 FdIl M1 V          
+3231 Staya                ?200???-? Va                                     - - - ?10 10 LuIm M2 V M8 V     
+3235 Ikaak                ?434???-?                                        - - - ?10 11 FdIl K3 V          
+3236 Fadia                ?596???-?                                        - - - ?15 10 FdIl K2 V M0 V     
+3237 Revd                 ?988???-?                                        - - - ?20 12 FdIl G6 V          
+3240 Haiwhou              ?432???-? Po                                     - - - ?04 14 FdIl M0 V M3 V     

--- a/res/Sectors/M1120/1120_Gush.xml
+++ b/res/Sectors/M1120/1120_Gush.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0"?>
+<Sector xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Name>Gushemege</Name>
+  <Credits>
+
+             &lt;b&gt;Gushemege&lt;/b&gt; sector was designed by Marc W. Miller
+             and appears in &lt;cite&gt;Atlas of the Imperium&lt;/cite&gt; (GDW,
+             1984).
+
+             It was refined by Martin J. Dougherty and appears in
+             &lt;cite&gt;1248 Sourcebook 2: Bearers of the Flame&lt;/cite&gt;
+             (ComStar Media/Avenger Enterprises, 2006).
+
+             Rebellion Era borders were designed by James Holden, Joe D. Fugate Jr. and Terry McInnes
+             and appeared in The MegaTraveller Alien, Volume 1: Vilani & Vargr (
+             Digest Group Publications, 1990).
+
+    </Credits>
+  <Product Title="MegaTraveller Alien Vol. 1: Vilani %29 Vargr" Publisher="Digest Group Publications" Ref="http://wiki.travellerrpg.com/Alien_-_Vilani_%26_Vargr"/>
+  <Subsectors>
+    <Subsector Index="A">Riften</Subsector>
+    <Subsector Index="B">Khiira</Subsector>
+    <Subsector Index="C">Taapvaia</Subsector>
+    <Subsector Index="D">Tansa</Subsector>
+    <Subsector Index="E">Gandonen</Subsector>
+    <Subsector Index="F">Rure</Subsector>
+    <Subsector Index="G">Ankhsusgar</Subsector>
+    <Subsector Index="H">Isi Ahto</Subsector>
+    <Subsector Index="I">Balech</Subsector>
+    <Subsector Index="J">Sallounn</Subsector>
+    <Subsector Index="K">Dashinshaii</Subsector>
+    <Subsector Index="L">Shire</Subsector>
+    <Subsector Index="M">Vipach</Subsector>
+    <Subsector Index="N">Laeth</Subsector>
+    <Subsector Index="O">Truax</Subsector>
+    <Subsector Index="P">Lagan</Subsector>
+  </Subsectors>
+  <Allegiances>
+    <Allegiance Code="CsIm">Client state, Third Imperium</Allegiance>
+    <Allegiance Code="FdIl">Federation of Ilelish</Allegiance>
+    <Allegiance Code="ImLc">Third Imperium, Lancian Cultural Region</Allegiance>
+    <Allegiance Code="LuIm">Lucan's Imperium</Allegiance>
+    <Allegiance Code="NaHu">Non-Aligned, Human-dominated</Allegiance>
+    <Allegiance Code="StIm">Strephon's Imperium</Allegiance>
+  </Allegiances>
+  <Borders>
+    <Border WrapLabel="true" Allegiance="FdIl" LabelPosition="0736" Color="Purple">0030 0031 0032 0033 0034 0135 0136 0236 0337 0436 0435 0535 0634 0735 0835 0935 0936 1036 1136 1135 1235 1236 1337 1437 1537 1637 1737 1837 1938 2037 2036 2136 2235 2335 2434 2435 2536 2635 2634 2633 2734 2833 2934 3033 3034 3035 3136 3235 3335 3336 3337 3338 3339 3340 3341 3241 3141 3041 2941 2841 2741 2641 2541 2441 2341 2241 2141 2041 1941 1841 1741 1641 1541 1441 1341 1241 1141 1041 0941 0841 0741 0641 0541 0441 0341 0241 0141 0041 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030</Border>
+    <Border WrapLabel="true" Allegiance="ImLc" LabelPosition="2712" Label="Lancian Cultural Region">2007 2107 2106 2105 2204 2203 2202 2302 2301 2401 2501 2601 2701 2800 2900 3000 3100 3200 3201 3202 3203 3304 3305 3306 3307 3308 3309 3310 3311 3312 3212 3213 3214 3215 3216 3217 3218 3219 3119 3019 2920 2820 2720 2620 2619 2618 2617 2517 2516 2415 2414 2413 2412 2411 2311 2210 2110 2109 2008 2007</Border>
+    <Border Allegiance="LuIm" LabelPosition="1536" Color="DarkRed">0130 0229 0330 0430 0531 0631 0732 0832 0932 1031 1132 1232 1332 1432 1532 1632 1733 1833 1933 2032 2133 2232 2333 2432 2533 2632 2732 2831 2931 3030 3130 3129 3128 3227 3327 3328 3329 3330 3331 3332 3333 3334 3234 3135 3134 3133 3032 2933 2832 2733 2632 2533 2534 2535 2534 2433 2334 2234 2135 2035 1936 1937 1836 1736 1636 1536 1436 1336 1335 1234 1134 1034 1035 1034 0934 0834 0734 0633 0534 0434 0335 0336 0235 0234 0134 0133 0132 0131 0130</Border>
+    <Border Allegiance="StIm" LabelPosition="1316" Color="Crimson">0029 0129 0128 0127 0126 0125 0224 0223 0222 0323 0422 0522 0621 0721 0820 0819 0818 0718 0617 0517 0616 0615 0614 0714 0813 0913 0912 1011 1111 1210 1209 1309 1308 1407 1507 1606 1605 1705 1704 1703 1702 1801 1800 1900 2000 2100 2200 2300 2400 2500 2600 2700 2800 2900 3000 3100 3200 3300 3301 3302 3303 3304 3305 3306 3307 3308 3309 3310 3311 3312 3313 3314 3315 3316 3317 3217 3218 3219 3220 3221 3222 3223 3224 3225 3226 3127 3027 3028 3029 2930 2830 2731 2631 2532 2431 2332 2231 2132 2031 1932 1832 1732 1631 1531 1431 1331 1231 1131 1030 0931 0831 0731 0630 0530 0429 0329 0228 0129 0029</Border>
+  </Borders>
+  <Routes>
+    <Route Start="0327" End="0223" />
+    <Route Start="0527" End="0327" />
+    <Route Start="0527" End="0428" />
+    <Route Start="0527" End="0630" />
+    <Route Start="0826" End="0527" />
+    <Route Start="0912" End="1013" />
+    <Route Start="0923" End="0926" />
+    <Route Start="0923" End="1322" />
+    <Route Start="0926" End="0826" />
+    <Route Start="1013" End="1015" />
+    <Route Start="1015" End="0718" />
+    <Route Start="1015" End="1018" />
+    <Route Start="1015" End="1414" />
+    <Route Start="1019" End="0923" />
+    <Route Start="1236" End="1038" />
+    <Route Start="1319" End="1019" />
+    <Route Start="1322" End="1423" />
+    <Route Start="1414" End="1512" />
+    <Route Start="1414" End="1616" />
+    <Route Start="1423" End="1722" />
+    <Route Start="1426" End="1423" />
+    <Route Start="1426" End="1826" />
+    <Route Start="1530" End="1426" />
+    <Route Start="1616" End="1816" />
+    <Route Start="1619" End="1319" />
+    <Route Start="1637" End="1439" />
+    <Route Start="1722" End="2022" />
+    <Route Start="1733" End="1835" />
+    <Route Start="1811" End="2210" />
+    <Route Start="1814" End="1811" />
+    <Route Start="1816" End="1814" />
+    <Route Start="1816" End="2018" />
+    <Route Start="1826" End="1926" />
+    <Route Start="1926" End="2127" />
+    <Route Start="1930" End="1530" />
+    <Route Start="2018" End="1619" />
+    <Route Start="2018" End="2418" />
+    <Route Start="2022" End="1926" />
+    <Route Start="2022" End="2018" />
+    <Route Start="2036" End="2037" />
+    <Route Start="2037" End="2040" />
+    <Route Start="2037" End="2439" />
+    <Route Start="2127" End="2325" />
+    <Route Start="2231" End="1930" />
+    <Route Start="2325" End="2424" />
+    <Route Start="2415" End="2614" />
+    <Route Start="2418" End="2415" />
+    <Route Start="2424" End="2725" />
+    <Route Start="2439" End="2539" />
+    <Route Start="2539" End="2839" />
+    <Route Start="2614" End="2815" />
+    <Route Start="2725" End="2822" />
+    <Route Start="2725" End="2925" />
+    <Route Start="2815" End="3013" />
+    <Route Start="2839" End="3240" />
+    <Route Start="2925" End="3126" />
+    <Route Start="3013" End="3211" />
+    <Route Start="3029" End="2730" />
+    <Route Start="3126" End="0325" EndOffsetX="1" />
+    <Route Start="3126" End="3029" />
+    <Route Start="3230" End="0329" EndOffsetX="1" />
+    <Route Start="3240" End="0240" EndOffsetX="1" />
+    <Route Start="3240" End="3137" />
+  </Routes>
+</Sector>

--- a/res/Sectors/M1120/1120_Vlan.sec
+++ b/res/Sectors/M1120/1120_Vlan.sec
@@ -1,0 +1,534 @@
+Hex  Name           UWP       Remarks                         {Ix}   (Ex)    [Cx]   N    B  Z PBG W  A    Stellar
+---- -------------- --------- ------------------------------- ------ ------- ------ ---- -- - --- -- ---- ---------------
+0101 Aakhorn        D556754-7 Ag Vila1                        { -1 } (967-3) [5635] -    -  - 204 11 ZiSi F5 V G6 V      
+0102 Rokii          E799345-8 Lo Vila1                        { -3 } (621-5) [1136] -    -  - 210 11 ZiSi M3 V           
+0104 Maluuf         E432338-9 Lo Po Vila1                     { -2 } (621-2) [3159] -    -  - 110 8  ZiSi K9 V K8 V      
+0105 Gikkon         E543500-8 Ni Po Vila1                     { -3 } (C41-5) [1213] -    -  - 932 11 ZiSi G8 V G0 V      
+0107 Taraddiin      C656563-9 Ga Ni Ag Cy O:0110 Vila1        { 0 }  (944-3) [2526] -    -  - 311 13 ZiSi M3 V           
+0109 Hakkat         C658887-6 Ph Pa Vila1                     { -1 } (A76-1) [8756] -    V  - 823 13 ZiSi G1 V           
+0110 Ossin          B100877-C Va Ph Na Pi Pz Vila1            { 2 }  (F7C+2) [8A5C] -    -  A 705 9  ZiSi M1 V           
+0202 Kalkako        C544405-A Ni Pa Vila1                     { 0 }  (C33-2) [2438] -    V  - 324 17 ZiSi F8 V K2 V      
+0203 Bannon's World E100488-A Va Ni Vila1                     { -1 } (832-1) [435A] -    -  - 120 13 ZiSi M3 V K6 V      
+0205 Khankari       B885411-B Ga Ni Pa Vila2                  { 1 }  (734-3) [1517] -    -  - 110 13 ZiSi M2 V           
+0209 Lankhi         E746552-6 Ni Ag Vila1                     { -2 } (742-5) [1312] -    -  - 503 8  ZiSi M2 V           
+0210 Khalgun        E576734-6 Ag Pi Vila1                     { -1 } (966-3) [5634] -    -  - 601 12 ZiSi M1 V           
+0303 Anert          B9B466A-B Fl Ni O:0506 Vila1              { 1 }  (955+3) [877D] -    -  - 610 11 ZiSi G7 V           
+0306 Skathi         B585698-9 Ni Ag Ri Vila2                  { 3 }  (957+3) [6959] -    KV - 210 14 ZiSi M0 V K0 V      
+0307 Enard          C8A37AC-9 Fl Vila1                        { 0 }  (A69+3) [A78C] -    S  - 501 9  ZiSi M1 V M7 V      
+0402 Kuk            C540222-8 De He Lo Po Vila1               { -2 } (511-5) [1114] -    V  - 901 8  VNgC K2 V K6 V      
+0403 Apkeraas       C438547-9 Ni Vila1                        { -1 } (943-1) [5459] -    -  - 420 8  ZiSi G2 V           
+0404 Katti          A8D8210-D Lo Vila2                        { 1 }  (811-3) [1318] -    -  - 404 8  ZiSi M3 V           
+0408 Shaddukan      B622156-D He Lo Po Vila1                  { 2 }  (401+1) [134C] -    KV - 410 13 ZiSi G1 V           
+0502 Lugaluru       C859443-A Ni Vila1                        { 0 }  (733-3) [1427] -    -  - 201 9  VNgC M0 V           
+0506 Gamibuu        B524610-A Ni Vila2                        { 2 }  (956-2) [1815] -    KV - 101 9  ZiSi K0 V M3 V      
+0507 Kharta         E552755-7 Po Vila1                        { -2 } (966-4) [5535] -    -  - 804 11 ZiSi K6 V G9 V      
+0508 Arfaan         B767400-C Ga Ni Pa Vila1                  { 1 }  (A34-3) [1517] -    -  - 713 11 ZiSi M1 V           
+0601 Athanuez       B100863-B Va Ph Na Pi Cy O:Wind-0740Vila1 { 2 }  (B7C-1) [5A28] -    -  - 101 8  VNgC K5 V M0 V      
+0605 Sheshat        A526111-C Lo Vila2                        { 1 }  (901-3) [1218] -    K  - 124 9  ZiSi F8 V           
+0610 Rakurram       B200369-C Va Lo Mr Vila1                  { 1 }  (821+2) [446D] -    K  - 212 13 ZiSi G7 V           
+0701 Taegzdueg      C665552-9 Ga Ni Ag Pr Vila1               { 0 }  (C44-4) [1515] -    -  - 314 12 VNgC G0 V M5 V      
+0703 Khigapka       B797457-C Ni Pa Vila1                     { 1 }  (834+1) [455C] -    -  - 902 9  ZiSi M2 V           
+0705 Shukhuge       C727830-9 Ph Pi Vila1                     { 0 }  (B79-4) [3814] -    -  - 110 11 ZiSi M1 V           
+0707 Lenordi        D000487-8 As Va Ni Vila1                  { -3 } (731-3) [4158] -    V  - 310 8  ZiSi M2 V           
+0708 Voskhod        B3109ED-E Hi Na In Vila1                  { 5 }  (C8H+5) [DE9J] -    W  - 101 12 ZiSi M1 V M0 V      
+0709 Kharzet        A565597-D Ni Ag Pr Vila2                  { 2 }  (846+2) [575D] -    -  - 601 17 ZiSi M0 V G3 V      
+0801 Ogerrgh        E62A837-8 Ph Pi Vila1                     { -2 } (B76-2) [8658] -    -  - 110 9  VNgC M1 V           
+0804 Kegirur        D76A945-8 Wa Hi Pr Pz Vila1               { -1 } (C88-3) [7836] -    -  A 901 10 NaVa M0 V           
+0806 Gadiga         E88A202-A Wa Lo Da Vila1                  { -1 } (511-5) [1116] -    -  A 101 11 ZiSi F9 V K8 V M8 V 
+0807 Kunumi         A554412-D Ni Pa Vila2                     { 1 }  (934-3) [1519] -    -  - 621 12 ZiSi K0 V           
+0902 Otsaellghue    A425435-F Ni Varg9 Vila1                  { 1 }  (934-1) [253D] -    K  - 303 8  VNgC K9 V           
+0906 Iishashun      C62546A-A Ni O:0708 Vila1                 { 0 }  (A33+2) [647C] -    -  - 713 10 ZiSi K3 V           
+0909 Jiinasha       C200789-A Va Na Pi Vila1                  { 1 }  (B6A+2) [886B] -    V  - 820 7  ZiSi M4 III         
+1001 Odhughe        C525545-9 Ni Varg9 Vila1                  { -1 } (843-3) [3437] -    -  - 910 13 VNgC K0 V M6 V      
+1003 Anaanika       B54057A-8 De He Ni Po Vila1               { -1 } (943+1) [747A] -    -  - 911 8  VNgC M1 V           
+1004 Esngougz       EA7A443-6 Oc Ni Vila1                     { -3 } (631-5) [1123] -    -  - 620 8  VNgC M2 V           
+1007 Laaru          C69A9CC-C Wa Hi In Vila1                  { 3 }  (H8E+5) [CC8F] -    V  - 424 9  ZiSi G7 V           
+1102 Azu            A547857-D Ph Pa Pi Varg2 Vila1            { 2 }  (B7D+2) [8A5D] -    K  - 801 5  VNgC M1 V M3 V      
+1104 Gvaellekh      D885215-8 Ga Lo Vila2                     { -3 } (511-4) [1136] -    C  - 610 8  VNgC K2 V K6 V      
+1107 Sikilar        B4328DH-A Ph Na Po Fo Vila1               { 2 }  (E7B+5) [DAAF] -    -  R 722 7  ZiSi G2 V           
+1108 Vakhoneri      C76A9AB-C Wa Hi Pr Vila1                  { 2 }  (C8D+4) [BB7E] -    V  - 710 16 ZiSi K8 V           
+1109 Suragginsu     E433352-A Lo Po Vila1                     { -1 } (721-5) [1216] -    -  - 711 13 ZiSi F6 V M8 V      
+1110 Liwar          C550300-A De Lo Po Vila1                  { 0 }  (A21-4) [1315] -    V  - 405 9  ZiSi K2 V           
+1201 Erim           D573785-4 Pi Vila1                        { -2 } (965-4) [5532] -    -  - 801 9  VNgC M1 V K0 V      
+1202 Anghurr        D4308AA-7 De Ph Na Po Vila1               { -2 } (A76+1) [A679] -    C  - 520 9  VNgC K9 V           
+1203 Angvae         C422377-9 He Lo Po Varg5 Vila1            { -1 } (C21-1) [3259] -    -  - 834 14 VNgC F3 V K0 V      
+1206 Kummus         C434520-9 Ni Vila1                        { -1 } (943-5) [1414] -    V  - 702 8  ZiSi M1 V           
+1208 Vhodan         A758A8A-D Hi Cp Vila1                     { 3 }  (H9F+5) [CD7F] -    -  - 123 11 ZiSi G1 V K0 IV     
+1309 Enpar Konal    E57778A-6 Ag Pi Vila1                     { -1 } (966+1) [9678] -    -  - 121 7  ZiSi K8 V           
+1403 Deraan         B426649-C Ni Vila1                        { 1 }  (955+2) [776D] -    -  - 210 7  VNgC M2 V           
+1405 Diiron         B89A8AA-C Wa Ph Pi Pz Vila1               { 2 }  (E7C+4) [AA7E] -    -  A 604 10 ZiSi G3 V           
+1406 Timat          B98A779-9 Wa Ri Vila1                     { 3 }  (C6C+4) [8A6A] -    KV - 921 12 ZiSi M0 V           
+1407 Guusimka       E539A77-C Hi Vila1                        { 1 }  (E9C+1) [AB5C] -    -  - 411 9  ZiSi M0 V           
+1408 Maran          B552A78-E Hi Po Vila1                     { 3 }  (G9F+3) [AD5E] -    N  - 322 8  ZiSi M1 V           
+1410 Zentove        C8A3587-9 Fl Ni Vila2                     { -1 } (943-1) [5459] -    V  - 720 10 ZiSi K3 V G4 V      
+1505 Odinaga        A2016A9-C Ic Va Ni Na Vila1               { 1 }  (B55+2) [776D] -    -  - 203 10 ZiSi M0 V M5 V      
+1509 Audhumla       A98A400-E Wa Ni Vila2                     { 1 }  (734-3) [1519] -    -  - 201 9  ZiSi M1 V G1 V      
+1604 Gamgilebo      B000756-B As Va Na Pi Vila1               { 2 }  (C6C+1) [694A] -    -  - 212 11 NaVa F4 IV M1 V M1 V
+1606 Dannar         C2006A8-A Va Ni Na Vila1                  { 0 }  (A54+1) [665A] -    -  - 820 15 ZiSi F6 V M3 V      
+1608 Riinel         E746651-7 Ni Ag Vila1                     { -2 } (852-5) [2413] -    -  - 601 11 ZiSi M3 V           
+1609 Sakkuum        C3107AB-A Na Pi Vila2                     { 1 }  (A6A+3) [987C] -    V  - 701 10 ZiSi M1 V           
+1701 Taksarrgh      B624697-A Ni Varg4 Vila2                  { 1 }  (955+1) [675A] -    -  - 710 8  VNgC M1 V           
+1703 Dathsuts       C310200-A Lo Varg3 Vila2                  { 0 }  (511-4) [1215] -    -  - 901 8  VNgC F7 V M0 V      
+1704 Rronaetuts     D424142-7 Lo Varg6 Vila2                  { -3 } (301-5) [1113] -    -  - 120 10 VNgC M1 V           
+1705 Ugarun         C7C27A8-9 Fl He Vila2                     { 0 }  (B69+1) [7759] -    -  - 402 7  VNgC G8 V           
+1708 Zelaklaka      C7B2300-B Fl He Lo Vila2                  { 0 }  (621-4) [1316] -    V  - 301 8  ZiSi M2 V M2 V      
+1709 Zigaadig       B541389-B He Lo Po Vila2                  { 1 }  (A21+2) [446C] -    -  - 523 9  ZiSi G9 V K6 V      
+1710 Tollori        B884536-9 Ni Ag Pr Vila2                  { 2 }  (846+1) [4748] -    KV - 501 7  ZiSi M3 V           
+1801 Newcastle      C567769-8 Ag Ri O:1903Vila2               { 1 }  (B69+2) [8869] -    -  - 802 8  VNgC M2 V           
+1802 Zannokh        B545235-8 Lo Vila2                        { -1 } (611-3) [1136] -    -  - 920 13 VNgC G8 V           
+1803 Ronni          C645576-9 Ni Ag (Ronnin) Vila2            { 0 }  (B44-1) [4548] -    -  - 522 9  VNgC G7 V           
+1804 Kashiin        B54089E-8 De He Ph Pi Po Vila3            { 0 }  (C78+4) [C89C] -    K  - 620 12 VNgC M2 V M8 V      
+1807 Ranilson       C999421-A Ni Vila2                        { 0 }  (733-4) [1416] -    V  - 301 10 ZiSi K1 V G5 V      
+1810 Eshu           D560100-8 De Lo Vila2                     { -3 } (701-5) [1113] -    V  - 322 9  ZiSi K3 V           
+1901 Ghurrllekh     C560558-A De Ni Pr Vila2                  { 0 }  (944+1) [555A] -    C  - 120 7  VNgC M3 V           
+1903 Gemid          A423979-F Hi Na In Po Vila2               { 4 }  (H8G+5) [AD6G] -    K  - 724 10 VNgC K0 V           
+1904 Daama          B576538-A Ni Ag Vila2                     { 2 }  (846+2) [575A] -    -  - 401 8  VNgC M2 V K4 V      
+1906 Envar          D9C5333-9 Fl Lo Vila2                     { -2 } (621-5) [1126] -    V  - 701 8  ZiSi M2 V           
+1907 Kakkin         B423333-C Lo Po Vila2                     { 1 }  (721-2) [1429] -    -  - 402 9  ZiSi G8 V           
+1909 Nashazi        A300211-F Va Lo Vila3                     { 1 }  (611-3) [131B] -    -  - 120 8  ZiSi M2 III F7 IV   
+2005 Gadushan       C536488-A Ni Vila2                        { 0 }  (733+1) [445A] -    V  - 510 10 ZiSi M4 V M5 V      
+2006 Niitomok       C552595-9 Ni Po Vila3                     { -1 } (843-3) [3437] -    -  - 201 9  ZiSi M2 V           
+2007 Kaaka          C898662-8 Ni Ag Cy An O:2205 Vila2        { -1 } (953-5) [2514] -    V  - 901 7  ZiSi F7 V M8 V      
+2008 Morimur        C550AAE-C De Hi Po Fo Vila2               { 2 }  (G9D+5) [EC9G] -    -  R 113 14 ZiSi M0 V           
+2101 Miiko Belt     C000234-9 As Va Lo Vila1                  { -1 } (611-3) [1137] -    -  - 820 7  VNgC F1 V           
+2103 Hteh Hut       A000546-E As Va Ni Vila2                  { 1 }  (945+1) [464D] -    -  - 811 8  CsIm K7 V M5 V      
+2105 Ninnigam       C9D57A6-9 Vila2                           { 0 }  (A69-1) [6748] -    V  - 710 13 ZiSi M1 V           
+2106 Hellvaplace    DAB5423-8 Fl Ni Vila2                     { -3 } (731-5) [1125] -    -  - 901 10 ZiSi M2 V G2 V      
+2107 Sadniben       C778978-6 Hi In Vila2                     { 1 }  (B89+1) [9A56] -    V  - 204 15 ZiSi M1 V           
+2203 Angvae         C657610-8 Ga Ni Ag Vila3                  { -1 } (A53-5) [1513] -    C  - 720 12 NaVa M2 V           
+2205 Anarsi         B7479EA-C Hi In Fo Vila2                  { 4 }  (D8F+5) [BD7E] -    -  R 920 15 ZiSi G3 V M3 V      
+2208 Kuzashamir     E546853-7 Ph Pa Pi Vila2                  { -2 } (A76-5) [5624] -    -  - 520 10 ZiSi M3 V           
+2210 Deglaraarbiis  E737725-7 Vila2                           { -2 } (966-4) [5535] -    -  - 312 6  ZiSi K2 V G4 V K4 V 
+2301 Knaeghzoka     B4317A6-B Na Po Vila1                     { 2 }  (A6C+1) [694A] -    -  - 401 7  CsIm M1 V M1 V      
+2306 Nelak          C64A6AA-A Wa Ni Da Vila2                  { 0 }  (954+2) [867C] -    -  A 110 9  ZiSi M0 V           
+2308 Bolziin        B310212-D Lo Vila3                        { 1 }  (911-3) [1319] -    K  - 914 14 ZiSi M3 V           
+2309 Moribur        C550650-9 De Ni Po Vila2                  { -1 } (A53-5) [1514] -    -  - 920 13 ZiSi M2 V           
+2310 Barshun        B510683-B Ni Na Vila2                     { 1 }  (A55-2) [3728] -    -  - 620 12 ZiSi F8 V M8 V      
+2402 Kfoerudzo      B559353-D Lo Vila2                        { 1 }  (821-2) [142A] -    -  - 921 14 NaVa M1 V           
+2406 Derekam        C5468CB-8 Ph Pa Pi Fo Vila2               { -1 } (C77+1) [A77A] -    -  R 120 10 ZiSi K6 V           
+2407 Gida           E200265-9 Va Lo Re O:2409 Vila2           { -2 } (511-4) [1137] -    -  - 810 10 ZiSi M3 V           
+2408 Shabii         B854610-A Ni Ag Vila3                     { 2 }  (956-2) [1815] -    -  - 301 9  ZiSi M1 V G9 V      
+2409 Sardiika       A54467B-C Ni Ag Vila2                     { 3 }  (957+5) [897E] -    KV - 210 6  ZiSi F9 V           
+2410 Karamursel     C438235-A Lo Vila2                        { 0 }  (611-2) [1238] -    V  - 520 15 ZiSi K6 V           
+2501 Khugan         B623520-A Ni Po Vila1                     { 1 }  (C45-3) [1615] -    C  - 623 11 NaVa M0 V M1 V      
+2502 Rhodes         B413534-C Ic Ni Vila1                     { 1 }  (945-1) [363A] -    K  - 902 10 CsIm F0 III M5 V    
+2507 Shunisar       D556502-8 Ni Ag Vila2                     { -2 } (842-5) [1314] -    -  - 301 8  ZiSi M3 V M6 V      
+2508 Nii            E42558C-7 Ni Da Vila2                     { -3 } (741+1) [828A] -    -  A 110 14 ZiSi M1 V           
+2602 Daztsoun       C556330-9 Lo Vila1                        { -1 } (721-5) [1214] -    -  - 911 11 V17D F7 V           
+2603 Kaengtsaelzon  B100857-A Va Ph Na Pi Varg8 Vila2         { 2 }  (B7B+2) [8A5A] -    -  - 201 8  V17D M3 V M3 V      
+2604 Fongknoe       C300877-8 Va Ph Na Pi Vila2               { -1 } (B77-1) [8758] -    -  - 801 10 V17D M0 V           
+2605 Raltaedz       B430264-D De Lo Po Re O:2205 Vila2        { 1 }  (811-1) [133B] -    -  - 504 15 V17D M1 V           
+2610 Malokh         E57167B-6 He Ni Vila1                     { -3 } (851-1) [8378] -    -  - 801 10 ZiSi F8 V M2 V      
+2804 Ongvaturr      B989742-7 Ri Vila1                        { 1 }  (969-3) [3813] -    -  - 402 9  V17D M3 V           
+2806 Paval          B581212-B Lo Vila2                        { 1 }  (A11-3) [1317] -    K  - 724 15 ZiSi M3 V           
+2808 Spinport       C575A84-C Hi In Vila1                     { 3 }  (E9D+1) [8D3A] -    V  - 820 15 ZiSi M2 V           
+2905 Zupilak        D553353-8 Lo Po Vila1                     { -3 } (C21-5) [1125] -    -  - 634 10 V17D K8 V           
+2907 Akkunat        C878501-A Ni Ag Vila1                     { 1 }  (845-3) [1616] -    V  - 101 13 ZiSi M2 V K8 V      
+2909 Goobsfol       D544200-8 Lo Vila1                        { -3 } (911-5) [1113] -    V  - 623 9  ZiSi M2 V           
+3002 Ksuerrgh       D42788D-8 Ph Pi Vila1                     { -2 } (F76+2) [C69C] -    C  - 914 16 V17D M1 V           
+3003 Khughfudz      E9995AC-8 Ni Vila1                        { -3 } (941+1) [828B] -    C  - 220 12 V17D M2 V           
+3004 Shupin         A511375-B Ic Lo Vila1                     { 1 }  (C21-1) [1439] -    -  - 434 17 V17D M1 V           
+3006 Mukata         B310456-E Ni Da Vila1                     { 1 }  (734+1) [354D] -    -  A 101 6  ZiSi F0 V M3 V      
+3008 Shishaldin     D420652-9 De He Ni Na Po Vila1            { -2 } (B52-5) [2415] -    V  - 103 12 ZiSi M0 V           
+3106 Arga           C300999-C Va Hi Na In Vila2               { 3 }  (C8E+4) [AC6D] -    V  - 910 8  ZiSi M1 V M8 V      
+3107 Theton         BABA653-C Fl Ni Cp Vila1                  { 1 }  (955-2) [3729] -    K  - 510 4  ZiSi M0 V K1 V      
+3201 Thoegzknaedz   C676532-9 Ni Ag Vila1                     { 0 }  (A44-4) [1515] -    C  - 603 7  V17D M2 V           
+3202 Vutsarrgh      D665987-5 Ga Hi Pr Vila1                  { -1 } (B87-1) [9855] -    -  - 720 9  V17D M0 V M8 V      
+3206 Argonos        D89A235-8 Wa Lo (minor) Vila1             { -3 } (611-5) [1136] -    -  - 620 7  ZiSi M0 V           
+3208 Sardia         D436554-A Ni Vila1                        { -1 } (D43-3) [3438] -    -  - 433 11 ZiSi K6 V           
+3209 Veppim         E684524-7 Ni Ag Pr Vila1                  { -2 } (742-4) [3335] -    -  - 704 11 ZiSi M2 V           
+3210 Tasho          E425300-A Lo Vila1                        { -1 } (921-5) [1215] -    -  - 722 13 ZiSi K1 IV          
+0211 Giikur         A689521-C Ni Pr Vila1                     { 1 }  (845-3) [1618] -    K  - 910 8  ZiSi M2 V M9 V      
+0311 Omero          A430320-F De Lo Po Vila1                  { 1 }  (921-3) [141A] -    K  - 822 13 ZiSi M3 V G8 V      
+0619 Lalaki         A9B4785-D Fl Vila0                        { 2 }  (B6D+1) [593B] -    -  - 702 10 ZiSi M3 V           
+0711 Rishiin        C539332-B Lo Vila1                        { 0 }  (621-4) [1317] -    V  - 610 14 ZiSi M2 V M7 V      
+1011 Iren           A8C389E-C Fl Ph Vila3                     { 2 }  (F7C+5) [CA9G] -    K  - 814 10 ZiSi K7 V M3 V      
+1012 Askhu          C554120-8 Lo Vila2                        { -2 } (501-5) [1113] -    -  - 402 9  ZiSi M0 V G8 V      
+1112 Vallae         A897788-A Ag Pi An Vila2                  { 3 }  (A6C+3) [7A5A] -    -  - 810 13 ZiSi F3 V           
+1113 Thogho         C898669-8 Ni Ag O:1112 Vila2              { -1 } (A53+1) [7569] -    -  - 920 11 ZiSi M3 V           
+1114 Gukhaga        A877576-D Ni Ag Vila2                     { 2 }  (846+1) [474C] -    -  - 310 17 ZiSi G4 V M6 V      
+1116 Darmagu        B412312-D Ic Lo Vila3                     { 1 }  (621-3) [1419] -    -  - 901 11 ZiSi M3 V K5 V      
+1117 The Uris Belt  B000464-E As Va Ni Re Mr Vila2            { 1 }  (834-1) [253C] -    K  - 911 6  ZiSi M1 V K5 V      
+1119 Daku           C432620-A Ni Na Po Vila2                  { 0 }  (C54-4) [1615] -    V  - 804 8  ZiSi K2 V           
+1120 Ideshe         B969657-B Ni Ri Vila2                     { 2 }  (A56+2) [685B] -    K  - 920 10 ZiSi M1 V G6 V      
+1211 Gagzoe         A585420-C Ni Pa Vila2                     { 1 }  (834-3) [1517] -    -  - 602 9  ZiSi M2 V M3 V      
+1215 Siruga         C100559-D Va Ni Vila2                     { 0 }  (844+1) [656E] -    -  - 201 13 ZiSi M0 V K3 V      
+1217 Estoff         B6B6330-C Fl Lo Vila2                     { 1 }  (721-3) [1417] -    K  - 620 11 ZiSi M2 V           
+1219 Ramir          C66A322-B Wa Lo (Tagi) Vila2              { 0 }  (621-4) [1317] -    V  - 801 9  ZiSi M2 V K8 V      
+1220 Imik           C563303-A Lo Vila2                        { 0 }  (B21-3) [1327] -    V  - 624 9  ZiSi K1 V           
+1311 Kema           E100233-A Va Lo Vila2                     { -1 } (511-4) [1127] -    -  - 810 8  ZiSi M2 V           
+1312 Taksar         C432345-A Lo Po Vila2                     { 0 }  (621-2) [1338] -    -  - 110 10 ZiSi K4 V           
+1313 Hisus          C7788BF-7 Ph Pa Pi Vila2                  { -1 } (A77+4) [D7AC] -    V  - 514 12 ZiSi M0 V           
+1317 Anik           C541569-9 He Ni Po O:1519 Vila2           { -1 } (943+1) [646A] -    -  - 211 13 ZiSi M1 V           
+1319 Ganar          E200527-8 Va Ni Vila2                     { -3 } (A41-3) [5258] -    -  - 821 12 ZiSi M0 V           
+1412 Karka          C200876-8 Va Ph Na Pi Vila2               { -1 } (B77-2) [7747] -    -  - 801 13 ZiSi M0 V           
+1414 Centra         A592541-D He Ni Vila2                     { 1 }  (D45-3) [1619] -    K  - 124 16 ZiSi M1 V           
+1417 Astira         C55248C-9 Ni Po Vila2                     { -1 } (832+2) [738C] -    V  - 820 11 ZiSi M0 V           
+1515 Luunbu         E8D6255-9 Lo Da Vila2                     { -2 } (511-4) [1137] -    -  A 810 13 ZiSi M2 V           
+1516 Duam           E564869-6 Ph Pa Ri O:1519 Vila2           { -1 } (A76+1) [9767] -    -  - 710 11 ZiSi M1 V           
+1519 Kagamira       B577A83-E Hi In Cp Vila2                  { 4 }  (K9G+1) [7E2B] -    K  - 525 10 ZiSi G4 V           
+1520 Shulishu       A55259B-D Ni Po Da Vila3                  { 1 }  (845+3) [767F] -    -  A 410 10 ZiSi M0 V K1 V      
+1612 Ersii          E561431-7 Ni Vila2                        { -3 } (631-5) [1113] -    -  - 210 12 ZiSi F6 V           
+1619 Midku          B764585-9 Ni Ag Pr Vila2                  { 1 }  (845-1) [3637] -    K  - 110 10 ZiSi M3 V           
+1716 Enaa           B300859-B Va Ph Na Pi Vila2               { 2 }  (C7C+3) [9A6C] -    K  - 402 9  ZiSi M2 V           
+1717 Vland          A967A9A-F Hi Cx [Vilani] Vila3            { 3 }  (D9F+5) [CD7H] -    K  - 310 7  ZiSi F8 V           
+1718 Kirma          A797111-D Lo Vila3                        { 1 }  (A01-3) [1219] -    K  - 725 11 ZiSi G8 V K2 V      
+1719 Sazisi         E586720-6 Ag Ri Vila2                     { 0 }  (967-4) [2711] -    -  - 703 7  ZiSi M0 V M2 V      
+1811 Anaam          C424753-B Pi Vila2                        { 1 }  (A6B-2) [4828] -    -  - 510 11 ZiSi G1 V           
+1813 Khusher        C646754-9 Ag Pi Vila2                     { 1 }  (D6A-1) [5837] -    V  - 722 11 ZiSi G5 V G9 V      
+1816 Shinla         C5608A9-8 De Ph Ri Vila2                  { 0 }  (H78+1) [9869] -    -  - 934 16 ZiSi K2 V M9 V      
+1817 Tauri          A430998-F De Hi Na Po Vila3               { 3 }  (D8F+3) [9C5F] -    -  - 420 7  ZiSi K3 V           
+1819 Dusu           C9E4487-A Ni Vila2                        { 0 }  (833+1) [445A] -    -  - 520 6  ZiSi F3 V           
+1820 Kha            A86A642-D Wa Ni Ri Vila2                  { 2 }  (E56-2) [2819] -    -  - 824 11 ZiSi K6 V           
+1915 Giinam         C565303-A Lo Vila2                        { 0 }  (921-3) [1327] -    V  - 304 14 ZiSi M3 V           
+1916 Kipii          B430222-D De Lo Po Vila2                  { 1 }  (611-3) [1319] -    K  - 202 8  ZiSi M3 V           
+1918 Kusheggi       E596778-5 Ag Pi Vila2                     { -1 } (966-1) [7655] -    -  - 420 7  ZiSi F8 V           
+1919 Khula          B575A77-E Hi In Di(Khulans) Vila2         { 4 }  (D9G+4) [AE5E] -    K  - 510 10 ZiSi M0 V           
+1920 Inkha          B797442-B Ni Pa Vila2                     { 1 }  (734-3) [1517] -    -  - 310 9  ZiSi M0 V M4 V      
+2013 Isbudin        C9C5984-B Fl Hi In Vila2                  { 3 }  (G8E+1) [7C39] -    -  - 623 8  ZiSi F6 V M7 V      
+2016 Zurrian        C563536-9 Ni Pr Vila2                     { -1 } (943-2) [4448] -    V  - 402 10 ZiSi M1 V M1 V      
+2017 Tahaver        B769A78-B Hi (Tahavi) Vila2               { 3 }  (D9E+3) [AD5B] -    -  - 110 13 ZiSi M2 V           
+2019 Lobode         E554666-5 Ni Ag O:1919 Vila2              { -2 } (852-3) [5444] -    -  - 510 8  ZiSi M2 V M3 V      
+2020 Shushguum      B522577-B He Ni Po Vila2                  { 1 }  (D45+1) [565B] -    K  - 924 13 ZiSi G6 V           
+2111 Flire          B779A77-E Hi In Vila2                     { 4 }  (H9G+3) [AE5E] -    -  - 423 9  ZiSi K8 V           
+2113 Ishala         C866751-9 Ga Ag Ri Vila2                  { 2 }  (D6B-2) [3915] -    -  - 404 13 ZiSi M1 V           
+2115 Zedu Gisla     E533587-6 Ni Po Vila2                     { -3 } (741-3) [5256] -    -  - 701 6  ZiSi M1 V M2 V      
+2117 Uri            A313632-E Ic Ni Na Vila2                  { 1 }  (A55-3) [271A] -    -  - 220 12 ZiSi F9 V           
+2120 Pyam           B799385-C Lo Vila2                        { 1 }  (721-1) [143A] -    K  - 320 17 ZiSi M1 V           
+2211 Irila          B568403-A Ni Pa Vila2                     { 1 }  (B34-2) [1527] -    K  - 523 8  ZiSi M1 V           
+2216 Ashbakha       A672500-B He Ni Vila2                     { 1 }  (845-3) [1616] -    K  - 201 14 ZiSi M2 V K9 V      
+2314 Dangasha       C550664-8 De Ni Po O:2616 Vila2           { -2 } (952-4) [4436] -    -  - 801 6  ZiSi M3 V           
+2316 Kagush         A736300-A Lo Vila2                        { 1 }  (B21-3) [1415] -    -  - 724 9  ZiSi K6 V           
+2319 Shudi          A7669BB-A Ga Hi Pr Fo Vila2               { 3 }  (J8D+5) [BC7C] -    -  R 525 12 ZiSi G6 V G2 V      
+2320 Gidapisek      B200623-C Va Ni Na Vila2                  { 1 }  (955-2) [3729] -    -  - 810 11 ZiSi K7 V           
+2412 Ansin          E563A95-A Hi Vila2                        { 1 }  (E9B-1) [8B38] -    -  - 820 8  ZiSi K2 V K2 V      
+2416 Liisurkhish    A562788-C Ri Vila2                        { 3 }  (A6D+3) [7A5C] -    -  - 810 16 ZiSi K0 V M2 V      
+2419 Nasha          E200201-9 Va Lo Vila2                     { -2 } (511-5) [1115] -    -  - 710 11 ZiSi M0 V M2 V      
+2511 Iigshuren      B66A766-C Wa Ri O:2409 Vila1              { 3 }  (E6D+2) [6A4B] -    -  - 223 11 ZiSi G5 V           
+2512 Imziinune      B62737A-C Lo Vila1                        { 1 }  (721+3) [547E] -    K  - 720 9  ZiSi M1 V           
+2513 Shiigus        A5717CB-B He Pi Cp Vila1                  { 2 }  (A6C+4) [997D] -    K  - 101 15 ZiSi F5 V M9 V      
+2515 Gookir         B9D787C-A Ph Vila1                        { 2 }  (E7B+5) [BA8D] -    K  - 122 10 ZiSi K8 V           
+2518 Khe            E433425-8 Ni Po Vila1                     { -3 } (731-5) [2136] -    -  - 201 14 ZiSi M2 V           
+2519 Muukakam       B52368C-A Ni Na Po Da Vila1               { 1 }  (A55+4) [978D] -    -  A 511 7  ZiSi M1 V           
+2520 Ma             C585200-A Lo Vila2                        { 0 }  (511-4) [1215] -    -  - 710 13 ZiSi M0 V M0 V      
+2611 Kimii          D403750-8 Ic Va Na Pi Vila1               { -2 } (A66-5) [2513] -    -  - 901 9  ZiSi K2 V M3 V      
+2612 Gaska Khiin    C544577-9 Ni Ag Vila1                     { 0 }  (C44+1) [5559] -    V  - 823 12 ZiSi M1 V           
+2613 Kusu           A541676-B He Ni Po Vila1                  { 1 }  (A55+1) [574A] -    -  - 202 9  ZiSi K3 IV          
+2615 Malta          B000266-C As Va Lo O:2616 Vila1           { 1 }  (611+1) [134B] -    V  - 611 11 ZiSi K6 V M3 V      
+2616 St. George     B7C59BB-D Fl Hi In Fo Vila1               { 4 }  (D8G+5) [BD7F] -    -  R 820 12 ZiSi G5 IV          
+2618 Dudid          B510526-A Ni Vila1                        { 1 }  (845+1) [4649] -    V  - 501 8  ZiSi M0 V M0 V      
+2620 Mennoral       B858723-9 Ag Vila2                        { 3 }  (C6C+1) [4A26] -    KV - 421 10 ZiSi K3 V           
+2713 Aanshi         BA8AA97-C Oc Hi Vila2                     { 3 }  (D9E+3) [AD5C] -    V  - 401 10 ZiSi M3 V           
+2716 Eriston        C69A144-9 Wa Lo Vila1                     { -1 } (501-3) [1137] -    -  - 420 14 ZiSi G8 V G7 V      
+2812 Alkhaas        E99769D-6 Ni Ag Fo Vila2                  { -2 } (852+2) [A49A] -    -  R 133 9  ZiSi M1 V M2 V      
+2815 Karmanidora    C310330-B Lo Vila1                        { 0 }  (721-4) [1316] -    -  - 702 9  ZiSi K4 V           
+2816 Faranidon      B6569AD-9 Ga Hi Fo Vila1                  { 2 }  (C8C+5) [DB9D] -    -  R 910 12 ZiSi M0 V           
+2818 Tazaris        C9B4688-9 Fl Ni Vila1                     { -1 } (A53-1) [6559] -    V  - 302 12 ZiSi M3 V           
+2820 Anzalits       EA9A210-9 Oc Lo Vila2                     { -2 } (B11-5) [1114] -    -  - 734 16 ZiSi M3 V M7 V      
+2911 Naalkin        D555565-7 Ni Ag O:2914 Vila1              { -2 } (742-4) [3335] -    -  - 701 6  ZiSi K3 V M3 V      
+2912 Damakho        A998574-D Ni Ag Vila1                     { 2 }  (C46+1) [373B] -    -  - 223 8  ZiSi M0 V           
+2914 Mimere         B9B6999-D Fl Hi In Vila2                  { 5 }  (C8H+5) [AE6E] -    KV - 510 12 ZiSi M1 V M2 V      
+2915 Lormiza        B435652-D Ni Vila1                        { 1 }  (955-3) [2719] -    -  - 910 12 ZiSi M0 V M6 V      
+2916 Iizmarna       B427421-B Ni Vila1                        { 1 }  (834-3) [1517] -    V  - 820 12 ZiSi M3 V           
+2918 Beroni         C563777-8 Ri Vila1                        { 0 }  (A68+1) [7758] -    -  - 601 10 ZiSi M1 V M5 V      
+2919 Alanidon       D554423-7 Ni Pa Vila1                     { -3 } (631-5) [1124] -    V  - 120 6  ZiSi M0 V M1 V      
+2920 Sidenis        D31067B-8 Ni Na Vila1                     { -3 } (A51-1) [837A] -    V  - 920 16 ZiSi K8 V M1 V      
+3011 Lourer         E594A8A-A Hi In Vila1                     { 2 }  (D9C+4) [CC7C] -    -  - 810 12 ZiSi M3 V M8 V      
+3014 Zaan           C557462-9 Ni Pa O:2914 Vila1              { -1 } (A32-5) [1315] -    V  - 904 7  ZiSi G5 V           
+3018 Sikal          C545644-8 Ni Ag Vila1                     { -1 } (953-3) [4536] -    V  - 810 11 ZiSi M1 V M1 V      
+3019 Braldini       C897736-8 Ag Pi Vila1                     { 0 }  (B68-1) [6747] -    -  - 520 10 ZiSi M2 V M6 V      
+3020 Trilorn        C100858-C Va Ph Na Pi Vila1               { 1 }  (B7B+1) [895C] -    -  - 510 11 ZiSi K3 V M5 V      
+3111 Kalanuu        D754544-7 Ni Ag Vila1                     { -2 } (742-4) [3335] -    -  - 624 9  ZiSi M1 V           
+3115 Dusuureg       C404466-B Ic Va Ni O:3215 Vila1           { 0 }  (A33-1) [344A] -    V  - 622 10 ZiSi F9 V K6 V      
+3116 Kirlasesh      C546684-8 Ni Ag Vila1                     { -1 } (D53-3) [4536] -    -  - 923 8  ZiSi G5 V           
+3117 Altman         A561674-B Ni Ri Vila1                     { 2 }  (956+1) [4839] -    K  - 710 4  ZiSi K6 V           
+3119 Aarkhiin       D57769C-5 Ni Ag Vila2                     { -2 } (852+1) [9488] -    V  - 125 13 ZiSi M1 V           
+3211 Urkimgar       C577400-A Ni Pa Vila1                     { 0 }  (733-4) [1415] -    -  - 410 11 ZiSi M1 V           
+3212 Amnukun        B41097B-E Hi Na In Vila1                  { 4 }  (D8G+5) [BD7G] -    -  - 111 12 ZiSi M1 V           
+3213 Ami            E567500-8 Ni Ag Pr Vila1                  { -2 } (942-5) [1313] -    -  - 202 15 ZiSi M1 V M3 V      
+3214 Khunimmam      E9B7200-8 Fl Lo Vila1                     { -3 } (611-5) [1113] -    -  - 402 13 ZiSi M2 V           
+3215 Shaia          B64A998-E Wa Hi In Vila2                  { 4 }  (C8G+4) [9D5E] -    -  - 110 12 ZiSi M1 V           
+3216 Kigirgam       D561444-6 Ni Vila1                        { -3 } (631-5) [2134] -    -  - 113 13 ZiSi M1 V           
+3218 Gisharu        D556513-6 Ni Ag Vila2                     { -2 } (742-5) [2323] -    V  - 310 8  ZiSi M1 V M7 V      
+0221 Keshiil        C530833-9 De Ph Na Po Vila0               { 0 }  (C79-3) [5826] -    -  - 220 9  ZiSi M2 V           
+0422 Niirka         A300757-F Va Na Pi Vila0                  { 2 }  (D6E+2) [795F] -    -  - 922 15 ZiSi M9 III D       
+0430 Khulekii       E677899-6 Ph Pa Pi Vila2                  { -2 } (A75-1) [9667] -    -  - 222 11 ZiSi G3 V           
+0530 Pirrom         A884589-D Ni Ag Pr Vila1                  { 2 }  (946+3) [676E] -    K  - 511 14 ZiSi G2 V           
+0622 Beshe          E8B8888-8 Fl Ph Vila0                     { -2 } (G76-2) [8658] -    -  - 115 12 ZiSi M2 V           
+0630 Giraran        D555242-6 Lo Vila1                        { -3 } (411-5) [1112] -    -  - 524 10 ZiSi K3 V           
+0921 Ganiir         C423320-B Lo Po Vila0                     { 0 }  (A21-4) [1316] -    -  - 105 16 ZiSi M3 V M5 V      
+0923 Gazzum         B549655-C Ni Vila0                        { 1 }  (A55-1) [473A] -    K  - 720 10 ZiSi M2 V M2 V      
+0924 Shugandarsii   E745322-7 Lo Vila0                        { -3 } (521-5) [1113] -    -  - 401 8  ZiSi M2 V           
+0927 Havland        C7939CD-A Hi In Fo Vila0                  { 3 }  (C8D+5) [DC9E] -    -  R 301 8  ZiSi M2 V M0 V      
+0930 Gokodeyo       E5818AA-4 Ph Ri Pz Vila0                  { -1 } (A75+1) [A776] -    -  A 110 16 ZiSi F3 V M0 V      
+1028 Apurshish      C555A64-9 Hi O:0927 Vila0                 { 1 }  (H9B-1) [8B37] -    -  - 623 17 ZiSi G8 V           
+1128 Shakshim       CAA558B-A Fl Ni Vila0                     { 0 }  (844+2) [757C] -    V  - 301 8  ZiSi M1 V M4 V      
+1227 Sumabaal       C432436-9 Ni Po Vila0                     { -1 } (732-2) [3348] -    V  - 501 11 ZiSi M0 V M3 V      
+1323 Robbuun        A524520-E Ni Vila0                        { 1 }  (945-3) [1619] -    V  - 902 13 ZiSi K0 V K7 V      
+1523 Ilma           D510744-7 Na Pi Di(Qiceteu) Vila1         { -2 } (966-4) [5535] -    V  - 601 9  ZiSi M0 V           
+1530 Bakog          A8D9351-F Lo Vila1                        { 1 }  (A21-3) [141B] -    V  - 832 12 ZiSi G8 V           
+1623 Etsur          D410552-A Ni Vila1                        { -1 } (943-5) [1416] -    V  - 720 7  ZiSi M4 III K3 V    
+1624 Zushar         C631854-A Ph Na Po Vila1                  { 1 }  (C7A-1) [6938] -    -  - 811 14 ZiSi M2 V K9 V      
+1625 Bashimus       A542568-D He Ni Po Mr Vila1               { 1 }  (945+1) [565D] -    K  - 320 12 ZiSi M4 V           
+1626 Lalazim        E8C4454-9 Fl Ni Vila1                     { -2 } (731-4) [2237] -    -  - 410 10 ZiSi M1 V           
+1628 Akumid         A867457-E Ga Ni Pa Cp Vila1               { 1 }  (B34+1) [455E] -    -  - 923 14 ZiSi K0 V           
+1630 Kanoka         E7B25A7-8 Fl He Ni Vila1                  { -3 } (A41-3) [5258] -    -  - 603 12 ZiSi M2 V           
+1722 Asanik         D554356-8 Lo Vila2                        { -3 } (921-4) [2147] -    -  - 204 16 ZiSi G6 V G4 V      
+1725 Kalimgar       B799667-B Ni O:1825 Vila1                 { 2 }  (E56+2) [685B] -    W  - 824 13 ZiSi K8 V           
+1726 Gunavarum      E553551-8 Ni Po Vila1                     { -3 } (B41-5) [1214] -    -  - 304 14 ZiSi K0 V K1 V      
+1728 Ashok          B698100-A Lo Vila2                        { 1 }  (501-3) [1215] -    K  - 920 16 ZiSi G0 V           
+1729 Kargem         E310654-9 Ni Na Vila2                     { -2 } (A52-4) [4437] -    -  - 420 5  ZiSi G8 V M1 V      
+1730 Lurkha         B6748AA-A Ph Pa Pi An Vila2               { 2 }  (C7B+4) [AA7C] -    V  - 120 9  ZiSi F7 V           
+1821 Iikhok         B43449A-D Ni Vila3                        { 1 }  (C34+3) [657F] -    -  - 724 16 ZiSi M2 V           
+1822 Kasear         A5479AE-E Hi In Cp Fo Vila2               { 4 }  (D8G+5) [DD9J] -    -  R 220 11 ZiSi G5 V M2 V      
+1825 Karfir         A753A66-F Hi Po MrVila1                   { 3 }  (H9F+2) [9D4E] -    -  - 923 12 ZiSi K4 V           
+1830 Sindal         C9B8332-A Fl Lo Vila2                     { 0 }  (621-4) [1316] -    -  - 801 13 ZiSi G6 V M3 V      
+1923 Sagida         C423965-C Hi Na In Po Mr Vila2            { 3 }  (D8E+1) [7C3A] -    V  - 802 14 ZiSi M0 V M0 V      
+1928 Nimmer         B420100-D De He Lo Po Vila2               { 1 }  (901-3) [1218] -    K  - 324 9  ZiSi G4 V           
+1929 Sakhem         B404474-D Ic Va Ni Vila2                  { 1 }  (734-1) [253B] -    -  - 710 7  ZiSi M0 V           
+1930 Ziirkago       A878654-C Ni Ag Vila2                     { 3 }  (C57+1) [493A] -    KV - 613 7  ZiSi M0 V           
+2022 Emrim          D100442-9 Va Ni Vila2                     { -2 } (731-5) [1215] -    V  - 501 15 ZiSi M0 V           
+2023 Zhattar        B88A240-B Wa Lo Vila2                     { 1 }  (511-3) [1316] -    -  - 410 9  ZiSi M3 V           
+2027 Gaarluzargu    B775799-8 Ag Pi Vila3                     { 1 }  (B69+2) [8869] -    V  - 820 7  ZiSi M0 V M1 V      
+2029 Gabik          B512100-D Ic Lo Vila2                     { 2 }  (901-2) [1318] -    KV - 833 11 ZiSi F2 V           
+2030 Duusan         B9CA65A-D Fl Ni Vila2                     { 1 }  (C55+3) [877F] -    -  - 922 13 ZiSi M3 V           
+2122 Lekkon         B540510-B De He Ni Po Vila3               { 1 }  (945-3) [1616] -    V  - 902 12 ZiSi K8 V M1 V      
+2123 Blikig         C544634-8 Ni Ag Vila2                     { -1 } (953-3) [4536] -    -  - 801 15 ZiSi K7 V M9 V      
+2124 Razzun         A572768-B He Pi Mr Vila2                  { 2 }  (A6C+2) [795B] -    K  - 910 7  ZiSi M2 V M2 V      
+2125 Shib           E799687-7 Ni Vila2                        { -3 } (851-3) [6357] -    -  - 310 7  ZiSi K2 V M2 V      
+2126 Dekhuun        B578797-A Ag Pi Vila3                     { 3 }  (B6C+3) [7A5A] -    K  - 120 13 ZiSi M3 V           
+2129 Gunnar         D000788-9 As Va Na Pi Vila2               { -1 } (A68-1) [7659] -    V  - 910 10 ZiSi M2 V           
+2221 Karlum         B57A500-E Wa Ni Vila2                     { 1 }  (945-3) [1619] -    K  - 920 10 ZiSi K2 V K5 V      
+2222 Markassar      E7788CA-4 Ph Pa Pi Fo Vila2               { -2 } (A75+1) [A676] -    -  R 923 12 ZiSi G2 V G4 V      
+2223 Gurzish        D76A326-9 Wa Lo Vila2                     { -2 } (621-3) [2148] -    V  - 401 12 ZiSi M2 V M8 V      
+2225 Iamone         C310A9A-E Hi Na In Vila3                  { 3 }  (J9F+5) [CD7G] -    V  - 624 11 ZiSi K4 V           
+2227 Zikurag        A536585-E Ni Vila2                        { 1 }  (D45-1) [363C] -    -  - 524 15 ZiSi F8 V           
+2229 Munakhiin      D2027BB-8 Ic Va Na Pi Vila2               { -2 } (A66+1) [957A] -    V  - 910 7  ZiSi K5 V           
+2321 Gikarlum       C432476-A Ni Po Vila2                     { 0 }  (C33-1) [3449] -    -  - 133 9  ZiSi M3 V           
+2322 Hefas          C775961-8 Hi In Cy Mr Vila2               { 1 }  (H8A-3) [5A14] -    V  - 615 9  ZiSi M2 V           
+2323 Zruub          E553531-7 Ni Po Vila2                     { -3 } (741-5) [1213] -    -  - 603 15 ZiSi M1 V           
+2324 Firdakh        D432451-A Ni Po Vila2                     { -1 } (832-5) [1316] -    -  - 120 14 ZiSi K9 V           
+2325 Derkhuun       E310224-9 Lo Vila2                        { -2 } (911-4) [1137] -    -  - 205 12 ZiSi F1 V K5 V      
+2328 Fharnas        D8D8A97-B Hi Vila3                        { 1 }  (D9C+1) [AB5B] -    V  - 901 9  ZiSi M0 V           
+2329 Tobrun         B400554-E Va Ni Vila2                     { 1 }  (845-1) [363C] -    -  - 410 15 ZiSi F8 V M9 V      
+2330 Umzgaa         C000311-C As Va Lo Vila3                  { 0 }  (621-4) [1318] -    -  - 710 15 ZiSi M3 V           
+2425 Martle         C54099B-A De He Hi In Po Vila3            { 3 }  (H8D+5) [BC7C] -    V  - 424 10 ZiSi M0 V           
+2426 Khanaddar      A000302-F As Va Lo Vila2                  { 1 }  (821-3) [141B] -    -  - 112 12 ZiSi K6 V M6 V      
+2429 Irgar          E420478-8 De He Ni Po Vila2               { -3 } (931-3) [4158] -    -  - 912 12 ZiSi M3 V           
+2524 Kakhashedir    B560302-C De Lo Vila1                     { 1 }  (721-3) [1418] -    -  - 102 12 ZiSi M2 V           
+2526 Daapuken       E564200-8 Lo Da Vila1                     { -3 } (511-5) [1113] -    -  A 310 12 ZiSi G8 V M1 V      
+2527 Kaple          E421656-9 He Ni Na Po Vila2               { -2 } (A52-3) [5448] -    -  - 811 11 ZiSi K9 V           
+2528 Shuurnnish     C202225-B Ic Va Lo Vila2                  { 0 }  (511-2) [1239] -    V  - 701 12 ZiSi M1 V           
+2530 Thaggesh       B6668A8-A Ga Ph Pa Ri (Thaggeshi) Vila2   { 3 }  (B7C+3) [8B5A] -    -  - 601 14 ZiSi F6 V M7 V M6 V 
+2621 Malvar         C683797-8 Ri Vila3                        { 0 }  (F68+1) [7758] -    V  - 724 12 ZiSi F8 V M3 V      
+2624 Shera          C6838AB-8 Ph Ri Vila2                     { 0 }  (D78+2) [A87A] -    V  - 603 7  ZiSi M1 V           
+2627 Taluza         D594547-5 Ni Ag Vila2                     { -2 } (742-2) [5355] -    V  - 323 13 ZiSi K6 V           
+2628 Floranus       C8B3786-9 Fl Vila2                        { 0 }  (A69-1) [6748] -    -  - 201 16 ZiSi M0 V M3 V      
+2629 Rikaan         D8D8898-7 Ph Vila3                        { -2 } (A76-2) [8657] -    V  - 710 9  ZiSi M2 V           
+2721 Nodden         B774534-B Ni Ag Vila2                     { 2 }  (846+1) [3739] -    K  - 301 12 ZiSi G6 V M0 V      
+2723 Klidon         D76388B-6 Ph Ri Vila2                     { -1 } (A76+1) [A778] -    V  - 910 4  ZiSi K7 V           
+2725 Duranus        B00037C-C As Va Lo Vila2                  { 1 }  (B21+4) [648F] -    K  - 915 16 ZiSi M1 V           
+2728 Kenash         A594677-C Ni Ag Mr Vila2                  { 3 }  (B57+5) [897E] -    D  - 121 13 ZiSi K6 V           
+2823 Tektras        C536534-9 Ni Vila2                        { -1 } (843-3) [3437] -    -  - 901 9  ZiSi M2 V M3 V      
+2824 Jana           C300963-C Va Hi Na In Cy O:3125 Vila2     { 3 }  (G8E+1) [6C29] -    V  - 723 18 ZiSi G6 V           
+2825 Arron          D424246-9 Lo An Vila2                     { -2 } (611-3) [1148] -    V  - 920 9  ZiSi F3 V           
+2826 Zafron         E575426-7 Ni Pa Vila2                     { -3 } (631-4) [3146] -    -  - 735 11 ZiSi F4 V           
+2827 Hannipur       E100979-B Va Hi Na In Vila2               { 2 }  (C8D+3) [AB6C] -    -  - 201 11 ZiSi F4 IV M2 V     
+2829 Luukon         A5779B6-C Hi In Vila2                     { 4 }  (C8F+3) [8D4B] -    K  - 601 11 ZiSi K3 V M1 V      
+2830 Lezaneraz      E547455-8 Ni Pa Vila2                     { -3 } (831-5) [2136] -    -  - 202 7  ZiSi M2 V           
+2921 Iton           CAA7565-9 Fl Ni O:3021 Vila2              { -1 } (843-3) [3437] -    -  - 901 10 ZiSi M1 V           
+2923 Zircon         C571116-8 He Lo Vila3                     { -2 } (401-3) [1147] -    V  - 410 7  ZiSi M0 V M6 V      
+2925 Kaanpush       B430424-D De Ni Po Vila2                  { 1 }  (834-1) [253B] -    K  - 820 10 ZiSi M2 V           
+2926 Sanderson      A9C4688-D Fl Ni Vila2                     { 1 }  (A55+1) [675D] -    V  - 520 9  ZiSi K9 V           
+3021 Talama         B4106A8-A Ni Na Vila2                     { 1 }  (A55+1) [675A] -    V  - 302 7  ZiSi M3 V M8 V      
+3022 Arklin         B9CA313-E Fl Lo Vila3                     { 1 }  (C21-2) [142B] -    -  - 834 12 ZiSi M3 III         
+3024 Bertrand       E200666-7 Va Ni Na O:3125 Vila2           { -3 } (851-4) [5346] -    -  - 113 9  ZiSi M1 V           
+3025 Shervan        E545785-6 Ag Pi Pz Vila2                  { -1 } (966-3) [5634] -    -  A 224 10 ZiSi G2 V K6 V      
+3029 Kamolad        C8D8355-B Lo Vila2                        { 0 }  (621-2) [1339] B    -  - 801 12 LuIm M1 V M4 V G4 V 
+3122 Ekum           E56068C-6 De Ni Ri Da Vila2               { -2 } (852+1) [9489] -    -  A 624 9  ZiSi G6 V M9 V      
+3124 Thaar          D87A79A-7 Wa Pi Vila3                     { -2 } (966+1) [9579] -    V  - 802 7  ZiSi M1 V M6 V      
+3125 Inandir        C676AE9-C Hi In Vila2                     { 3 }  (E9E+4) [BD6D] -    V  - 411 11 ZiSi K9 V M0 V      
+3126 Renbad         C568554-8 Ni Ag Pr Vila2                  { -1 } (843-3) [3436] -    -  - 410 13 ZiSi K9 V           
+3128 Xantril        B676659-B Ni Ag Vila2                     { 2 }  (A56+3) [786C] BC   N  - 520 9  LuIm M3 V           
+3129 Wimorel        C765543-8 Ga Ni Ag Pr An Di(Kolzar)Vila2  { -1 } (D43-4) [2425] BcC  -  - 224 13 LuIm F6 V           
+3130 Gamidan        CA5A454-9 Oc Ni Vila2                     { -1 } (932-3) [2337] B    -  - 512 15 LuIm M1 V G1 V      
+3221 Sadkha         B836313-C Lo Vila3                        { 2 }  (821-1) [1529] -    KV - 321 15 ZiSi G6 V           
+3222 Nemsa          E300353-A Va Lo Vila2                     { -1 } (721-4) [1227] -    -  - 920 10 ZiSi F5 V M1 V      
+3224 Anakod         A796258-E Lo Cp An Vila2                  { 1 }  (A11+1) [235E] -    -  - 124 13 ZiSi F7 V           
+3226 Eshdigi        E747325-7 Lo Da Vila2                     { -3 } (521-5) [1135] -    -  A 323 17 ZiSi K2 V K4 V      
+3228 Nirnalur       B544474-B Ni Pa Vila2                     { 1 }  (B34-1) [2539] Bc   S  - 723 9  LuIm G3 V           
+3229 Diikaras       AA9A651-F Oc Ni Vila2                     { 1 }  (A55-3) [271B] B    -  - 602 9  LuIm M2 V           
+0131 Skasputin      C763340-9 Lo Vila1                        { -1 } (B21-5) [1214] B    -  - 324 10 StIm M2 V           
+0132 Kald           C5509AB-A De Hi Po Vila1                  { 2 }  (C8C+4) [BB7C] BE   S  - 701 8  StIm M1 V M1 V      
+0134 Zanagud        E66A686-7 Wa Ni Ri Vila1                  { -2 } (852-3) [5446] BC   -  - 523 14 StIm M2 V           
+0135 Sakin          C430668-A De Ni Na Po O:0336 Vila1        { 0 }  (D54+1) [665A] B    S  - 814 10 StIm F9 V M4 V      
+0137 Shaaki         B9B4750-C Fl Vila1                        { 2 }  (B6C-2) [2917] B    N  - 620 16 StIm F1 V M1 V      
+0232 Tratami        D9C7887-9 Fl Ph Vila1                     { -1 } (F78-1) [8759] Be   S  - 323 8  StIm F7 III M2 V    
+0234 Nurrungar      A649100-F Lo Vila1                        { 2 }  (401-2) [131A] B    NS - 810 11 StIm M3 V M3 V      
+0236 Khishugii      C420534-B De He Ni Po Vila1               { 0 }  (844-2) [3539] B    S  - 510 16 StIm M0 V           
+0237 Shashim        B427698-C Ni Vila2                        { 2 }  (B56+2) [685C] B    W  - 203 12 StIm G8 V           
+0333 Paspaa         A554455-E Ni Pa Vila1                     { 1 }  (734-1) [253C] Bc   N  - 510 11 StIm K3 V G0 V      
+0335 Nadud          D97A350-9 Wa Lo Vila1                     { -2 } (721-5) [1114] B    -  - 220 13 StIm M1 V           
+0336 Parsi          A989A9C-F Hi Cp Pz Vila2                  { 3 }  (J9F+5) [DD8J] BEF  -  A 224 12 StIm K9 V           
+0338 Vanessa        E568330-7 Lo Vila1                        { -3 } (521-5) [1112] B    -  - 510 14 StIm M0 V K8 V      
+0340 Jessheim       AAC5233-E Fl Lo Vila1                     { 2 }  (B11-1) [142B] B    NS - 425 11 StIm M2 V           
+0431 Answerin       B584A85-E Hi (Answerin) Vila1             { 3 }  (E9F+1) [8D3C] -    K  - 420 10 ZiSi F7 V G0 V      
+0434 Geguru         D000432-9 As Va Ni Vila1                  { -2 } (D31-5) [1215] B    S  - 325 11 StIm K1 V           
+0435 Ganidam        D100455-B Va Ni Vila1                     { -1 } (732-3) [2339] B    -  - 501 5  StIm M2 V M5 V      
+0436 Meprim         B300136-D Va Lo Vila1                     { 1 }  (401+1) [124C] B    N  - 910 10 StIm M1 V           
+0437 Thatii         DA7A437-9 Oc Ni Vila1                     { -2 } (C31-2) [4259] B    S  - 224 11 StIm K8 V           
+0531 Seglound       D99A453-A Wa Ni Vila1                     { -1 } (832-4) [1327] -    V  - 220 14 ZiSi M1 V           
+0532 Kinswana       C310659-B Ni Na Vila1                     { 0 }  (C54+1) [766C] -    -  - 304 9  ZiSi K6 V           
+0533 Khi Tai        E668732-6 Ag Ri Vila1                     { 0 }  (967-4) [3712] -    -  - 401 9  ZiSi M3 V M3 V      
+0534 Khakkakum      C657768-8 Ga Ag O:0431 Vila1              { 0 }  (C68+1) [7758] -    -  - 221 12 ZiSi M3 V           
+0536 Fauski         A420751-E De He Na Pi Po Vila1            { 2 }  (A6D-2) [391A] BD   N  - 401 5  StIm K0 V M1 V      
+0631 Enbart         B201689-C Ic Va Ni Na Vila1               { 1 }  (A55+2) [776D] -    -  - 920 8  ZiSi M1 V           
+0633 Kamar Kurker   E554524-7 Ni Ag Vila1                     { -2 } (742-4) [3335] -    -  - 410 6  ZiSi K1 V           
+0635 Savvud         C545499-9 Ni Pa Vila2                     { -1 } (732+1) [536A] Bc   S  - 601 14 StIm M1 V           
+0637 Bood           A540520-C De He Ni Po Vila1               { 1 }  (845-3) [1617] B    -  - 410 14 StIm M0 V           
+0639 Liigima        B7C2303-D Fl He Lo Vila1                  { 1 }  (821-2) [142A] B    N  - 403 11 StIm K9 V K2 V      
+0640 Aquacade       A67A224-F Wa Lo Vila1                     { 1 }  (611-1) [133D] B    N  - 120 8  StIm M2 V           
+0732 Pirumush       E524410-8 Ni Vila2                        { -3 } (A31-5) [1113] -    -  - 622 13 ZiSi G4 V M2 V      
+0734 Kishbar        B301310-D Ic Va Lo Vila2                  { 1 }  (721-3) [1418] -    -  - 720 10 ZiSi M2 V           
+0737 Kuzey Anadolu  C50069D-9 Va Ni Na Vila2                  { -1 } (B53+3) [A59D] B    S  - 403 9  StIm K5 V K3 V      
+0738 Daglari        C310688-A Ni Na Vila1                     { 0 }  (B54+1) [665A] B    -  - 121 14 StIm M3 V           
+0739 Trabbon        D554733-5 Ag Vila1                        { -1 } (966-4) [4622] BC   -  - 620 6  StIm K7 V           
+0740 Kirov          B683A9B-D Hi Pz Vila2                     { 3 }  (D9F+5) [CD7F] BE   -  A 810 10 StIm K5 V K4 V      
+0831 Igsudi         B572320-B He Lo Vila1                     { 1 }  (721-3) [1416] -    K  - 320 10 ZiSi G4 V K6 V      
+0832 Kirlikin       C5407BD-8 De He Pi Po Vila1               { -1 } (B67+3) [B69C] -    V  - 902 12 ZiSi M2 V           
+0833 Karbarlah      D5878A8-6 Ph Pa Ri Vila1                  { -1 } (A76-1) [8756] -    -  - 210 12 ZiSi M1 V           
+0834 Khisber        B87A501-D Wa Ni Vila1                     { 2 }  (C46-2) [1719] -    KV - 523 10 ZiSi F6 V           
+0835 Zhirka         E000110-A As Va Lo Vila2                  { -1 } (401-5) [1115] -    -  - 610 12 ZiSi M2 V M9 V      
+0839 Kiimiim        B672352-C He Lo Vila1                     { 1 }  (821-3) [1418] B    -  - 803 7  StIm G2 V           
+0933 Arluk          C41198B-C Ic Hi Na In Vila1               { 3 }  (F8E+5) [BC7E] -    -  - 613 11 ZiSi M2 V           
+0934 Imdakhun       A20348D-F Ic Va Ni Da Vila1               { 1 }  (734+5) [859K] -    -  A 401 12 ZiSi G5 V M1 V      
+0938 Rhyolite       C560342-9 De Lo Vila1                     { -1 } (B21-5) [1215] B    -  - 224 9  StIm K7 V M0 V      
+0939 Gashumu        D76A65A-9 Wa Ni Ri Vila1                  { -1 } (A53+1) [857B] BC   -  - 102 5  StIm G8 V           
+1032 Umaanshar      D432566-9 Ni Po O:0933 Vila1              { -2 } (C42-3) [4348] -    V  - 823 10 ZiSi K6 V K2 V      
+1033 Komirex        C200263-9 Va Lo O:0933 Vila1              { -1 } (611-4) [1126] -    V  - 820 7  ZiSi G7 V F8 V      
+1038 Isle           E68AA87-B Wa Hi Vila1                     { 1 }  (D9C+1) [AB5B] BE   -  - 901 9  StIm K0 V M3 V      
+1131 Neegak         B537662-B Ni Cy O:1332 Vila1              { 1 }  (C55-3) [2717] -    -  - 422 9  ZiSi F8 V           
+1134 Jupset         B8C3466-B Fl Ni O:1334 Vila1              { 1 }  (B34+1) [354A] -    -  - 923 8  ZiSi M1 V           
+1135 Abalakova      C5658CD-8 Ph Pa Ri Vila1                  { 0 }  (E78+4) [C89C] -    V  - 822 10 ZiSi F5 V M3 V      
+1136 Daangiilu      A565544-D Ni Ag Pr Cp Vila1               { 2 }  (A46+1) [373B] -    -  - 703 17 ZiSi G2 V M4 V      
+1137 Usaamkirkhiir  E56456A-7 Ni Ag Pr O:1437 Vila1           { -2 } (742+1) [7379] BcC  -  - 314 13 StIm K1 V           
+1138 Chrysantheum   C4307A8-9 De Na Po Vila1                  { 0 }  (A69+1) [7759] B    S  - 401 13 StIm M1 V M0 V      
+1139 Uureg          B553859-B Ph Po Vila1                     { 2 }  (D7C+3) [9A6C] Be   -  - 412 8  StIm M2 V           
+1140 Hiroshi        C675766-6 Ag Pi O:1139 Vila1              { 0 }  (967-1) [6745] BCD  -  - 201 10 StIm K5 V M3 V      
+1232 Lekziika       C885566-9 Ga Ni Ag Pr O:1334 Vila1        { 0 }  (944-1) [4548] -    -  - 620 10 ZiSi K9 V           
+1235 Themistocles   B433562-D Ni Po Cy O:1334 Vila1           { 1 }  (845-3) [1619] -    V  - 701 7  ZiSi F6 V M1 V      
+1236 Fymur          C55178B-8 Po Vila1                        { -1 } (A67+1) [967A] -    -  - 610 15 ZiSi M1 V           
+1237 Kanumshikaa    C755501-9 Ga Ni Ag Vila1                  { 0 }  (944-4) [1515] BC   -  - 620 5  StIm M0 V           
+1238 Iplukaddesh    D000323-9 As Va Lo Vila1                  { -2 } (721-5) [1126] B    -  - 411 12 StIm K1 V           
+1240 Nelson         E200200-A Va Lo Vila1                     { -1 } (611-5) [1115] B    -  - 120 6  StIm M0 V           
+1332 Nii Khu        A55497B-C Hi Vila1                        { 3 }  (C8E+5) [BC7E] -    K  - 501 13 ZiSi K0 V M3 V      
+1334 Lukham         A564ABE-G Hi Fo Vila1                     { 4 }  (E9G+5) [EE9L] -    -  R 602 9  ZiSi K1 V K6 V      
+1336 Pygmy          E540423-7 De He Ni Po Vila1               { -3 } (631-5) [1124] -    -  - 111 9  ZiSi F8 V K3 V      
+1337 Borealis       C5116BD-9 Ic Ni Na Fo Vila1               { -1 } (C53+3) [A59D] -    -  R 504 11 ZiSi F5 V M5 V      
+1339 Darm           A100362-F Va Lo O:1437 Vila1              { 1 }  (B21-3) [141B] B    -  - 924 16 StIm M1 V           
+1340 Anishda        E614310-8 Ic Lo Vila2                     { -3 } (721-5) [1113] B    -  - 902 8  StIm M0 V           
+1431 Daalurge       C558532-9 Ni Ag Vila1                     { 0 }  (844-4) [1515] -    -  - 410 11 ZiSi M2 V M1 V      
+1432 Agagir         C430588-B De Ni Po Vila1                  { 0 }  (844+1) [555B] -    V  - 110 15 ZiSi M4 V           
+1435 Dakeshir       C401400-C Ic Va Ni Vila1                  { 0 }  (833-4) [1417] -    -  - 102 14 ZiSi M1 V           
+1437 Igikuuni       A797799-C Ag Pi Vila2                     { 3 }  (D6D+4) [8A6D] -    K  - 522 14 ZiSi G0 V           
+1438 Zaal           A896511-D Ni Ag Vila2                     { 2 }  (846-2) [1719] -    -  - 301 12 ZiSi K4 V M5 V      
+1531 Kolrado        C422462-A He Ni Po O:1730 Vila1           { 0 }  (733-4) [1416] -    V  - 910 9  ZiSi M0 V           
+1533 Samotk         A100410-F Va Ni Vila2                     { 1 }  (734-3) [151A] -    -  - 901 8  ZiSi M1 V M8 V      
+1534 Senkon         D510100-9 Lo Vila1                        { -2 } (801-5) [1114] -    -  - 623 9  ZiSi G6 V M3 V      
+1535 Malapaan       C426841-A Ph Pi Vila1                     { 1 }  (C7A-3) [4916] -    -  - 620 9  ZiSi K0 V           
+1536 Pamiimkhi      C000400-D As Va Ni Vila1                  { 0 }  (833-4) [1418] -    V  - 320 14 ZiSi M0 V           
+1539 Zarurza        B95A500-B Wa Ni Vila1                     { 1 }  (A45-3) [1616] B    -  - 812 9  StIm M1 V F6 V G6 V 
+1540 Limed          B430689-B De Ni Na Po Vila1               { 1 }  (C55+2) [776C] B    -  - 413 11 StIm M2 V           
+1632 Imdur          E540100-8 De He Lo Po Vila1               { -3 } (401-5) [1113] -    -  - 810 8  ZiSi M1 V           
+1633 Darkishar      B42058B-D De He Ni Po Vila1               { 1 }  (845+3) [767F] -    V  - 910 12 ZiSi K0 V M3 V      
+1634 Isuugi         E756546-5 Ga Ni Ag Vila1                  { -2 } (742-3) [4344] -    -  - 413 12 ZiSi G6 V G0 V      
+1637 Preserve       D551222-7 Lo Po Vila1                     { -3 } (411-5) [1113] -    -  - 501 11 ZiSi M1 V           
+1638 Twana          C553533-9 Ni Po Vila1                     { -1 } (943-4) [2426] B    -  - 120 6  StIm G8 V M8 V M2 V 
+1732 Nikham         E89A425-9 Wa Ni Vila1                     { -2 } (731-4) [2237] -    -  - 410 11 ZiSi M3 V           
+1734 Miku           A8C3575-E Fl Ni Vila1                     { 1 }  (B45-1) [363C] -    -  - 104 8  ZiSi M1 V           
+1735 Zhinutar       A31259C-F Ic Ni Da Vila2                  { 1 }  (B45+4) [868J] -    -  A 204 9  ZiSi G6 V M0 V      
+1736 Ake            C528433-A Ni Vila1                        { 0 }  (733-3) [1427] -    V  - 301 12 ZiSi M1 V A9 V      
+1740 Glanidarn      D4359CE-A Hi Vila1                        { 1 }  (G8B+5) [DA9E] BE   S  - 623 11 StIm M2 V           
+1831 Mekhe          C546567-8 Ni Ag O:1730 Vila1              { -1 } (E43-1) [5458] -    -  - 325 11 ZiSi K3 V M1 V      
+1833 Shadi          B597445-B Ni Pa Vila1                     { 1 }  (734-1) [2539] -    K  - 901 11 ZiSi G6 V M3 V      
+1839 Kordanor       D778796-6 Ag Pi Vila2                     { -1 } (966-2) [6645] BCD  -  - 303 17 StIm M3 V           
+1931 Shorlon        D430546-9 De Ni Po Vila1                  { -2 } (942-3) [4348] -    -  - 202 9  ZiSi M1 V           
+1932 Sharan         C765323-9 Ga Lo Vila1                     { -1 } (B21-4) [1226] -    V  - 124 9  ZiSi G8 V           
+1933 Kaskar         C673664-7 Ni O:2035 Vila1                 { -2 } (852-4) [4435] -    -  - 901 12 ZiSi K6 V M0 V      
+1936 Ekhin          E400673-7 Va Ni Na Vila1                  { -3 } (851-5) [3324] -    -  - 701 8  ZiSi M0 III M7 V    
+1937 Nulisud        A8A366A-D Fl Ni Cp MrVila1                { 1 }  (B55+3) [877F] -    K  - 421 15 ZiSi K3 V           
+2032 Vuldaan        C522765-9 He Na Pi Po O:2035 Vila1        { 0 }  (E69-2) [5737] -    -  - 623 12 ZiSi F8 V           
+2035 Hykluitt       B5409BA-C De He Hi In Po Pz Vila1         { 4 }  (F8F+5) [BD7E] -    -  A 804 9  ZiSi M1 V           
+2036 Diinagar       C560423-9 De Ni Vila1                     { -1 } (732-4) [1326] -    V  - 610 15 ZiSi K0 V M2 V      
+2039 Miizam         B573577-B Ni Vila1                        { 1 }  (845+1) [565B] B    -  - 310 5  StIm M2 V M0 V      
+2132 Imshiig        B574545-A Ni Ag Vila1                     { 3 }  (947+1) [3838] -    KV - 620 12 ZiSi M3 V           
+2133 Iddun          D583201-8 Lo An Vila1                     { -3 } (611-5) [1114] -    -  - 320 10 ZiSi F7 V           
+2134 Zemal          C699124-A Lo Vila1                        { 0 }  (401-2) [1138] -    V  - 410 8  ZiSi M3 V M5 V      
+2137 Shaka          E410200-A Lo Vila1                        { -1 } (711-5) [1115] B    -  - 512 9  StIm F0 V           
+2138 Istuary        B582ABA-E Hi Pz Vila1                     { 3 }  (G9F+5) [CD7G] BE   -  A 122 14 StIm M1 V           
+2139 Zolo           C6286BB-9 Ni Fo Vila1                     { -1 } (953+1) [857B] B    -  R 701 12 StIm M1 V           
+2232 Gikarlum       B999542-A Ni Vila1                        { 1 }  (845-3) [1616] -    V  - 810 15 ZiSi G2 V M3 V      
+2233 Segikin        D768A77-7 Hi Vila1                        { -1 } (C98-1) [A957] -    V  - 501 11 ZiSi M3 V           
+2235 Rishin         E31057B-9 Ni Vila1                        { -2 } (D42+1) [737B] B    -  - 824 14 StIm G0 V           
+2236 Gaarid         E543746-6 Pi Po Vila1                     { -2 } (965-3) [6545] BD   -  - 213 10 StIm K7 V M2 V      
+2238 Khugan         B786420-B Ga Ni Pa Vila1                  { 1 }  (A34-3) [1516] Bc   -  - 504 13 StIm M3 V           
+2240 Bakor          B878869-8 Ph Pa Pi Mr Vila1               { 0 }  (B78+1) [9869] BcDe N  - 710 17 StIm K0 V M3 V      
+2331 Aaluggidira    C79A304-C Wa Lo Vila1                     { 0 }  (821-2) [133A] -    -  - 703 11 ZiSi F3 V           
+2332 Zaakkusham     D583520-7 Ni Pr Vila1                     { -3 } (741-5) [1212] -    -  - 101 12 ZiSi M1 V M8 V      
+2335 Miiliinlur     B422665-C He Ni Na Po Mr Vila1            { 1 }  (E55-1) [473A] B    N  - 724 13 StIm G7 V M4 V      
+2336 Kunni          A784511-D Ni Ag Pr Vila2                  { 2 }  (846-2) [1719] BcC  N  - 401 5  StIm M2 V M0 V      
+2337 Idi            A561436-D Ni Vila1                        { 1 }  (934+1) [354C] B    N  - 512 10 StIm G8 V M6 V      
+2340 Orguk          E545632-6 Ni Ag Vila1                     { -2 } (852-5) [2412] BC   -  - 620 7  StIm M3 V           
+2431 Dusekhip       B633964-D Hi Na Po O:2432 Vila1           { 3 }  (F8F+1) [7C3B] -    V  - 822 10 ZiSi K7 V           
+2432 Korm           B987867-A Ph Pa Ri Mr Vila1               { 3 }  (D7C+3) [8B5A] -    K  - 503 13 ZiSi M0 V           
+2433 Ashuugakher    C310899-8 Ph Na Pi Vila2                  { -1 } (C77+1) [9769] -    -  - 620 8  ZiSi G6 V           
+2435 Li             E423856-7 Ph Na Pi Po Vila1               { -2 } (A76-3) [7646] BDe  -  - 120 9  StIm M1 V           
+2438 Shakir         A626201-F Lo Vila1                        { 1 }  (911-3) [131B] -    -  - 723 12 ZiSi K6 V           
+2440 Shuurdiikha    C652569-9 Ni Po O:2540 Vila1              { -1 } (843+1) [646A] B    S  - 810 11 StIm F8 V M5 V      
+2531 Kiddinu        B555553-C Ni Ag Vila1                     { 2 }  (E46-1) [2729] -    -  - 434 11 ZiSi M0 V           
+2533 Aki            D697AFF-A Hi In Fo Vila1                  { 2 }  (D9C+5) [FCAF] -    -  R 110 13 ZiSi F5 V M0 V      
+2534 Zerapii        C411774-A Ic Na Pi Vila1                  { 1 }  (D6A-1) [5838] -    V  - 822 12 ZiSi M1 V           
+2536 Linissa        E200777-8 Va Na Pi Vila1                  { -2 } (A66-2) [7558] BD   -  - 710 12 StIm G9 V           
+2539 Nunaat         B624248-C Lo Vila1                        { 1 }  (A11+1) [235C] B    N  - 924 9  StIm M0 V           
+2540 Kalaalit       A7698B9-D Ph Ri Vila1                     { 3 }  (B7E+4) [9B6E] BCe  N  - 510 6  StIm M3 V           
+2631 Kane           E789ABE-A Hi Fo Vila1                     { 1 }  (H9B+5) [EB9E] -    -  R 723 10 ZiSi K9 V           
+2634 Wakarsat       B68A789-B Wa Ri Vila1                     { 3 }  (E6D+4) [8A6C] -    K  - 814 13 ZiSi M0 V           
+2636 Kakadan        A9C7400-F Fl Ni Cp Vila1                  { 1 }  (734-3) [151A] B    N  - 601 8  StIm M2 V           
+2637 Akon           A56358A-D Ni Pr Vila1                     { 1 }  (A45+3) [767F] Bc   N  - 703 10 StIm K4 V M1 V      
+2640 Statia         B300440-D Va Ni Vila1                     { 1 }  (734-3) [1518] B    -  - 310 13 StIm M1 V           
+2732 Dnak'kritz     D582758-7 Ri Vila1                        { -1 } (967-1) [7657] -    V  - 104 7  ZiSi G0 V M2 V      
+2733 Jarmat         A310122-D Lo Vila1                        { 1 }  (801-3) [1219] -    -  - 614 9  ZiSi M0 V           
+2734 Rambant        B310113-C Lo Vila2                        { 1 }  (701-2) [1229] -    -  - 104 11 ZiSi F4 V K0 V      
+2737 Kesali         B2009AB-E Va Hi Na In Vila1               { 4 }  (E8G+5) [BD7G] BEf  N  - 503 6  StIm M3 V           
+2738 Tepmaa         B410251-D Lo Vila1                        { 1 }  (911-3) [1319] B    S  - 323 12 StIm M0 V           
+2739 Sg'aa          AAB5895-D Fl Ph Vila2                     { 2 }  (E7D+1) [6A3B] Be   -  - 613 11 StIm K6 V M4 V      
+2740 P'ginzh        C554567-9 Ni Ag O:2839 Vila1              { 0 }  (844+1) [5559] BC   S  - 710 14 StIm M2 V           
+2831 Kiimzhal       C55455A-A Ni Ag Vila1                     { 1 }  (845+3) [767C] -    -  - 801 8  ZiSi M3 V M7 V      
+2832 Telkaa         C635515-A Ni Vila2                        { 0 }  (A44-2) [3538] -    -  - 721 10 ZiSi M2 V K3 V K3 V 
+2836 Inushir        E989ADE-7 Hi Fo Vila1                     { -1 } (C98+3) [E99B] BE   -  R 623 17 StIm K0 V           
+2837 Piazza         C794685-6 Ni Ag Vila1                     { -1 } (853-3) [4534] BC   -  - 822 12 StIm K4 V M3 V      
+2839 Zombagu        A684730-B Ag Ri An Vila1                  { 4 }  (F6E+1) [2B16] BCf  -  - 924 9  StIm F7 V           
+2931 Icuspin        A200976-F Va Hi Na In Vila1               { 4 }  (D8G+3) [8D4E] -    -  - 820 13 ZiSi M2 V           
+2932 Zanski         B585530-B Ni Ag Pr Vila1                  { 3 }  (A47-1) [1816] -    KW - 421 12 ZiSi M3 V           
+2933 Kanat          B567359-B Lo Vila1                        { 1 }  (921+2) [446C] -    -  - 513 13 ZiSi M2 V           
+2934 Assazak        C5908C9-8 De He Ph Pi Pz Vila1            { -1 } (B77+1) [9769] -    -  A 401 11 ZiSi M1 V           
+2936 Elafdt         E200320-8 Va Lo Vila1                     { -3 } (621-5) [1113] B    -  - 801 5  StIm K9 V G0 V M0 V 
+2938 Punnari        B737358-D Lo RsA Vila1                    { 1 }  (621+1) [345D] B    N  - 101 13 StIm M2 V M5 V      
+2939 Teralvar       C585563-9 Ni Ag Pr Cy O:2839 Vila1        { 0 }  (844-3) [2526] BcC  S  - 701 7  StIm G3 V M8 V      
+3031 New Salen      C202974-C Ic Va Hi Na In Vila1            { 3 }  (D8E+1) [7C3A] -    -  - 920 13 ZiSi M2 V           
+3032 Matuyama       C540899-8 De He Ph Pi Po Vila2            { -1 } (F77+1) [9769] -    -  - 323 8  ZiSi G0 V M0 V      
+3035 Zhanora        D651754-7 Po Vila1                        { -2 } (966-4) [5535] B    S  - 101 7  LuIm G2 V M3 V      
+3037 Raanbazziil    A428334-E Lo Vila1                        { 1 }  (621-1) [143C] B    N  - 110 10 StIm M0 V           
+3039 Gilnat Paz     A535300-E Lo Vila1                        { 1 }  (821-3) [1419] B    -  - 721 11 StIm M1 V           
+3131 Maamibrin      B5629CA-C Hi Pr Fo Vila1                  { 3 }  (D8E+5) [BC7E] BcE  -  R 120 13 LuIm F7 V           
+3134 Toborit        C424664-8 Ni O:2931 Vila1                 { -2 } (C52-4) [4436] B    -  - 322 10 LuIm M2 V           
+3135 Debekov        B572305-B He Lo Vila1                     { 1 }  (621-1) [1439] B    N  - 901 11 LuIm M2 V           
+3137 Alleman        A200555-F Va Ni Vila1                     { 1 }  (945-1) [363D] B    -  - 702 13 LuIm K6 III K1 V    
+3138 Nasaa          E425545-9 Ni Vila1                        { -2 } (942-4) [3337] B    -  - 320 13 LuIm G8 V           
+3140 Zana           E653546-7 Ni Po Vila1                     { -3 } (741-4) [4246] B    -  - 310 8  LuIm K0 V M2 V      
+3231 Vanutappan     B547547-B Ni Ag Vila1                     { 2 }  (D46+2) [575B] BC   -  - 624 14 LuIm F7 V M9 V      
+3232 Tamayo         A779568-C Ni O:2931 Vila1                 { 1 }  (845+1) [565C] B    -  - 601 11 LuIm M0 V G6 V M6 V 
+3235 Debort         B581778-A Ri Vila1                        { 3 }  (A6C+3) [7A5A] BC   N  - 510 14 LuIm F9 V G4 V      
+3237 Zhannag        C534373-A Lo Vila1                        { 0 }  (C21-3) [1327] B    S  - 634 13 LuIm G8 V           
+3238 Lamiina        E768330-7 Lo Vila1                        { -3 } (521-5) [1112] B    -  - 313 12 LuIm K0 V K1 V      
+3239 Lannazol       D845110-7 Lo Vila2                        { -3 } (301-5) [1112] B    S  - 301 12 LuIm M3 V           

--- a/res/Sectors/M1120/1120_Vlan.xml
+++ b/res/Sectors/M1120/1120_Vlan.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0"?>
+<Sector xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Name>Vland</Name>
+  <Credits>
+
+             &lt;b&gt;Vland&lt;/b&gt; sector was designed by Marc W. Miller and
+             appears in &lt;cite&gt;Atlas of the Imperium&lt;/cite&gt; (GDW,
+             1984).
+
+             It was refined by Joe D. Fugate Sr. and appears in
+             &lt;cite&gt;The Travellers Digest&lt;/cite&gt; and &lt;cite&gt;The
+             MegaTraveller Alien, Volume 1: Vilani &amp;amp; Vargr&lt;/cite&gt;
+             (DGP, 1990)
+
+    </Credits>
+  <Product Title="MegaTraveller Alien Vol. 1: Vilani %29 Vargr" Publisher="Digest Group Publications" Ref="http://wiki.travellerrpg.com/Alien_-_Vilani_%26_Vargr"/>
+  <Subsectors>
+    <Subsector Index="A">Voskhod</Subsector>
+    <Subsector Index="B">Vhodan</Subsector>
+    <Subsector Index="C">Anarsi</Subsector>
+    <Subsector Index="D">Theton</Subsector>
+    <Subsector Index="E">Lalaki Kharir</Subsector>
+    <Subsector Index="F">Kagamira</Subsector>
+    <Subsector Index="G">Vland</Subsector>
+    <Subsector Index="H">Shiigus</Subsector>
+    <Subsector Index="I">Dusa</Subsector>
+    <Subsector Index="J">Akumid</Subsector>
+    <Subsector Index="K">Kasear</Subsector>
+    <Subsector Index="L">Anakod</Subsector>
+    <Subsector Index="M">Parsi</Subsector>
+    <Subsector Index="N">Daangiilu</Subsector>
+    <Subsector Index="O">Nulisud</Subsector>
+    <Subsector Index="P">Kakadan</Subsector>
+  </Subsectors>
+  <Allegiances>
+    <Allegiance Code="CsIm">Client state, Third Imperium</Allegiance>
+    <Allegiance Code="LiIm">Lucan's Imperium</Allegiance>
+    <Allegiance Code="NaVa">Non-Aligned, Vargr-dominated</Allegiance>
+    <Allegiance Code="ZiSi">Ziru Sirkaa</Allegiance>
+    <Allegiance Code="StIm">Strephon's Imperium</Allegiance>
+    <Allegiance Code="V17D">17th Disjuncture</Allegiance>
+    <Allegiance Code="VNgC">Ngath Confedertation</Allegiance>
+    <Allegiance Code="CRVi">Vilani Cultural Region</Allegiance>
+  </Allegiances>
+  <Borders>
+    <Border Allegiance="LiIm" WrapLabel="true" LabelPosition="3133" Color="DarkRed">2927 3026 3127 3227 3328 3329 3330 3331 3332 3333 3334 3335 3336 3337 3338 3339 3340 3341 3241 3141 3041 3040 3140 3139 3138 3137 3036 3035 3034 3033 3133 3132 3131 3030 2930 2929 2928 2927 </Border>
+    <Border Allegiance="StIm" LabelPosition="1838" Color="Crimson">0029 0030 0131 0231 0331 0332 0432 0433 0434 0535 0634 0735 0736 0836 0937 1036 1137 1237 1338 1339 1439 1539 1638 1738 1737 1837 1938 2037 2137 2136 2135 2234 2335 2434 2535 2635 2735 2834 2935 2936 2937 3037 3038 3039 2940 2941 2841 2741 2641 2541 2441 2341 2241 2141 2041 1941 1841 1741 1641 1541 1441 1341 1241 1141 1041 0941 0841 0741 0641 0541 0441 0341 0241 0141 0041 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030 0029</Border>
+    <Border Allegiance="V17D" LabelPosition="2801" Color="OliveDrab">2602 2702 2801 2800 2900 3000 3100 3200 3201 3202 3103 3003 3004 3005 2906 2805 2706 2605 2604 2603 2602 </Border>
+    <Border Allegiance="VNgC"  LabelPosition="1502" Color="OliveDrab">0402 0502 0601 0600 0700 0800 0900 1000 1100 1200 1300 1400 1500 1600 1700 1800 1900 2000 2100 2200 2101 2001 1902 1903 1904 1804 1705 1706 1605 1705 1704 1603 1504 1404 1305 1205 1106 1006 1005 0905 0904 0803 0802 0702 0602 0503 0402 </Border>
+    <Border Allegiance="ZiSi" LabelPosition="1225" Color="Yellow">0001 0101 0102 0202 0303 0403 0504 0603 0703 0704 0705 0805 0906 0907 1007 1107 1206 1306 1405 1505 1506 1606 1707 1807 1907 1906 2005 2105 2205 2306 2406 2507 2607 2707 2806 2907 3006 3106 3206 3307 3308 3309 3310 3311 3312 3313 3314 3315 3316 3317 3318 3319 3320 3321 3322 3323 3324 3325 3326 3327 3226 3126 3025 2926 2826 2827 2828 2829 2830 2931 3031 3032 2933 2934 2833 2734 2634 2534 2433 2334 2233 2134 2034 2035 2036 1937 1836 1736 1636 1637 1538 1438 1437 1337 1236 1136 1035 0936 0835 0834 0734 0633 0534 0533 0532 0431 0430 0530 0630 0731 0831 0931 0930 0929 0928 0927 0926 0825 0824 0724 0623 0523 0422 0322 0221 0321 0420 0521 0620 0619 0719 0819 0919 1018 1119 1218 1217 1117 1116 1215 1214 1114 1113 1012 1011 0911 0810 0711 0610 0510 0410 0311 0211 0210 0110 0009 0008 0007 0006 0005 0004 0003 0002 0001</Border>
+    <Border WrapLabel="true" Allegiance="CRVi" LabelPosition="1614" Color="Blue" Label="Vilani Cultural Region">1011 1112 1211 1311 1410 1510 1509 1608 1607 1707 1706 1705 1704 1703 1802 1801 1901 2001 2102 2201 2302 2402 2503 2603 2604 2605 2506 2507 2508 2408 2409 2410 2310 2210 2211 2212 2313 2314 2315 2415 2416 2417 2418 2419 2520 2620 2721 2821 2921 3021 3121 3221 3222 3223 3224 3225 3226 3227 3228 3229 3130 3029 2930 2830 2730 2629 2530 2429 2330 2229 2129 2029 2030 1930 1830 1730 1729 1728 1628 1728 1828 1928 2027 2026 2025 2024 2023 1923 1822 1722 1721 1620 1520 1420 1321 1220 1120 1119 1218 1217 1117 1116 1215 1214 1114  1113 1012 1011</Border>
+  </Borders>
+  <Routes>
+    <Route Start="0107" End="0408" />
+    <Route Start="0107" End="3208" EndOffsetX="-1" />
+    <Route Start="0234" End="0333" />
+    <Route Start="0234" End="0436" />
+    <Route Start="0234" End="3232" EndOffsetX="-1" />
+    <Route Start="0311" End="0408" />
+    <Route Start="0340" End="0640" />
+    <Route Start="0404" End="0408" />
+    <Route Start="0404" End="0605" />
+    <Route Start="0408" End="0708" />
+    <Route Start="0422" End="0619" />
+    <Route Start="0431" End="0530" />
+    <Route Start="0436" End="0536" />
+    <Route Start="0530" End="0831" />
+    <Route Start="0536" End="0637" />
+    <Route Start="0605" End="0807" />
+    <Route Start="0619" End="0921" />
+    <Route Start="0637" End="0640" />
+    <Route Start="0640" End="0402" EndOffsetY="1" />
+    <Route Start="0708" End="0709" />
+    <Route Start="0708" End="0807" />
+    <Route Start="0709" End="1011" />
+    <Route Start="0807" End="1208" />
+    <Route Start="0831" End="0934" />
+    <Route Start="0921" End="1120" />
+    <Route Start="0923" End="1323" />
+    <Route Start="0934" End="1136" />
+    <Route Start="0934" End="1332" />
+    <Route Start="1011" End="1112" />
+    <Route Start="1112" End="1211" />
+    <Route Start="1112" End="1414" />
+    <Route Start="1114" End="1414" />
+    <Route Start="1120" End="1520" />
+    <Route Start="1136" End="1235" />
+    <Route Start="1136" End="1437" />
+    <Route Start="1208" End="1211" />
+    <Route Start="1208" End="1408" />
+    <Route Start="1211" End="1414" />
+    <Route Start="1217" End="1519" />
+    <Route Start="1235" End="1533" />
+    <Route Start="1323" End="1520" />
+    <Route Start="1323" End="1625" />
+    <Route Start="1332" End="1530" />
+    <Route Start="1339" End="1202" EndOffsetY="1" />
+    <Route Start="1408" End="1505" />
+    <Route Start="1408" End="1509" />
+    <Route Start="1414" End="1717" />
+    <Route Start="1509" End="1709" />
+    <Route Start="1519" End="1520" />
+    <Route Start="1519" End="1717" />
+    <Route Start="1520" End="1822" />
+    <Route Start="1530" End="1533" />
+    <Route Start="1530" End="1628" />
+    <Route Start="1533" End="1735" />
+    <Route Start="1533" End="1735" />
+    <Route Start="1625" End="1628" />
+    <Route Start="1625" End="1822" />
+    <Route Start="1709" End="1909" />
+    <Route Start="1717" End="1817" />
+    <Route Start="1717" End="1820" />
+    <Route Start="1717" End="1916" />
+    <Route Start="1735" End="1937" />
+    <Route Start="1817" End="1919" />
+    <Route Start="1817" End="2117" />
+    <Route Start="1820" End="1821" />
+    <Route Start="1820" End="1822" />
+    <Route Start="1821" End="1822" />
+    <Route Start="1822" End="1825" />
+    <Route Start="1825" End="1928" />
+    <Route Start="1825" End="2225" />
+    <Route Start="1909" End="2111" />
+    <Route Start="1916" End="2013" />
+    <Route Start="1919" End="2020" />
+    <Route Start="1928" End="1930" />
+    <Route Start="1928" End="2227" />
+    <Route Start="1930" End="2132" />
+    <Route Start="2013" End="2111" />
+    <Route Start="2020" End="2221" />
+    <Route Start="2111" End="2409" />
+    <Route Start="2117" End="2316" />
+    <Route Start="2117" End="2319" />
+    <Route Start="2132" End="2232" />
+    <Route Start="2205" End="2308" />
+    <Route Start="2225" End="2227" />
+    <Route Start="2225" End="2426" />
+    <Route Start="2240" End="2540" />
+    <Route Start="2308" End="2409" />
+    <Route Start="2316" End="2416" />
+    <Route Start="2316" End="2513" />
+    <Route Start="2319" End="2620" />
+    <Route Start="2337" End="2438" />
+    <Route Start="2409" End="2513" />
+    <Route Start="2409" End="2808" />
+    <Route Start="2416" End="2616" />
+    <Route Start="2426" End="2728" />
+    <Route Start="2438" End="2540" />
+    <Route Start="2438" End="2637" />
+    <Route Start="2513" End="2912" />
+    <Route Start="2540" End="2602" EndOffsetY="1" />
+    <Route Start="2540" End="2739" />
+    <Route Start="2616" End="2816" />
+    <Route Start="2636" End="2637" />
+    <Route Start="2728" End="2926" />
+    <Route Start="2728" End="2931" />
+    <Route Start="2739" End="2938" />
+    <Route Start="2806" End="2808" />
+    <Route Start="2806" End="3107" />
+    <Route Start="2816" End="3117" />
+    <Route Start="2829" End="2931" />
+    <Route Start="2912" End="3211" />
+    <Route Start="2926" End="3224" />
+    <Route Start="2938" End="3037" />
+    <Route Start="3107" End="0309" EndOffsetX="1" />
+    <Route Start="3117" End="0118" EndOffsetX="1" />
+    <Route Start="3137" End="0236" EndOffsetX="1" />
+    <Route Start="3211" End="0111" EndOffsetX="1" />
+    <Route Start="3232" End="0132" EndOffsetX="1" />
+    <Route Start="3232" End="0134" EndOffsetX="1" />
+    <Route Start="1519" End="1919" Type="Trade"/>
+    <Route Start="1822" End="1919" Type="Trade"/>
+    <Route Start="1903" End="2205" Type="Trade"/>
+    <Route Start="2616" End="2914" Type="Trade"/>
+    <Route Start="2737" End="2839" Type="Trade"/>
+    <Route Start="2829" End="2931" Type="Trade"/>
+    <Route Start="2914" End="3212" Type="Trade"/>
+    <Route Start="2914" End="3215" Type="Trade"/>
+    <Route Start="3212" End="3215" Type="Trade"/>
+  </Routes>
+</Sector>

--- a/res/Sectors/M1120/M1120.xml
+++ b/res/Sectors/M1120/M1120.xml
@@ -79,5 +79,37 @@
     <DataFile Author="James Holden, Mike Mikesh and Nancy Parker" Type="SecondSurvey">1120_Dene.sec</DataFile>
     <MetadataFile>1120_Dene.xml</MetadataFile>
   </Sector>
+
+  <!-- Vilani & Vargr -->
+  <Sector Abbreviation="Vlan" Tags="Unreviewed" Selected=true Milieu="M1120">
+    <Y>-1</Y>
+    <X>-1</X>
+    <Name>Vland</Name>
+    <DataFile Author="James Holden, Joe D. Fugate Jr. and Terry McInnes" Type="SecondSurvey">1120_Vlan.sec</DataFile>
+    <MetadataFile>1120_Vlan.xml</MetadataFile>
+  </Sector>
+  <Sector Abbreviation="Gush" Tags="Unreviewed" Selected=true Milieu="M1120">
+    <Y>0</Y>
+    <X>-2</X>
+    <Name>Gushemege</Name>
+    <DataFile Author="James Holden, Joe D. Fugate Jr. and Terry McInnes" Type="SecondSurvey">1120_Gush.sec</DataFile>
+    <MetadataFile>1120_Gush.xml</MetadataFile>
+  </Sector>
+  <Sector Abbreviation="Dagu" Tags="Unreviewed" Selected=true Milieu="M1120">
+    <Y>0</Y>
+    <X>-1</X>
+    <Name>Dagudashaag</Name>
+    <Name>Dagudashag</Name>
+    <DataFile Author="James Holden, Joe D. Fugate Jr. and Terry McInnes" Type="SecondSurvey">1120_Dagu.sec</DataFile>
+    <MetadataFile>1120_Dagu.xml</MetadataFile>
+  </Sector>
+  <Sector Abbreviation="Core" Tags="Unreviewed" Selected=true Milieu="M1120">
+    <Y>0</Y>
+    <X>0</X>
+    <Name>Core</Name>
+    <Name Lang="vi">Ukan</Name>
+    <DataFile Author="James Holden, Joe D. Fugate Jr. and Terry McInnes" Type="SecondSurvey">1120_Core.sec</DataFile>
+    <MetadataFile>1120_Core.xml</MetadataFile>
+  </Sector>
  
 </Sectors>


### PR DESCRIPTION
OK This covers the "Imperial" Sectors found in Vilani & Vargr.
Please add is possible CRVi allegiance ( CRVi = CV = Vilani Cultural Region). I have no worlds with this allegiance, but a bordered region. I plan to add other Cultural Regions in other eras when I get to them like Geonee (CRGe) Suerrat (CRGe) Anakundu (CRAk) (see below)

Vland is the only complete sector, Gushemege, Dagudashaag and Core had their borders indicated. Capitals and Depots came from GDW Rebellion Sourcebook. Lishun is excluded at this time to give Kligs from COTI a chance to participate per discussion there.
*Next: First Imperium borders for IW based on Vilani & Vargr (Yes, all of them!)
*Following: Vargr borders of 1120 (taking into account the Empress Wave intruding on the Vargr Splinters)