### PR TITLE
Cauldron sector: Lords of the High Real - Changed allegiance code 'Lr' to 'Lh'.

### DIFF
--- a/res/Sectors/Distant Fringe/Where The Stars End/Cauldron.xml
+++ b/res/Sectors/Distant Fringe/Where The Stars End/Cauldron.xml
@@ -28,10 +28,10 @@
     <Region Color="Red">2624 2724 2725 2624 </Region>
   </Regions>
   <Borders>
-    <Border Allegiance="Lr" ShowLabel="false">0022 0122 0221 0322 0323 0223 0124 0125 0025 0024 0023 0022 </Border>
+    <Border Allegiance="Lh" ShowLabel="false">0022 0122 0221 0322 0323 0223 0124 0125 0025 0024 0023 0022 </Border>
   </Borders>
   <Allegiances>
-    <Allegiance Code="Lr">Lords of the High Realm</Allegiance>
+    <Allegiance Code="Lh">Lords of the High Realm</Allegiance>
   </Allegiances>
   <Stylesheet>
     border.Lr { color: green; style: dotted }


### PR DESCRIPTION
Reason:
- [Cauldron.txt](https://github.com/inexorabletash/travellermap/blob/main/res/Sectors/Distant%20Fringe/Where%20The%20Stars%20End/Cauldron.txt#L78#L81) contains 'Lh' as code that is not described in metadata because of mismatch with xml => no allegiance information in map available too
- seems to be a typo
- Kataran sector uses code 'Lh' in [xml file](https://github.com/inexorabletash/travellermap/blob/main/res/Sectors/Distant%20Fringe/Where%20The%20Stars%20End/Kataran.xml#L38#L43) too.

Fixes [issue 242](https://github.com/inexorabletash/travellermap/issues/242).