### PR TITLE
Sector Data: removed 'Barren' allegiances

### DIFF
--- a/res/Sectors/M1201/Alpha Crucis.xml
+++ b/res/Sectors/M1201/Alpha Crucis.xml
@@ -49,7 +49,6 @@
     <Allegiance Code="Cf">Colfax Freehold</Allegiance>
     <Allegiance Code="Be">Beltan Empire</Allegiance>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>
   </Allegiances>
 
   <Stylesheet>

--- a/res/Sectors/M1201/Corridor.xml
+++ b/res/Sectors/M1201/Corridor.xml
@@ -48,7 +48,6 @@
   <Allegiances>
     <Allegiance Code="Br">Brinn</Allegiance>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>
   </Allegiances>
 
   <Routes>

--- a/res/Sectors/M1201/Diaspora.xml
+++ b/res/Sectors/M1201/Diaspora.xml
@@ -48,7 +48,6 @@
     <Allegiance Code="Wi">Wilds</Allegiance>
     <Allegiance Code="Ao">Reformation Coalition Area of Operation</Allegiance>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>    
   </Allegiances>
   
   <Borders>

--- a/res/Sectors/M1201/Empty Quarter.xml
+++ b/res/Sectors/M1201/Empty Quarter.xml
@@ -42,7 +42,6 @@
       <Allegiances>
     <Allegiance Code="Cc">Grand Council of Creches</Allegiance>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>    
   </Allegiances>
 
     <Stylesheet>

--- a/res/Sectors/M1201/Gushemege.xml
+++ b/res/Sectors/M1201/Gushemege.xml
@@ -44,7 +44,6 @@
 
   <Allegiances>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>
     <Allegiance Code="Ut">Usdiki Trade Alliance</Allegiance>
   </Allegiances>
 

--- a/res/Sectors/M1201/Gvurrdon.xml
+++ b/res/Sectors/M1201/Gvurrdon.xml
@@ -51,7 +51,6 @@
     <Allegiance Code="Vf">Ongue Republic</Allegiance>
     <Allegiance Code="Vg">Allez</Allegiance>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>
   </Allegiances>
 
 

--- a/res/Sectors/M1201/Hinterworlds.xml
+++ b/res/Sectors/M1201/Hinterworlds.xml
@@ -44,7 +44,6 @@
 
   <Allegiances>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>
     <Allegiance Code="Rp">Ring Pact</Allegiance>
   </Allegiances>
 

--- a/res/Sectors/M1201/Massilia.xml
+++ b/res/Sectors/M1201/Massilia.xml
@@ -52,7 +52,6 @@
     <Allegiance Code="Gc">Third Geonee Confederation</Allegiance>
     <Allegiance Code="Tp">Tanny Project</Allegiance>
     <Allegiance Code="Wi">Wilds</Allegiance>    
-    <Allegiance Code="">Barren</Allegiance>
   </Allegiances>
 
   <Borders>

--- a/res/Sectors/M1201/Meshan.xml
+++ b/res/Sectors/M1201/Meshan.xml
@@ -45,7 +45,6 @@
     <Allegiance Code="Tu">Tokho Union</Allegiance>
     <Allegiance Code="Ki">Kisiidi</Allegiance>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>
   </Allegiances>
   <Borders>
     <Border Allegiance="Ki">1829 1929 1928 1927 1926 1927 1928 2028 2129 2028 1929 1829 </Border>

--- a/res/Sectors/M1201/Old Expanses.xml
+++ b/res/Sectors/M1201/Old Expanses.xml
@@ -55,7 +55,6 @@
     <Allegiance Code="Sc">Sitah Hiver Client State</Allegiance>
     <Allegiance Code="Mt">Monteran Theocracy</Allegiance>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>
   </Allegiances>
   
   <Borders>

--- a/res/Sectors/M1201/Reavers Deep.xml
+++ b/res/Sectors/M1201/Reavers Deep.xml
@@ -41,7 +41,6 @@
   <Allegiances>
     <Allegiance Code="Gu">Gralyn Union</Allegiance>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>
   </Allegiances>
 
   <Stylesheet>

--- a/res/Sectors/M1201/Reft.xml
+++ b/res/Sectors/M1201/Reft.xml
@@ -59,7 +59,6 @@
     <Allegiance Code="Rf">Regency Frontier</Allegiance>
     <Allegiance Code="Re">Regency</Allegiance>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>
   </Allegiances>
 
   <Borders>

--- a/res/Sectors/M1201/Trojan Reach.xml
+++ b/res/Sectors/M1201/Trojan Reach.xml
@@ -61,7 +61,6 @@
     <Allegiance Code="Re">Regency</Allegiance>
     <Allegiance Code="Fl">Florian League</Allegiance>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>
   </Allegiances>
 
   <Routes>

--- a/res/Sectors/M1201/Tuglikki.xml
+++ b/res/Sectors/M1201/Tuglikki.xml
@@ -35,7 +35,6 @@
   </Subsectors>
   <Allegiances>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>
   </Allegiances>
   <Borders>
   </Borders>

--- a/res/Sectors/M1201/Vland.xml
+++ b/res/Sectors/M1201/Vland.xml
@@ -40,7 +40,6 @@
   <Allegiances>
     <Allegiance Code="Zs">Ziru Sirkaa</Allegiance>
     <Allegiance Code="Wi">Wilds</Allegiance>
-    <Allegiance Code="">Barren</Allegiance>
   </Allegiances>
 
   <Stylesheet>

--- a/res/Sectors/M1201/Zarushagar.xml
+++ b/res/Sectors/M1201/Zarushagar.xml
@@ -63,7 +63,6 @@
     <Allegiance Code="Df">Darmine Federation</Allegiance>
     <Allegiance Code="Af">Alcauan Federated Combine</Allegiance>
     <Allegiance Code="Wi">Wilds</Allegiance>   
-    <Allegiance Code="">Barren</Allegiance>
   </Allegiances>
 
   <Stylesheet>


### PR DESCRIPTION
Barren (Ba) is a trade code and not an allegiance.

Fixes [issue 238](https://github.com/inexorabletash/travellermap/issues/238).