### PR TITLE
Switch Hiver legacy govs to standard T5.10 ones.

### DIFF
--- a/res/Sectors/M1105/Phlask.txt
+++ b/res/Sectors/M1105/Phlask.txt
@@ -93,79 +93,79 @@ Hex  Name                 UWP       Remarks                      {Ix}   (Ex)    
 0314 Pravda               E211667-4 Ic Na Ni O:0210              { -3 } (651-2) [8366] - -  - 303 10 Na   F3 V
 0315 Derig                E79799A-8 Hi In                        {  0 } (A87+0) [6983] - -  - 413  9 Na   M1 V
 0317                      A581202-D Lo                           {  1 } (A11-1) [134B] - -  - 104 12 HvFd F4 V M9 V
-0318                      A6955S5-9 Ag Ni                        {  1 } (847-4) [764A] - -  - 905 17 HvFd G4 V
+0318                      A695555-9 Ag Ni                        {  1 } (847-4) [764A] - -  - 905 17 HvFd G4 V
 0413 Dunkirk              E5898DE-5 Ri Ph                        { -1 } (B74+2) [5768] - -  - 900  8 NaXX M1 V K7 V
 0415 Krossbyr             E000499-7 As Va Ni                     { -3 } (331-3) [3115] - -  - 803 16 Na   G8 IV M3 V
 0416 Eregdor              C739798-8                              { -1 } (B65+2) [866B] - -  - 800 10 Na   M5 V
 0418                      B160212-B De Lo                        {  1 } (A11+3) [436A] - M  - 204 12 HvFd M7 V
 0512 Sirma                C7A6105-B Fl Lo                        {  0 } (F01+2) [1146] - -  - 324 19 NaXX K2 IV M9 V
 0514 Hardon               X523314-1 Lo Po Fo                     { -3 } (221+2) [1126] - -  R 912  6 NaXX M2 V
-0519                      B1305S6-9 De Ni Po                     {  0 } (844+3) [5534] - M  - 104 14 HvFd M0 V M5 V
+0519                      B130576-9 De Ni Po                     {  0 } (844+3) [5534] - M  - 104 14 HvFd M0 V M5 V
 0614 Angie                A633110-9 Lo Po                        {  0 } (B01-1) [213E] - -  - 213 15 Na   K2 III M2 V
 0615 Betraytor            A87488A-B Ph Pa Pi                     {  2 } (97A+1) [8A7F] - N  - 400  6 Na   M7 V M4 V
 0617                      A383101-C Lo                           {  1 } (801-5) [125E] - K  - 210  8 HvFd G9 V
 0619                      B100213-B Lo Va                        {  1 } (B11-1) [3349] - K  - 924 16 HvFd M9 V
-0716                      E7696S4-4 Ni Ri                        { -2 } (452-5) [3447] - -  - 323 13 HvFd G8 IV M0 V
-0720 Uapul                A5549S6-9 Hi                           {  2 } (786+2) [9B46] - K  - 301  6 HvFd M8 III M9 V
+0716                      E769674-4 Ni Ri                        { -2 } (452-5) [3447] - -  - 323 13 HvFd G8 IV M0 V
+0720 Uapul                A5549A6-9 Hi                           {  2 } (786+2) [9B46] - K  - 301  6 HvFd M8 III M9 V
 0813 Bielform             C000249-B As Va Lo                     {  0 } (E11-2) [22AC] - S  - 114 15 Na   M8 V K6 V
 0817                      B683002-8 Di                           {  0 } (607+5) [0000] - KM - 003  8 HvFd M5 V
-0818 Panio                B6669W5-C Hi Ga Pr                     {  3 } (B8B-3) [9CAD] - -  - 413 15 HvFd M6 V
-0819                      B1006S4-9 Na Ni Va                     {  1 } (955+4) [477D] - KM - 314  9 HvFd M9 V
-0820 Cigenan              A5759T3-D Hi In Cs                     {  4 } (C88+3) [ED1E] - K  - 213 13 HvFd F9 V
+0818 Panio                B666995-C Hi Ga Pr                     {  3 } (B8B-3) [9CAD] - -  - 413 15 HvFd M6 V
+0819                      B100674-9 Na Ni Va                     {  1 } (955+4) [477D] - KM - 314  9 HvFd M9 V
+0820 Cigenan              A5759AB-D Hi In Cs                     {  4 } (C88+3) [ED1E] - K  - 213 13 HvFd F9 V
 0912 Lestrigge            X888774-2 Ag Ri Fo                     {  0 } (767+1) [4712] - -  R 203 10 Na   M1 V M0 V
 0913 Coseecer             X746441-0 Ni Pa Fo                     { -3 } (730+4) [3175] - -  R 312 15 Na   G9 V
 0914 Lucienne             X78A230-0 Lo Wa Fo                     { -3 } (611-4) [2161] - -  R 412 11 Na   G0 IV M7 V
-0917 Cenoogo              C8B7701-7 Fl (Cenoogo) Pz              { -1 } (661+1) [365B] - -  A 912 14 HvFd M1 V G6 V
+0917 Cenoogo              C8B7787-7 Fl (Cenoogo) Pz              { -1 } (661+1) [365B] - -  A 912 14 HvFd M1 V G6 V
 0920                      A775302-B Lo                           {  1 } (B21+1) [2497] - -  - 804  9 HvFd M6 V
 1011 Rudolph              D95A747-6 Wa                           { -2 } (865+0) [B575] - S  - 210  6 Na   M6 V M6 V
 1012 Woods                D334A7B-8 Hi                           { -1 } (A99+3) [C955] - S  B 224 16 Na   M6 V
-1014 Gomotgul             C4369T4-7 Hi                           {  0 } (584+1) [9977] - M  - 225 14 HvFd M3 V M6 V
+1014 Gomotgul             C436974-7 Hi                           {  0 } (584+1) [9977] - M  - 225 14 HvFd M3 V M6 V
 1017                      A110405-F Ni                           {  1 } (736-4) [251F] - -  - 500  6 HvFd M6 V
-1020                      A7798T5-8 Ph Pi                        {  0 } (977+1) [7849] - K  - 604 10 HvFd M6 V
+1020                      A779875-8 Ph Pi                        {  0 } (977+1) [7849] - K  - 604 10 HvFd M6 V
 1114                      A999203-B Lo                           {  1 } (D11+2) [236A] - -  - 814  8 HvFd M5 V M8 V
-1115                      C4606S6-8 De Ni Ri                     { -1 } (D51+2) [5524] - M  - 320 13 HvFd M7 V
-1117                      A5637S4-B Ri                           {  3 } (C67+2) [6AAC] - -  - 603 12 HvFd F2 V M8 V
+1115                      C460646-8 De Ni Ri                     { -1 } (D51+2) [5524] - M  - 320 13 HvFd M7 V
+1117                      A563797-B Ri                           {  3 } (C67+2) [6AAC] - -  - 603 12 HvFd F2 V M8 V
 1119                      A324664-D Ni O:0820                    {  1 } (753-2) [374E] - -  - 204 10 HvFd M2 V
 1120                      A401201-F Ic Lo Va                     {  1 } (611-4) [335B] - K  - 822 14 HvFd F2 V
 1211 Swanne               C222443-8 Ni Po                        { -2 } (C30-2) [2258] - -  - 215 14 Na   K1 III M4 V
 1212 Dominga              C201664-9 Ic Na Ni Va O:1208           { -1 } (754-1) [5558] - S  - 100  8 Na   M7 V M1 V
-1215                      C6A37S2-7 Fl                           { -1 } (569+2) [6645] - M  - 502 10 HvFd M4 V F2 V
+1215                      C6A3752-7 Fl                           { -1 } (569+2) [6645] - M  - 502 10 HvFd M4 V F2 V
 1220                      A332562-D Ni Po Cy O:1021              {  1 } (846+0) [764E] - -  - 902  9 HvFd M7 III
 1311 Vescy                AA9A302-F Lo Oc                        {  2 } (A21-5) [656D] - NS - 803  6 Na   M8 V
