### PR TITLE
Sector data: added missing matching allegiance 'Hf' to xml (M1105 - Averegua, Folgore, Wrenton)

### DIFF
--- a/res/Sectors/M1105/Avereguar.xml
+++ b/res/Sectors/M1105/Avereguar.xml
@@ -30,6 +30,7 @@
     <Subsector Index="P"></Subsector>
   </Subsectors>
   <Allegiances>
+    <Allegiance Code="Hf">Hive FDA Uplift/Observation Site</Allegiance>
     <Allegiance Code="HvFd">Hive Federation</Allegiance>
     <Allegiance Code="Iy">Iyuok Hegemony</Allegiance>
   </Allegiances>

--- a/res/Sectors/M1105/Folgore.xml
+++ b/res/Sectors/M1105/Folgore.xml
@@ -30,6 +30,7 @@
     <Subsector Index="P">Axwrax</Subsector>
   </Subsectors>
   <Allegiances>
+    <Allegiance Code="Hf">Hive FDA Uplift/Observation Site</Allegiance>
     <Allegiance Code="HvFd">Hive Federation</Allegiance>
   </Allegiances>
 

--- a/res/Sectors/M1105/Wrenton.xml
+++ b/res/Sectors/M1105/Wrenton.xml
@@ -30,6 +30,7 @@
     <Subsector Index="P">Rirekluan</Subsector>
   </Subsectors>
   <Allegiances>
+    <Allegiance Code="Hf">Hive FDA Uplift/Observation Site</Allegiance>
     <Allegiance Code="HvFd">Hive Federation</Allegiance>
   </Allegiances>
 


### PR DESCRIPTION
`Hf' exists in xml of nearby sectors Blaskon, Extolian and Centrax => added `<Allegiance Code="Hf">Hive FDA Uplift/Observation Site</Allegiance>` to xml.

Fixes [issue 243](https://github.com/inexorabletash/travellermap/issues/243)