### PR TITLE
Change Oghma's 1105 UWP to match travellerwiki and The Trojan Reach

### DIFF
--- a/res/Sectors/M1105/Trojan Reach.tab
+++ b/res/Sectors/M1105/Trojan Reach.tab
@@ -211,7 +211,7 @@ Troj	O	1933	Ereah	B67A369-D		Lo Wa O:1634		531	AsMw	K8 V	{ 1 }	(921+2)	[446E]		1
 Troj	C	2002	Kryslion	D583AA9-9		Hi		520	ImDd	F6 V	{ 0 }	(E9A+1)	[BA6A]	BE	11	1260
 Troj	C	2008	Orsasch	E541364-7	M	He Lo Po Mr		223	SeFo	M1 V	{ -3 }	(520-5)	[1135]		13	-50
 Troj	G	2018	Noricum	D8867BB-1		Ag Ga Ri Pz	A	804	NaHu	G2 V M9 V M6 V	{ 0 }	(965+2)	[9773]		14	540
-Troj	G	2020	Oghma	B534754-9				404	NaHu	K5 V M5 V M4 V	{ 1 }	(D6A-1)	[5837]		11	-780
+Troj	G	2020	Oghma	B214754-9		Ic		404	NaHu	K5 V M5 V M4 V	{ 1 }	(D6A-1)	[5837]		11	-780
 Troj	K	2023	Khusai	A576655-C	R	Ag Ni		724	AsVc	F7 V	{ 2 }	(E56+1)	[483A]		19	420
 Troj	K	2029	Staha	B755486-B	R	Ni Ga Pa		313	AsMw	F3 V D	{ 1 }	(A34+1)	[354A]		13	120
 Troj	C	2102	Cyan	C5689B9-A	W	Hi Pr Pz	A	510	ImDd	F6 V M7 V	{ 3 }	(C8D+4)	[AC6B]	BcE	12	4992


### PR DESCRIPTION
I believe the source of Oghma's 1105 UWP data is Mongoose's "The Trojan Reach" - that document has now been updated to use a UWP of B124754-9.

https://wiki.travellerrpg.com/Oghma_(world) also uses B124754-9, although in Classic Era (1115).