-1315 Daootuac             B6789T4-7 Hi In                        {  2 } (986+2) [8B85] - -  - 403 10 HvFd F1 V
+1315 Daootuac             B678974-7 Hi In                        {  2 } (986+2) [8B85] - -  - 403 10 HvFd F1 V
 1316                      B538663-8 Ni Cy O:1515                 { -1 } (D52-2) [95A9] - -  - 304  7 HvFd M9 V
 1317                      B5A1002-A Fl He Di                     {  1 } (D06+0) [0000] - -  - 023 15 HvFd M0 V K4 V
 1318                      B510421-8 Ni                           { -1 } (934-3) [533B] - K  - 602 14 HvFd M8 V
 1413                      B326413-B Ni                           {  1 } (A37+0) [455C] - K  - 724 14 HvFd M9 V M3 V
 1418                      B321521-C He Ni Po                     {  2 } (943+3) [772C] - KM - 102  9 HvFd M4 V M0 V
-1420                      D7785S6-2 Ag Ni                        { -2 } (740+1) [8321] - M  - 205 11 HvFd G2 V M4 V
+1420                      D778536-2 Ag Ni                        { -2 } (740+1) [8321] - M  - 205 11 HvFd G2 V M4 V
 1512                      B545563-8 Ag Ni Cy O:1515              {  0 } (A45+1) [A564] - K  - 212 11 HvFd G9 V
 1513                      B6A0521-8 He Ni                        { -1 } (841+2) [7439] - K  - 903  8 HvFd G4 V
-1515 Klenimam             C67A9T4-C Hi In Wa                     {  3 } (B8C+1) [DC78] - -  - 310 10 HvFd M4 V
+1515 Klenimam             C67A974-C Hi In Wa                     {  3 } (B8C+1) [DC78] - -  - 310 10 HvFd M4 V
 1516                      D646521-3 Ag Ni                        { -2 } (B41-2) [1384] - M  - 224 12 HvFd M5 V M2 V
-1519 Zanfaho              B3007S4-A Va Na Pi Cp                  {  3 } (C6E-3) [9A6B] - KM - 214 15 HvFd M2 V
+1519 Zanfaho              B300754-A Va Na Pi Cp                  {  3 } (C6E-3) [9A6B] - KM - 214 15 HvFd M2 V
 1520                      D753201-5 Lo Po                        { -3 } (811+4) [2188] - M  - 103 14 HvFd M1 V
-1613                      C5105U6-8 Ni                           { -2 } (543+0) [2378] - -  - 201  6 HvFd A8 V K9 V
+1613                      C510506-8 Ni                           { -2 } (543+0) [2378] - -  - 201  6 HvFd A8 V K9 V
 1617                      C439202-9 Lo                           { -1 } (D11+0) [112A] - -  - 111 11 HvFd M9 V
 1618 Oxdrildax            D8B3721-4 Fl (Oxdrildax) Da            { -2 } (364+0) [7534] - M  A 804 12 HvFd M8 III
-1619                      B8886S5-A Ag Ni Ri                     {  3 } (F59+3) [6965] - -  - 304 11 HvFd M4 V
-1711 Waldburga            B34457A-7 Ag Ni                        {  0 } (C42+2) [2585] - -  - 122  8 Na   M2 V
+1619                      B888675-A Ag Ni Ri                     {  3 } (F59+3) [6965] - -  - 304 11 HvFd M4 V
+1711 Waldburga            B34458A-7 Ag Ni                        {  0 } (C42+2) [2585] - -  - 122  8 Na   M2 V
 1719                      C536101-8 Lo                           { -2 } (901-1) [1197] - -  - 203  8 HvFd M5 V
 1811 Rollins              C4837BC-6 Ri                           {  0 } (968+1) [9717] - -  - 624 10 Na   G6 V
 1813                      D485102-6 Lo                           { -3 } (401+0) [1169] - M  - 513 11 HvFd K2 V M3 V
-1818                      B2446S1-A Ag Ni                        {  2 } (D58+3) [185C] - K  - 804 13 HvFd G8 V
-1819 Tafkanu              C558AW6-C Hi                           {  2 } (C95+3) [7C4E] - -  - 101 12 HvFd M1 V
+1818                      B244675-A Ag Ni                        {  2 } (D58+3) [185C] - K  - 804 13 HvFd G8 V
+1819 Tafkanu              C558A96-C Hi                           {  2 } (C95+3) [7C4E] - -  - 101 12 HvFd M1 V
 1912 Eastwood             B68667C-9 Ag Ni Ri Ga                  {  2 } (654+1) [6858] - N  B 304  8 Na   M4 V M7 V
 1916 Renidas              B659211-8 Lo Da NainW Fo               { -1 } (611-5) [5139] - -  A 101  7 HvFd F7 V
-1919                      C6357S5-6                              { -1 } (764-2) [8697] - M  - 902 10 HvFd M2 III
-2015 Nainur               B478829-A Ph Pa Pi (Nainur) Pz         {  2 } (674+3) [5A78] - -  A 804 14 HvFd M3 V
+1919                      C635755-6                              { -1 } (764-2) [8697] - M  - 902 10 HvFd M2 III
+2015 Nainur               B478899-A Ph Pa Pi (Nainur) Pz         {  2 } (674+3) [5A78] - -  A 804 14 HvFd M3 V
 2019                      C795402-7 Ni Pa                        { -2 } (630+2) [1267] - M  - 601 10 HvFd G9 III
 2112                      D876303-3 Lo                           { -3 } (621+5) [2175] - -  - 223 14 HvFd M9 V K4 V
 2114 Dooaca               B237101-9 Lo Pz NainW                  {  0 } (701-4) [1137] - -  A 611  9 HvFd G7 V
 2115                      D666522-5 Ag Ni Ga Pr Nain7            { -2 } (741+1) [6384] - M  - 813 11 HvFd F0 IV
 2116                      D8A3515-5 Fl Ni Nain8                  { -3 } (343-1) [3267] - -  - 100  7 HvFd K7 V
 2118                      B000521-E As Va Ni                     {  1 } (A43-4) [164F] - -  - 402  8 HvFd K3 V M8 V
-2213                      D5848S6-3 Ri Ph Pa                     { -1 } (777+2) [C736] - M  - 923 15 HvFd F0 V
+2213                      D584856-3 Ri Ph Pa                     { -1 } (777+2) [C736] - M  - 923 15 HvFd F0 V
 2215                      A524502-E Ni Nain9                     {  1 } (946-1) [867E] - M  - 812  9 HvFd M3 V
 2219                      C523663-5 Na Ni Po Cy O:2419           { -2 } (A52+0) [6446] - -  - 524 18 HvFd M3 V M7 V
 2220                      C554301-8 Lo                           { -2 } (C21+2) [6188] - M  - 404 13 HvFd K6 V M7 V
@@ -178,17 +178,17 @@ Hex  Name                 UWP       Remarks                      {Ix}   (Ex)    
 2412                      E659562-8 Ni Cy O:2516                 { -3 } (443+0) [8249] - -  - 110  8 HvFd M9 V M9 V
 2414                      C639204-8 Lo                           { -2 } (D11+2) [1177] - -  - 123 13 HvFd G5 V M9 V
 2415                      C654561-8 Ag Ni Cy O:2516              { -1 } (A41+1) [1419] - -  - 903 13 HvFd M0 V
-2418                      A8A17S5-C Fl He Cp                     {  2 } (C6A+1) [A99C] - K  - 704 10 HvFd M2 V
-2419                      B4108S1-A Na Pi Ph                     {  2 } (A7A-1) [BA7D] - -  - 920 14 HvFd A3 V
+2418                      A8A1785-C Fl He Cp                     {  2 } (C6A+1) [A99C] - K  - 704 10 HvFd M2 V
+2419                      B410885-A Na Pi Ph                     {  2 } (A7A-1) [BA7D] - -  - 920 14 HvFd A3 V
 2511                      D646562-7 Ag Ni Cy O:2516              { -2 } (644+3) [3317] - M  - 924 15 HvFd G7 V
 2512                      B300201-E Lo Va                        {  1 } (D11-1) [437E] - K  - 214 14 HvFd F0 V
-2516                      A4507S6-C De Po Cp                     {  2 } (F68-2) [7947] - K  - 214 15 HvFd G2 V
-2611                      D5638T5-3 Ri Ph                        { -1 } (A73+1) [77A5] - M  - 100 11 HvFd M2 V M4 V
-2612                      D6677S6-2 Ag Ri Ga                     {  0 } (96B+0) [3772] - M  - 804 11 HvFd M9 V
+2516                      A450786-C De Po Cp                     {  2 } (F68-2) [7947] - K  - 214 15 HvFd G2 V
+2611                      D563887-3 Ri Ph                        { -1 } (A73+1) [77A5] - M  - 100 11 HvFd M2 V M4 V
+2612                      D667786-2 Ag Ri Ga                     {  0 } (96B+0) [3772] - M  - 804 11 HvFd M9 V
 2614                      X100623-0 Na Ni Va Aoao9 Fo            { -3 } (853+0) [4333] - -  R 713 12 HvFd M9 V
 2616                      A543411-8 Ni Po                        { -1 } (533-4) [1338] - -  - 100 10 HvFd M1 V M6 V
 2619                      A8A4002-D Fl Di                        {  1 } (E03+0) [0000] - K  - 004 16 HvFd G7 V M9 V
-2713                      E5358S4-5 Ph                           { -2 } (A74-1) [665A] - -  - 414 18 HvFd M5 V M2 V
+2713                      E535885-5 Ph                           { -2 } (A74-1) [665A] - -  - 414 18 HvFd M5 V M2 V
 2714                      C100304-8 Lo Va AoaoW Pz               { -2 } (721+0) [2178] - -  A 604 10 HvFd M2 V K5 V
 2716 Ao                   C666763-8 Ag Ri Ga (Aoao) Cy O:2619 Da {  1 } (A69+3) [485C] - -  A 101 12 HvFd M3 V K0 V
 2718                      C679101-7 Lo AoaoW Pz                  { -2 } (401+4) [2194] - -  A 200 10 HvFd M0 V
@@ -198,20 +198,20 @@ Hex  Name                 UWP       Remarks                      {Ix}   (Ex)    
 2913                      D77A202-7 Lo Wa                        { -3 } (A11+2) [11A2] - M  - 300  7 HvFd F5 V M5 V
 2914                      D697561-7 Ag Ni Cy O:3116              { -2 } (C40-4) [2377] - M  - 402 12 HvFd M2 V K7 V
 3011                      D455362-7 Lo O:3116                    { -3 } (C21+5) [111C] - -  - 312 12 HvFd G6 V
-3012                      D5487S4-4 Ag Pi                        { -1 } (862+3) [9634] - M  - 102 14 HvFd M1 V K9 V
-3016                      C4916S2-8 Ni He                        { -2 } (C50-4) [1456] - -  - 613 11 HvFd M3 V
-3020                      C6957S3-5 Ag Pi                        {  0 } (767-4) [7753] - -  - 123 12 HvFd F7 V
-3116                      C5698T4-9 Ri Ph                        {  1 } (577+1) [995C] - -  - 500  6 HvFd K3 IV
+3012                      D548754-4 Ag Pi                        { -1 } (862+3) [9634] - M  - 102 14 HvFd M1 V K9 V
+3016                      C491652-8 Ni He                        { -2 } (C50-4) [1456] - -  - 613 11 HvFd M3 V
+3020                      C695783-5 Ag Pi                        {  0 } (767-4) [7753] - -  - 123 12 HvFd F7 V
+3116                      C569894-9 Ri Ph                        {  1 } (577+1) [995C] - -  - 500  6 HvFd K3 IV
 3120                      C213211-7 Ic Lo                        { -2 } (811+1) [5177] - M  - 313  8 HvFd F6 V
-3211 Koraa                D0009U5-8 As Va Hi Na In               {  0 } (A87-4) [497C] - -  - 502 12 HvFd K5 V
-3218                      B5347S3-9                              {  2 } (A65+2) [7955] - KM - 904  9 HvFd F5 V
+3211 Koraa                D0009A8-8 As Va Hi Na In               {  0 } (A87-4) [497C] - -  - 502 12 HvFd K5 V
+3218                      B534786-9                              {  2 } (A65+2) [7955] - KM - 904  9 HvFd F5 V
 3220                      B566301-7 Lo                           { -1 } (221-4) [52A8] - K  - 824 14 HvFd M1 V
 0123                      C635101-A Lo                           {  0 } (601+2) [316A] - -  - 500  5 HvFd G7 V M4 V
 0125                      C877864-7 Ph Pa Pi O:0123              { -1 } (B79+2) [5757] - M  - 823 11 HvFd K7 V M2 V
 0127                      C856521-6 Ag Ni Ga                     { -1 } (943+0) [1463] - -  - 905 15 HvFd M6 V M2 V
 0130                      C778212-9 Lo                           { -1 } (E11-1) [3156] - -  - 105 12 HvFd M3 V
-0221                      E4267S4-5 Pi                           { -2 } (664+1) [3543] - -  - 700 10 HvFd G8 V
-0223                      E0008S3-4 As Va Na Ph Pi               { -2 } (479-2) [7616] - -  - 913 15 HvFd M9 V M2 V
+0221                      E426786-5 Pi                           { -2 } (664+1) [3543] - -  - 700 10 HvFd G8 V
+0223                      E000883-4 As Va Na Ph Pi               { -2 } (479-2) [7616] - -  - 913 15 HvFd M9 V M2 V
 0323                      E150512-8 De Ni Po                     { -3 } (A40+4) [4259] - -  - 100  4 HvFd M9 V
 0330                      C744313-5 Lo                           { -2 } (C21+2) [3153] - M  - 303 10 HvFd M1 III M8 V
 0423                      C985105-8 Lo                           { -2 } (D01-3) [114B] - -  - 604 14 HvFd G6 V
@@ -219,72 +219,72 @@ Hex  Name                 UWP       Remarks                      {Ix}   (Ex)    
 0426                      E000514-8 As Va Ni                     { -3 } (E40-1) [2297] - -  - 824 14 HvFd K5 V
 0430                      EA9A503-5 Ni Oc                        { -3 } (C41-2) [8255] - -  - 801 10 HvFd G7 V M5 V
 0530                      E967864-5 Ph Pa Ri O:0531              { -1 } (871+4) [4766] - -  - 914 17 HvFd G5 III
-0622                      E7578S6-2 Ga Ph Pa                     { -2 } (473+1) [7612] - -  - 925 17 HvFd M3 V
-0625 Ikask                A784823-C Ph Pa Ri Cp                  { 3 }  (575+1) [AB38] - -  - 302 15 HvFd M3 V M7 V
+0622                      E757886-2 Ga Ph Pa                     { -2 } (473+1) [7612] - -  - 925 17 HvFd M3 V
+0625 Ikask                A784897-C Ph Pa Ri Cp                  { 3 }  (575+1) [AB38] - -  - 302 15 HvFd M3 V M7 V
 0722                      E668562-5 Ag Ni Pr Cy O:0820           { -2 } (B40+1) [7367] - -  - 802 11 HvFd A1 V G0 V
-0725                      C6426S2-8 He Ni Po                     { -2 } (951+1) [5438] - M  - 400  7 HvFd M5 V M7 V
-0821                      C4006S4-6 Na Ni Va                     { -2 } (A52-5) [1416] - -  - 202 12 HvFd K3 V
+0725                      C642687-8 He Ni Po                     { -2 } (951+1) [5438] - M  - 400  7 HvFd M5 V M7 V
+0821                      C400689-6 Na Ni Va                     { -2 } (A52-5) [1416] - -  - 202 12 HvFd K3 V
 0825                      C675421-7 Ni Pa                        { -2 } (734+1) [1247] - -  - 510  7 HvFd K4 IV
 0826                      E200525-6 Ni Va                        { -3 } (640-4) [8256] - -  - 103 11 HvFd M3 V M3 V
 0827                      E460423-8 De Ni                        { -3 } (C32-2) [3187] - -  - 620 11 HvFd M7 V G4 V
 0922                      B100421-B Ni Va                        {  1 } (736-2) [656B] - -  - 704  8 HvFd M2 V M2 V
-0923                      C4546S5-5 Ag Ni                        { -1 } (950-3) [6556] - -  - 303 10 HvFd G5 V M3 V
+0923                      C454685-5 Ag Ni                        { -1 } (950-3) [6556] - -  - 303 10 HvFd G5 V M3 V
 0929                      D000564-7 Va As Ni O:0531              { -3 } (841+1) [5289] - -  - 905  9 HvFd M9 III
 0930                      A845521-9 Ag Ni                        {  1 } (944-3) [2658] - -  - 801 10 HvFd M8 II
-1021 Oao Iei              C4339T5-B Hi Na Po                     {  2 } (E89-2) [BB5E] - -  - 413  8 HvFd M1 V
+1021 Oao Iei              C433987-B Hi Na Po                     {  2 } (E89-2) [BB5E] - -  - 413  8 HvFd M1 V
 1025                      A84A461-B Ni Wa O:1227                 {  1 } (B37-3) [655B] - -  - 703 15 HvFd K4 V M4 V
 1026                      A55A463-C Ni Wa O:1227                 {  1 } (A34+1) [755D] - K  - 500  7 HvFd M2 V K1 V
-1029                      D1108S4-9 Na Ph Pi                     { -1 } (E7A-1) [6759] - -  - 812  6 HvFd K3 V M9 V
+1029                      D110886-9 Na Ph Pi                     { -1 } (E7A-1) [6759] - -  - 812  6 HvFd K3 V M9 V
 1030                      A778202-D Lo                           {  1 } (711+4) [435D] - K  - 911 11 HvFd A8 V
-1122                      C6387S1-4                              { -1 } (767+3) [7651] - -  - 702  6 HvFd G5 V
+1122                      C638785-4                              { -1 } (767+3) [7651] - -  - 702  6 HvFd G5 V
 1127                      A210421-A Ni                           {  2 } (936+0) [566D] - KM - 604 10 HvFd M2 V
 1128                      C588203-7 Lo                           { -2 } (511-3) [4156] - M  - 103 11 HvFd M0 V M3 V
 1129                      C674526-8 Ag Ni                        { -1 } (842-2) [7417] - -  - 900 11 HvFd G8 V
 1130                      A464312-C Lo                           {  1 } (F21-3) [242C] - K  - 204 12 HvFd G1 V
 1221                      B693665-7 Ni O:1519                    { -1 } (351+0) [2569] - -  - 702  9 HvFd K3 IV
-1222                      A9877S4-8 Ag Ri                        {  2 } (A6B+1) [7969] - -  - 303 11 HvFd F3 V
-1224                      C6378S1-5 Ph                           { -1 } (778+1) [8736] - M  - 814  8 HvFd M4 V M3 V M4 V
+1222                      A987787-8 Ag Ri                        {  2 } (A6B+1) [7969] - -  - 303 11 HvFd F3 V
+1224                      C637887-5 Ph                           { -1 } (778+1) [8736] - M  - 814  8 HvFd M4 V M3 V M4 V
 1226                      A487216-C Lo                           {  1 } (C11+2) [433D] - K  - 904  9 HvFd M0 V M5 V
-1227 Koia                 C5359T2-9 Hi                           {  1 } (985-2) [CA66] - -  - 300  5 HvFd M3 V M8 V
+1227 Koia                 C535987-9 Hi                           {  1 } (985-2) [CA66] - -  - 300  5 HvFd M3 V M8 V
 1229                      A553103-D Lo Po                        {  1 } (901+1) [425F] - K  - 504 10 HvFd G7 III
 1323 Guuaron              AAC4301-B Fl Lo (Guuaron) Pz           {  1 } (D21-1) [146C] - K  A 904 10 HvFd M9 V M1 V
 1325                      B210302-E Lo                           {  1 } (921-3) [445E] - -  - 204 12 HvFd K8 V
 1326                      B8B8663-9 Fl Ni Guua9 Cy O:1227 Pz     {  0 } (753+0) [269D] - -  A 323 18 HvFd F5 V
-1330 Ivankil              A3029S6-F Hi Ic Na Va In Cp            {  4 } (B8F-2) [6D6F] - K  - 403 13 HvFd K4 V M2 V
-1422                      AA8A7T4-9 Ri Oc                        {  2 } (F65+0) [492B] - -  - 104 10 HvFd M1 III
+1330 Ivankil              A302998-F Hi Ic Na Va In Cp            {  4 } (B8F-2) [6D6F] - K  - 403 13 HvFd K4 V M2 V
+1422                      AA8A794-9 Ri Oc                        {  2 } (F65+0) [492B] - -  - 104 10 HvFd M1 III
 1427                      C533513-A Ni Po                        {  0 } (D43+0) [8536] - M  - 115 17 HvFd M1 V K6 V
 1430                      A527424-C Ni                           {  1 } (D34-1) [253F] - -  - 603 14 HvFd M0 V
 1526                      C000401-A As Va Ni                     {  0 } (934+0) [5429] - -  - 604 11 HvFd M9 V
-1529                      A9876S5-9 Ag Ni Ri                     {  2 } (C53-2) [1874] - -  - 401  8 HvFd M2 V
+1529                      A987685-9 Ag Ni Ri                     {  2 } (C53-2) [1874] - -  - 401  8 HvFd M2 V
 1530                      A100562-E Ni Va Cy O:1330              {  1 } (744+2) [663D] - -  - 800  3 HvFd G3 V M8 V
 1623                      B777565-9 Ag Ni O:1422                 {  1 } (445+1) [961E] - -  - 901 10 HvFd G5 V M2 V
 1624                      A7A8203-B Fl Lo                        {  1 } (B11+1) [135A] - K  - 104 11 HvFd M0 V M1 V
 1627                      C552301-7 Lo Po                        { -2 } (821+0) [7195] - M  - 204 11 HvFd M4 V M5 V
 1722                      E655321-5 Lo Ga                        { -3 } (721+3) [8173] - -  - 303 11 HvFd M1 V
-1723                      C5507S2-6 De Po                        { -1 } (96B-5) [A627] - M  - 914  9 HvFd M9 V K5 V
-1724 Peea                 C574AW6-7 Hi In                        {  1 } (C99-1) [7B16] - M  - 104  8 HvFd K7 V
+1723                      C550787-6 De Po                        { -1 } (96B-5) [A627] - M  - 914  9 HvFd M9 V K5 V
+1724 Peea                 C574A97-7 Hi In                        {  1 } (C99-1) [7B16] - M  - 104  8 HvFd K7 V
 1725                      C432101-A Lo Po                        {  0 } (901-3) [1169] - -  - 224 11 HvFd G1 III
 1726                      E787321-5 Lo Ga                        { -3 } (721-4) [4159] - -  - 712 10 HvFd M4 V
 1728                      E755724-1 Ag Ga                        { -1 } (A63-3) [3661] - -  - 811  8 HvFd G9 V
 1729                      C686303-9 Lo Ga                        { -1 } (A21+4) [2239] - M  - 613 14 HvFd M9 III M3 V
 1821                      E547562-3 Ag Ni Cy O:1819              { -2 } (444+3) [7341] - -  - 414 13 HvFd M4 V
-1823                      E4658S4-7 Ri Ph Pa                     { -1 } (671+1) [D786] - -  - 514 12 HvFd M8 III M8 V
+1823                      E465884-7 Ri Ph Pa                     { -1 } (671+1) [D786] - -  - 514 12 HvFd M8 III M8 V
 1824                      E100312-8 Lo Va                        { -3 } (F21-2) [8129] - -  - 724 14 HvFd G3 V
-1828                      E4456S5-7 Ag Ni                        { -2 } (650+1) [2456] - -  - 832 14 HvFd G2 V M0 V
+1828                      E445685-7 Ag Ni                        { -2 } (650+1) [2456] - -  - 832 14 HvFd G2 V M0 V
 1928                      E363464-4 Ni Re O:2427                 { -3 } (730+1) [1184] - -  - 905 15 HvFd M9 V
 1929                      E655421-2 Ni Ga Pa                     { -3 } (430-2) [8176] - -  - 202 15 HvFd M1 V
 2023                      E120001-5 Di De Po                     { -3 } (500-1) [0000] - -  - 010  9 HvFd A7 V
-2024 Uqqapin              C6B0825-7 He Ph (Uqqapin) Da           { -1 } (972+4) [5756] - -  A 510 12 HvFd G3 V M0 V
+2024 Uqqapin              C6B0885-7 He Ph (Uqqapin) Da           { -1 } (972+4) [5756] - -  A 510 12 HvFd G3 V M0 V
 2026                      C544364-8 Lo Re O:2427                 { -2 } (B21-1) [4198] - -  - 702  9 HvFd M0 V M7 V
-2027 Ninooo               C89A9T3-7 Hi In Wa                     {  1 } (38A+0) [6A97] - -  - 424 13 HvFd M5 V
+2027 Ninooo               C89A9A7-7 Hi In Wa                     {  1 } (38A+0) [6A97] - -  - 424 13 HvFd M5 V
 2030                      B444202-A Lo                           {  1 } (D11+1) [1387] - -  - 103 13 HvFd K4 V
 2121                      C310524-7 Ni                           { -2 } (A44+3) [4388] - M  - 810 10 HvFd M9 V
 2123                      C556562-9 Ag Ni Cy O:1819              {  0 } (545+2) [755B] - -  - 200 11 HvFd M2 V
 2127                      B120201-A De Lo Po                     {  1 } (F11+0) [1347] - K  - 103 16 HvFd G7 V
-2130                      B5428S6-6 Po He Ph Pi                  {  0 } (A72+1) [B835] - K  - 823 15 HvFd F6 III
+2130                      B542886-6 Po He Ph Pi                  {  0 } (A72+1) [B835] - K  - 823 15 HvFd F6 III
 2221                      C622202-6 Lo He Po                     { -2 } (711-1) [1195] - -  - 112  8 HvFd K1 IV
 2223                      D200314-9 Lo Va                        { -2 } (E21-3) [11A6] - -  - 304 10 HvFd G7 IV M0 V
-2224                      D2326S5-7 Na Ni Po                     { -3 } (850+3) [833B] - -  - 424 17 HvFd K1 V M5 V
+2224                      D232685-7 Na Ni Po                     { -3 } (850+3) [833B] - -  - 424 17 HvFd K1 V M5 V
 2226                      D150463-5 De Ni Po O:2427              { -3 } (631-2) [5159] - -  - 504 13 HvFd M1 II
 2227                      D100101-A Lo Va                        { -1 } (D01-5) [5167] - -  - 603 14 HvFd G8 V
 2228                      D301861-6 Ic Na Va Ph Pi Cy O:2427     { -2 } (774+1) [B645] - -  - 803  6 HvFd M7 V
@@ -292,149 +292,149 @@ Hex  Name                 UWP       Remarks                      {Ix}   (Ex)    
 2421                      C410513-6 Ni                           { -2 } (440-2) [538A] - M  - 114 16 HvFd M1 V
 2422                      B453306-C Lo Po                        {  1 } (921+0) [342D] - K  - 213 11 HvFd M0 V
 2424                      B365612-8 Ag Ni Ri                     {  1 } (A54-3) [5738] - M  - 303 10 HvFd M4 V
-2427 Eooa                 B3349S4-E Hi Cp                        {  3 } (78A+3) [CC4D] - -  - 402 12 HvFd F0 V
+2427 Eooa                 B334994-E Hi Cp                        {  3 } (78A+3) [CC4D] - -  - 402 12 HvFd F0 V
 2429 Naeaoo               E8C7623-5 Fl Ni (Naeaoo) Pz            { -3 } (753-3) [5353] - -  A 211 10 HvFd F5 V
 2430                      E849315-3 Lo                           { -3 } (821+4) [3121] - -  - 314  8 HvFd A7 V
 2530                      B88A201-C Lo Wa                        {  1 } (911+0) [135D] - K  - 903 11 HvFd M9 V
-2624                      B3537S4-7 Po                           {  0 } (76A-2) [4737] - K  - 300  5 HvFd K5 V
+2624                      B353784-7 Po                           {  0 } (76A-2) [4737] - K  - 300  5 HvFd K5 V
 2626                      E405102-5 Ic Lo Va                     { -3 } (C01+2) [1195] - -  - 522 16 HvFd M4 V
 2629                      B787325-6 Lo Ga                        { -1 } (A21+1) [5247] - -  - 200 10 HvFd M8 V
 2724                      B331564-C Ni Po O:2427                 {  1 } (746+4) [467A] - -  - 412  8 HvFd M3 V M4 V
 2727                      E64A723-3 Wa Pi                        { -2 } (662-2) [9553] - -  - 713 13 HvFd G5 V M0 V M1 V
 2728                      E673506-6 Ni                           { -3 } (942+3) [429A] - -  - 815 12 HvFd M1 V
 2730 Hak Hak              B8B0862-A He Ph (Hak) Cy O:2931 Pz     {  2 } (975+1) [5A8C] - -  A 100  8 HvFd M0 V
-2824                      D7A28S1-6 He Ph Fl                     { -2 } (579-5) [A648] - M  - 602 10 HvFd G8 V M6 V
+2824                      D7A2887-6 He Ph Fl                     { -2 } (579-5) [A648] - M  - 602 10 HvFd G8 V M6 V
 2825                      C110204-C Lo                           {  0 } (711-3) [326D] - -  - 100  9 HvFd G9 V
-2828                      A4358T2-C Ph                           {  2 } (A7A+2) [8A6E] - K  - 803 12 HvFd K1 V
-2923 Nudrana              D5129U5-7 Hi Ic Na In                  {  0 } (386+1) [A9A7] - M  - 404 14 HvFd M1 III
+2828                      A435897-C Ph                           {  2 } (A7A+2) [8A6E] - K  - 803 12 HvFd K1 V
+2923 Nudrana              D5129B8-7 Hi Ic Na In                  {  0 } (386+1) [A9A7] - M  - 404 14 HvFd M1 III
 2926                      B8B2413-C He Fl Ni HakW Pz             {  1 } (735+3) [458B] - M  A 514 16 HvFd G4 V M1 V
-2927                      B88A7S6-A Wa Ri                        {  3 } (C6C+1) [4A5A] - K  - 624 12 HvFd G1 V M4 V
+2927                      B88A786-A Wa Ri                        {  3 } (C6C+1) [4A5A] - K  - 624 12 HvFd G1 V M4 V
 2930                      B463411-B Ni                           {  1 } (835+4) [657B] - -  - 510  6 HvFd M9 III
 3022                      E883321-7 Lo                           { -3 } (921+0) [1142] - -  - 200  9 HvFd M8 V G2 V
 3024                      D565204-5 Lo                           { -3 } (211-3) [1141] - M  - 404 14 HvFd K0 V
-3121                      B6797S2-9 Pi                           {  1 } (B6C+2) [684A] - K  - 304 10 HvFd K7 V
-3125                      E8586U4-3 Ag Ni                        { -2 } (754+2) [8466] - -  - 201  4 HvFd M6 V
+3121                      B679787-9 Pi                           {  1 } (B6C+2) [684A] - K  - 304 10 HvFd K7 V
+3125                      E858694-3 Ag Ni                        { -2 } (754+2) [8466] - -  - 201  4 HvFd M6 V
 3221                      B759563-9 Ni Cy O:3224                 {  0 } (B44+0) [4599] - -  - 414  9 HvFd M0 III M1 V
 3223                      B223525-8 Ni Po                        { -1 } (841-1) [4449] - M  - 601  7 HvFd G5 V
-3224 Iooua                B8B4923-B Fl Hi In (Iooua) Cp          {  4 } (F8D+4) [7D9B] - K  - 734 17 HvFd M7 V
+3224 Iooua                B8B4976-B Fl Hi In (Iooua) Cp          {  4 } (F8D+4) [7D9B] - K  - 734 17 HvFd M7 V
 3227                      B798106-C Lo                           {  1 } (801-3) [129A] - M  - 603 12 HvFd G2 V
 3229                      A150512-C De Ni Po                     {  2 } (946+3) [673B] - KM - 801 13 HvFd M1 V M6 V
 0139                      B8B4463-A Fl Ni O:0238 Pz              {  2 } (D37+1) [4657] - KM A 223 14 HvFd M6 V
-0232                      C7798T1-6 Ph Pi                        { -1 } (878+3) [A769] - M  - 515 15 HvFd M7 V
+0232                      C7798A9-6 Ph Pi                        { -1 } (878+3) [A769] - M  - 515 15 HvFd M7 V
 0235 Oduart               C7B3004-5 Fl Di(Oduart) Da             { -2 } (800+2) [0000] - M  A 004 10 HvFd M3 V M7 V G4 V
-0238                      A6818S2-A Ri Ph                        {  4 } (87B+2) [BC65] - KM - 403 12 HvFd K5 V M9 V
+0238                      A681887-A Ri Ph                        {  4 } (87B+2) [BC65] - KM - 403 12 HvFd K5 V M9 V
 0239                      B202421-A Ic Ni Va                     {  2 } (433-3) [463A] - KM - 901  9 HvFd K8 V M3 V
-0240                      B2247S5-8 Pi                           {  0 } (D68+4) [B74B] - K  - 104 14 HvFd M0 V
+0240                      B224785-8 Pi                           {  0 } (D68+4) [B74B] - K  - 104 14 HvFd M0 V
 0332                      A776662-C Ag Ni Cy O:0531              {  2 } (857+5) [686A] - -  - 700 10 HvFd G1 V M4 V
-0334                      B7387S3-8                              {  0 } (F69+1) [A737] - -  - 105 14 HvFd M4 V M9 V
+0334                      B738753-8                              {  0 } (F69+1) [A737] - -  - 105 14 HvFd M4 V M9 V
 0336                      C888763-4 Ag Ri Cy O:0238              {  1 } (86C+1) [6857] - -  - 214 10 HvFd M2 V
 0431                      A744306-B Lo                           {  1 } (621-4) [145C] - K  - 800 10 HvFd M4 V
-0434 Ioou                 B64AAW1-B Hi In Wa                     {  4 } (F97+1) [AE1B] - -  - 215 18 HvFd A5 V
-0437                      B7836S4-5 Ni Ri                        {  0 } (656+1) [A643] - M  - 604 13 HvFd G3 IV M5 V
+0434 Ioou                 B64AA97-B Hi In Wa                     {  4 } (F97+1) [AE1B] - -  - 215 18 HvFd A5 V
+0437                      B783684-5 Ni Ri                        {  0 } (656+1) [A643] - M  - 604 13 HvFd G3 IV M5 V
 0440                      B746322-9 Lo                           {  0 } (521-1) [4357] - K  - 710 10 HvFd M9 V M4 V
-0531 Lufeku               A326AW5-F Hi In Cp                     {  4 } (69B+4) [FE6F] - -  - 210  6 HvFd M2 V
-0539 Lorufit              B99AAU6-E Hi In Wa                     {  4 } (69F-1) [AE5B] - -  - 200  8 HvFd M2 V
-0632                      C1008S3-A Na Va Ph Pi                  {  1 } (D76-2) [898F] - -  - 624 14 HvFd M1 V K7 V
+0531 Lufeku               A326AA8-F Hi In Cp                     {  4 } (69B+4) [FE6F] - -  - 210  6 HvFd M2 V
+0539 Lorufit              B99AAA7-E Hi In Wa                     {  4 } (69F-1) [AE5B] - -  - 200  8 HvFd M2 V
+0632                      C100883-A Na Va Ph Pi                  {  1 } (D76-2) [898F] - -  - 624 14 HvFd M1 V K7 V
 0731                      A444364-9 Lo Re O:0531                 {  0 } (821+1) [134A] - K  - 903 11 HvFd G6 V M5 V M2 V
-0732                      A4637S1-C Ri                           {  3 } (B6A-5) [CA3D] - -  - 105 15 HvFd M5 V
+0732                      A463786-C Ri                           {  3 } (B6A-5) [CA3D] - -  - 105 15 HvFd M5 V
 0734                      D659001-5 Di                           { -3 } (200-5) [0000] - -  - 013 12 HvFd M7 V
 0737                      B120322-C De Lo Po                     {  2 } (C21+0) [859F] - KM - 704 14 HvFd K4 V M2 V
 0832                      C999313-7 Lo                           { -2 } (621+1) [3137] - M  - 804 11 HvFd M2 V
 0833                      A615561-9 Ic Ni Cy O:1132              {  0 } (844-1) [8549] - K  - 402 10 HvFd M7 V
-0834                      A5468T4-B Ph Pa Pi                     {  2 } (A75-5) [5A7A] - -  - 502  7 HvFd M6 V M8 V
-0835                      A7527S6-8 Po                           {  0 } (D67-3) [C754] - M  - 104 15 HvFd G0 V
-0838                      B2208S4-8 De Na Po Ph Pi               {  0 } (876+2) [A829] - K  - 513 10 HvFd M1 V K7 V
+0834                      A546884-B Ph Pa Pi                     {  2 } (A75-5) [5A7A] - -  - 502  7 HvFd M6 V M8 V
+0835                      A752786-8 Po                           {  0 } (D67-3) [C754] - M  - 104 15 HvFd G0 V
+0838                      B220884-8 De Na Po Ph Pi               {  0 } (876+2) [A829] - K  - 513 10 HvFd M1 V K7 V
 0931                      A230202-E De Lo Po                     {  1 } (811+3) [23AC] - -  - 100  6 HvFd K6 V M9 V
 0934                      B659521-9 Ni                           {  0 } (941-2) [6544] - -  - 904 17 HvFd M5 V M9 V
-0935                      B6888T4-A Ri Ph Pa                     {  3 } (D7B+4) [3B48] - -  - 114 15 HvFd G1 V
+0935                      B688887-A Ri Ph Pa                     {  3 } (D7B+4) [3B48] - -  - 114 15 HvFd G1 V
 0940 Wrur                 A8B6722-E Fl (Wrur) Pz                 {  2 } (866+0) [794E] - -  A 720  9 HvFd F7 V
 1031                      C510425-8 Ni                           { -2 } (931+2) [7248] - M  - 601 14 HvFd G5 V
 1033                      A544103-C Lo                           {  2 } (E01+2) [236E] - KM - 704 14 HvFd M4 V
 1036                      C89A562-6 Ni Wa Cy O:0935              { -2 } (340-3) [A366] - M  - 302 10 HvFd A7 V
 1039                      C150411-7 De Ni Po                     { -2 } (430-3) [7268] - M  - 602  9 HvFd M3 V
 1040                      C544665-7 Ag Ni O:0539                 { -1 } (850-3) [556C] - -  - 305  9 HvFd M3 V
-1131                      C4387S6-6                              { -1 } (563+4) [46A4] - -  - 604 11 HvFd M7 V M7 V
-1132 Ooanu                A1209T4-C De Hi In Na Po Cp            {  4 } (A8F-1) [8D6F] - -  - 204 14 HvFd F9 IV
+1131                      C438776-6                              { -1 } (563+4) [46A4] - -  - 604 11 HvFd M7 V M7 V
+1132 Ooanu                A120984-C De Hi In Na Po Cp            {  4 } (A8F-1) [8D6F] - -  - 204 14 HvFd F9 IV
 1134                      A687421-8 Ni Ga Pa                     { -1 } (935+0) [5356] - -  - 624 15 HvFd M1 V M0 V
 1135                      C665625-5 Ag Ni Ri Ga                  {  0 } (756+1) [7649] - M  - 204 15 HvFd M0 V
 1136                      B767462-6 Ni Ga Pa O:0925              { -1 } (A35-4) [4347] - K  - 712  6 HvFd M2 V
 1138                      D364301-5 Lo                           { -3 } (421+0) [1183] - M  - 403 12 HvFd M0 V
-1140 Zaonec               C5789S3-7 Hi In                        {  1 } (B88+3) [AA17] - -  - 404 14 HvFd M6 V M6 V
-1231                      A1007S6-D Na Va Pi                     {  2 } (769+2) [996F] - K  - 320 11 HvFd K9 V M5 V
-1234                      A6537T4-9 Po                           {  1 } (967-4) [5888] - K  - 514 13 HvFd M2 III M6 V K2 V
+1140 Zaonec               C578985-7 Hi In                        {  1 } (B88+3) [AA17] - -  - 404 14 HvFd M6 V M6 V
+1231                      A100786-D Na Va Pi                     {  2 } (769+2) [996F] - K  - 320 11 HvFd K9 V M5 V
+1234                      A653784-9 Po                           {  1 } (967-4) [5888] - K  - 514 13 HvFd M2 III M6 V K2 V
 1236                      E130565-7 De Ni Po O:0935              { -3 } (643-2) [8292] - -  - 402 13 HvFd K3 II M7 V
 1237                      C342464-9 He Ni Po Re O:0935           { -1 } (B31+1) [2318] - M  - 110  4 HvFd M3 V
 1335                      A736362-E Lo O:1132                    {  1 } (A21+3) [242F] - K  - 403 16 HvFd M7 V M6 V
 1337                      C584523-7 Ag Pr Ni                     { -1 } (A43+1) [748C] - M  - 303 10 HvFd G7 II
 1339                      A471611-C He Ni                        {  1 } (C52-1) [378E] - -  - 312 15 HvFd M5 V
 1432                      C688562-9 Ag Ni Pr Cy O:1132           {  0 } (641-3) [5589] - -  - 112  9 HvFd M8 V
-1433                      A2007S5-C Na Va Pi                     {  2 } (D67+0) [B97F] - -  - 613 16 HvFd M0 V
+1433                      A200785-C Na Va Pi                     {  2 } (D67+0) [B97F] - -  - 613 16 HvFd M0 V
 1434                      A224413-A Ni                           {  1 } (E34+3) [552B] - M  - 713 11 HvFd G4 V
-1435 Oophlare             A7C5712-C Fl (Oophlare) Pz             {  2 } (C65+3) [293E] - K  A 204 16 HvFd G7 V M9 V M4 V
+1435 Oophlare             A7C5785-C Fl (Oophlare) Pz             {  2 } (C65+3) [293E] - K  A 204 16 HvFd G7 V M9 V M4 V
 1436                      B448404-A Ni Pa                        {  1 } (735-3) [5517] - K  - 700 11 HvFd M9 V
 1438                      B445521-A Ag Ni                        {  2 } (D43-4) [4739] - M  - 904 15 HvFd M1 V M6 V
-1440                      A1307S1-D De Na Po                     {  2 } (965+3) [693E] - K  - 500  5 HvFd M5 V
+1440                      A130756-D De Na Po                     {  2 } (965+3) [693E] - K  - 500  5 HvFd M5 V
 1532                      C659213-5 Lo                           { -2 } (711+3) [1141] - -  - 913 11 HvFd M0 III
-1534 Olaposk              C5419U6-8 He Hi In Po                  {  1 } (F88-1) [BA67] - M  - 424 15 HvFd G6 V
+1534 Olaposk              C5419A8-8 He Hi In Po                  {  1 } (F88-1) [BA67] - M  - 424 15 HvFd G6 V
 1631                      B642424-8 He Ni Po                     { -1 } (833+3) [2367] - M  - 503 11 HvFd M8 V M7 V
-1632                      B6867S5-A Ag Ga Ri                     {  4 } (66E-2) [7B9C] - K  - 602  8 HvFd M2 V
-1634                      A3748S2-C Ph Pa Pi                     {  2 } (775-3) [5A9E] - K  - 812 11 HvFd M5 V
+1632                      B686785-A Ag Ga Ri                     {  4 } (66E-2) [7B9C] - K  - 602  8 HvFd M2 V
+1634                      A374885-C Ph Pa Pi                     {  2 } (775-3) [5A9E] - K  - 812 11 HvFd M5 V
 1638                      B689521-7 Ni Pr                        {  0 } (846-1) [7586] - KM - 905 12 HvFd M8 V
-1731                      B5966S2-8 Ag Ni                        {  0 } (E55-2) [5678] - K  - 204 14 HvFd M5 V M9 V M2 V
+1731                      B596689-8 Ag Ni                        {  0 } (E55-2) [5678] - K  - 204 14 HvFd M5 V M9 V M2 V
 1735                      C451206-B Lo Po                        {  0 } (D11+0) [6268] - M  - 923 11 HvFd G9 V
 1736                      C374623-7 Ag Ni                        { -1 } (655+2) [9556] - -  - 123 13 HvFd M0 V
 1740                      C678104-7 Lo                           { -2 } (901-2) [213B] - -  - 521 15 HvFd M6 V
-1836                      C5648S1-7 Ri Ph Pa                     {  0 } (676+2) [7829] - -  - 714 11 HvFd G4 V M8 V
+1836                      C564887-7 Ri Ph Pa                     {  0 } (676+2) [7829] - -  - 714 11 HvFd G4 V M8 V
 1838                      C422512-7 He Ni Po                     { -2 } (743+3) [5325] - -  - 813  9 HvFd F9 IV
 1839                      C000664-6 As Va Na Ni O:1440           { -2 } (650+1) [5422] - -  - 101 10 HvFd M7 V M3 V
 1932                      D200423-7 Ni Va                        { -3 } (530-2) [2186] - -  - 502 13 HvFd M8 V M9 V
 1934                      C403561-8 Ic Ni Va Cy O:2134           { -2 } (542-2) [638D] - -  - 902  7 HvFd F1 IV M3 V
 1935                      C9E4305-6 Lo                           { -2 } (721+0) [8185] - -  - 314 12 HvFd M9 V
 1936                      C140204-8 De Lo Po                     { -2 } (F11+1) [213A] - M  - 934 10 HvFd M0 V
-2035                      C4828T5-8 Ri Ph                        {  0 } (477+4) [48AC] - -  - 800 13 HvFd M7 V
+2035                      C4828A7-8 Ri Ph                        {  0 } (477+4) [48AC] - -  - 800 13 HvFd M7 V
 2132                      D747563-6 Ag Ni Cy O:2134              { -2 } (642+3) [5317] - M  - 903  8 HvFd M2 V
-2134 Pulnosa              B452AT1-B Hi Po Cp                     {  3 } (39E+0) [8D4F] - M  - 400 12 HvFd M3 V M1 V
+2134 Pulnosa              B452A85-B Hi Po Cp                     {  3 } (39E+0) [8D4F] - M  - 400 12 HvFd M3 V M1 V
 2136                      B663421-B Ni                           {  1 } (A37+2) [154D] - -  - 613 13 HvFd G4 V
 2235                      D537103-6 Lo                           { -3 } (B01+3) [1177] - M  - 603  8 HvFd M0 II
 2237                      D424521-6 Ni                           { -3 } (343+0) [1258] - M  - 704 13 HvFd G1 V
-2238                      D4528T5-7 Po Ph                        { -2 } (A76-4) [9669] - M  - 804  8 HvFd K4 V
+2238                      D452885-7 Po Ph                        { -2 } (A76-4) [9669] - M  - 804  8 HvFd K4 V
 2239                      D380564-7 De Ni Pr O:2537              { -3 } (740-4) [4228] - M  - 904 13 HvFd M2 V M6 V
 2337                      E598465-2 Ni Pa Re O:2537              { -3 } (430-1) [4163] - -  - 513 11 HvFd M5 V M8 V M7 V
-2338                      E5647S2-4 Ag Ri                        {  0 } (769+0) [8773] - -  - 413 16 HvFd G0 V
+2338                      E564752-4 Ag Ri                        {  0 } (769+0) [8773] - -  - 413 16 HvFd G0 V
 2433                      E74A101-6 Lo Wa                        { -3 } (A01-1) [1156] - -  - 601 12 HvFd M3 V
 2434                      E767462-6 Ni Ga Pa O:2537              { -3 } (530+1) [5142] - -  - 524 15 HvFd M0 V
 2438                      E110564-A Ni O:2537                    { -1 } (C41-2) [A438] - -  - 713  9 HvFd M6 V M9 V
-2439                      E1408S3-6 De Po Ph Pi                  { -2 } (273-3) [5686] - -  - 812  9 HvFd M1 V M3 V
+2439                      E140885-6 De Po Ph Pi                  { -2 } (273-3) [5686] - -  - 812  9 HvFd M1 V M3 V
 2440                      E000521-5 As Va Ni                     { -3 } (240-3) [7225] - -  - 912  8 HvFd A0 V M2 V
-2534                      B3547S2-8 Ag                           {  1 } (766-5) [7848] - -  - 103  7 HvFd M6 V
-2536 Slanoe               A225AU4-F Hi In Cp                     {  4 } (59B+0) [FE7F] - -  - 300  7 HvFd A7 V G1 V
-2537 Slaskea              B210AW6-B Hi In Na                     {  4 } (99C-1) [8E7D] - K  - 223 11 HvFd M7 V
+2534                      B354785-8 Ag                           {  1 } (766-5) [7848] - -  - 103  7 HvFd M6 V
+2536 Slanoe               A225A87-F Hi In Cp                     {  4 } (59B+0) [FE7F] - -  - 300  7 HvFd A7 V G1 V
+2537 Slaskea              B210A97-B Hi In Na                     {  4 } (99C-1) [8E7D] - K  - 223 11 HvFd M7 V
 2631                      A466421-A Ni Pa                        {  1 } (632-4) [556B] - -  - 604 11 HvFd M8 V M0 V
-2633                      A4358S3-E Ph                           {  2 } (878+0) [8A4F] - -  - 720  9 HvFd M7 V
+2633                      A435885-E Ph                           {  2 } (878+0) [8A4F] - -  - 720  9 HvFd M7 V
 2634                      A358563-B Ag Ni Cy O:2536              {  2 } (F43-1) [579C] - K  - 824 13 HvFd G3 IV
 2637                      A64A661-A Ni Wa Cy O:2537              {  1 } (B52+2) [573C] - -  - 120 11 HvFd K7 V M5 V
 2639                      A562312-D Lo                           {  1 } (B21-2) [342F] - -  - 203 11 HvFd M8 V
-2640                      A5316S4-A Na Ni Po                     {  2 } (A57+4) [38A8] - KM - 303 14 HvFd M5 V
-2735                      C7A08T5-6 He Ph                        { -1 } (978-4) [7712] - -  - 803 12 HvFd M6 V
-2740                      B3217S3-C He Pi Na Po                  {  2 } (66A+0) [8989] - M  - 403  8 HvFd M5 V G1 V
+2640                      A531685-A Na Ni Po                     {  2 } (A57+4) [38A8] - KM - 303 14 HvFd M5 V
+2735                      C7A0885-6 He Ph                        { -1 } (978-4) [7712] - -  - 803 12 HvFd M6 V
+2740                      B321783-C He Pi Na Po                  {  2 } (66A+0) [8989] - M  - 403  8 HvFd M5 V G1 V
 2833                      C100321-A Lo Va                        {  0 } (721+0) [338D] - -  - 105 15 HvFd M6 V M4 V
 2834                      A462103-D Lo                           {  1 } (A01-3) [125B] - K  - 501  6 HvFd F3 III M1 V
-2836                      A4248S5-D Ph Pi                        {  2 } (877+0) [5A7F] - -  - 402  6 HvFd M4 V M9 V
+2836                      A424887-D Ph Pi                        {  2 } (877+0) [5A7F] - -  - 402  6 HvFd M4 V M9 V
 2839                      A858304-B Lo                           {  1 } (A21+3) [248B] - -  - 204 13 HvFd K5 V
-2931                      B56A8S6-C Ri Wa Ph                     {  3 } (67D+0) [6B5F] - -  - 100  9 HvFd M3 V
+2931                      B56A886-C Ri Wa Ph                     {  3 } (67D+0) [6B5F] - -  - 100  9 HvFd M3 V
 2937                      A150101-C De Lo Po                     {  1 } (B01+0) [3268] - K  - 502 13 HvFd K4 V M1 V
 2940                      C597564-6 Ag Ni O:3239                 { -1 } (740-1) [341B] - M  - 702 13 HvFd M5 V
 3031 Koos                 B8B8611-A Fl Ni (Koos) Pz              {  1 } (C55-1) [1729] - K  A 324 12 HvFd A8 V M9 V
-3032                      A7746S3-8 Ag Ni                        {  0 } (C53+0) [866C] - -  - 400  6 HvFd M3 V M8 V
-3033                      C4628S5-4 Ri Ph                        {  0 } (877-3) [A871] - -  - 903 15 HvFd G7 V
-3035                      B85A8T2-9 Wa Ph                        {  1 } (F77+3) [7928] - K  - 103 10 HvFd M6 V M8 V
+3032                      A774683-8 Ag Ni                        {  0 } (C53+0) [866C] - -  - 400  6 HvFd M3 V M8 V
+3033                      C462845-4 Ri Ph                        {  0 } (877-3) [A871] - -  - 903 15 HvFd G7 V
+3035                      B85A885-9 Wa Ph                        {  1 } (F77+3) [7928] - K  - 103 10 HvFd M6 V M8 V
 3132                      B887663-5 Ag Ni Ri Ga Cy O:3133        {  1 } (654+0) [A751] - -  - 205 18 HvFd K5 V
 3133                      B464624-A Ag Ni Ri                     {  3 } (857+2) [5969] - K  - 403 13 HvFd G5 V
 3135                      B333421-B Ni Po                        {  1 } (932+0) [65AD] - -  - 704 13 HvFd F3 V
 3138                      C322413-A He Ni Po                     {  0 } (B31-1) [845C] - -  - 924 14 HvFd M8 V M5 V
 3140                      C645505-6 Ag Ni                        { -1 } (741-1) [6426] - -  - 100  9 HvFd K0 V M3 V
 3233                      C7A1106-7 He Fl Lo                     { -2 } (801+3) [1127] - M  - 704 11 HvFd G4 V
-3235 Daee                 C9C2821-9 He Fl Ph (Daee) Pz           {  0 } (575+0) [4857] - M  A 101  7 HvFd M0 V M8 V M2 V
+3235 Daee                 C9C2885-9 He Fl Ph (Daee) Pz           {  0 } (575+0) [4857] - M  A 101  7 HvFd M0 V M8 V M2 V
 3236                      B335102-A Lo                           {  1 } (A01+1) [222A] - K  - 610  9 HvFd K7 V M6 V
-3239 Guamola              B1109U5-B Hi Na In                     {  4 } (A88+1) [CD8E] - E  - 900  7 HvFd M4 V
-3240                      C78A6S4-8 Ni Ri Wa                     { -1 } (653+2) [7526] - -  - 820 12 HvFd M7 V M8 V
+3239 Guamola              B110986-B Hi Na In                     {  4 } (A88+1) [CD8E] - E  - 900  7 HvFd M4 V
+3240                      C78A687-8 Ni Ri Wa                     { -1 } (653+2) [7526] - -  - 820 12 HvFd M7 V M8 V


### PR DESCRIPTION
* Switch Hiver legacy govs to standard T5.10 ones

Hiver governments in the 'In Review' sections of TravellerMap use standard T5.10 gov types. This is the first set of changes to make this standard in all of Hiver space. 