### PR TITLE
T5ss 1900 Corridor

### DIFF
--- a/res/Sectors/M1900/Corridor.tab
+++ b/res/Sectors/M1900/Corridor.tab
@@ -1,0 +1,269 @@
+Sector	SS	Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W	RU
+Corr	A	0102	Tersta	E574000-6	 	     An  Di 		020	Wild	F3 V	{ -3 }	(700+1)	[0000]	B	11	7
+Corr	A	0104	Khouth	X8C3000-D	 	       Di Fl 		020	Wild	M3 V	{ -1 }	(D00+3)	[0000]	B	13	39
+Corr	A	0105	Ankirst	X556000-2	 	     Di 		021	Wild	K3 V M1 V	{ -3 }	(300-5)	[0000]	B	11	-15
+Corr	A	0106	Ofo-Nebus	X541000-2	 	    rg1  Di He Po 		001	Wild	M0 V M1 V	{ -3 }	(600-2)	[0000]	B	11	-12
+Corr	A	0109	Synez	X864000-5	 	     Di 		020	Wild	M2 V	{ -3 }	(400-2)	[0000]	B	9	-8
+Corr	E	0111	Shinku	X879000-5	 	    rg1  Di 		022	Wild	F9 V	{ -3 }	(300-3)	[0000]	B	8	-9
+Corr	E	0112	Kiran	X554845-2	 	     Pa Ph 		401	Wild	K5 V M0 V	{ -2 }	(A73-5)	[5623]	Bce	10	-1050
+Corr	E	0113	Aga Sugek	X9B8000-B	 	     Di Fl 		001	Wild	K7 V M2 V	{ -1 }	(600-5)	[0000]	B	10	-30
+Corr	E	0115	Khikhuushir	X676000-4	 	      Di 		024	Wild	M0 V	{ -3 }	(700+2)	[0000]	B	9	14
+Corr	E	0119	Ka Eto	D615000-C	T 	     Di Ic 		002	Wild	M3 V	{ -1 }	(700+1)	[0000]	B	13	7
+Corr	A	0205	Koergfoes	D543000-5	 	    rgW RsE  Di Po 		022	Wild	M1 V	{ -3 }	(700+1)	[0000]	B	7	7
+Corr	A	0206	Mikesh	X8B7000-D	 	       Di Fl 		025	Wild	K1 V	{ -1 }	(K00+1)	[0000]	B	10	19
+Corr	A	0209	Pergzitt	X625000-B	 	     Di 		011	Wild	K5 V M6 V	{ -1 }	(700+4)	[0000]	B	11	28
+Corr	A	0210	Dry	X310000-A	 	       Di 		001	Wild	M1 V M9 V	{ -1 }	(B00+3)	[0000]	B	6	33
+Corr	E	0213	Erlu	X7C0000-9	 	     Di He 		004	Wild	M0 V	{ -2 }	(C00+3)	[0000]	B	12	36
+Corr	E	0218	Lobok	C582775-8	 	      Ri 		935	Wild	G1 V	{ 0 }	(J69-2)	[7747]	BC	11	-1944
+Corr	I	0221	Shush	C664672-7	 	    Ag Ri Ni 		423	Wild	F8 V G3 V	{ 0 }	(451+1)	[6646]	BC	15	20
+Corr	A	0301	Overlook	X575000-4	 	       Di 		001	Wild	M0 V	{ -3 }	(A00+1)	[0000]	B	12	10
+Corr	A	0304	Serk	X89A000-C	 	       Di Wa 		023	Wild	M2 V	{ -1 }	(F00+1)	[0000]	B	8	15
+Corr	A	0306	Hesarus	D553000-6	 	     Di Po 		020	Wild	M1 V	{ -3 }	(700+3)	[0000]	B	8	21
+Corr	A	0307	Caulins Belt	X000000-C	 	       As Va Di 		011	Wild	M5 V	{ -1 }	(600+3)	[0000]	B	9	18
+Corr	A	0308	Faraway	X68258C-0	 	     Ni Pr 		113	Wild	M1 V	{ -3 }	(743+1)	[5271]	Bc	7	84
+Corr	E	0311	Jubal	X300000-9	 	      Di Va 		023	Wild	G8 IV M8 V	{ -2 }	(B00+4)	[0000]	B	17	44
+Corr	E	0312	Muugagen	X553000-4	 	      Di Po 		001	Wild	M0 V	{ -3 }	(600-2)	[0000]	B	8	-12
+Corr	E	0313	Yubitty	E96A000-6	 	      Di Wa 		032	Wild	K9 V	{ -3 }	(B00+1)	[0000]	B	8	11
+Corr	M	0338	Ishirdu	X776000-3	 	     (Irdu)  Di 		003	Wild	M3 V	{ -3 }	(500+3)	[0000]	B	10	15
+Corr	A	0401	Auritaurus	E859000-6	 	     Di 		021	Wild	F9 V	{ -3 }	(500+1)	[0000]	B	12	5
+Corr	A	0402	Rrev Rigr	X100000-C	 	     rg6  Di Va 		010	Wild	M7 V	{ -1 }	(900+4)	[0000]	B	11	36
+Corr	A	0407	Sigma 7	X000000-7	 	       As Va Di 		012	Wild	A9 V M9 V	{ -3 }	(900-2)	[0000]	B	16	-18
+Corr	E	0411	Daban	X514000-8	 	      Di Ic 		002	Wild	K2 V	{ -3 }	(C00+1)	[0000]	B	6	12
+Corr	E	0416	Ian	X598832-2	 	        Pa Pi Ph 		103	Wild	M2 V	{ -2 }	(A72-3)	[8651]	BcDe	10	-420
+Corr	E	0417	Irasumshu	X554785-0	 	     Ag 		401	Wild	M0 V	{ -1 }	(C6B+2)	[B641]	BC	12	1584
+Corr	A	0502	Koppel	X563000-5	 	     Di 		034	Wild	K9 V	{ -3 }	(500+1)	[0000]	B	10	5
+Corr	A	0509	Naxx-Iygo	X7B5000-8	 	      Di Fl 		012	Wild	M8 V	{ -3 }	(900-1)	[0000]	B	10	-9
+Corr	A	0510	Pamock	E561531-7	 	     Ni Pr 		423	Wild	K8 V M2 V	{ -3 }	(740+3)	[826A]	Bc	11	84
+Corr	E	0511	Linix' Cha	X422000-8	 	     Di He Po 		022	Wild	M2 V	{ -3 }	(B00-2)	[0000]	B	12	-22
+Corr	E	0512	Beta Regilis	X543000-3	 	      Di Po 		014	Wild	M1 V	{ -3 }	(700+1)	[0000]	B	11	7
+Corr	E	0513	Kumorie	X431000-C	 	     Di Po 		025	Wild	K7 V	{ -1 }	(G00+2)	[0000]	B	12	32
+Corr	E	0516	Raiga	X664000-2	 	        Di 		014	Wild	M2 V	{ -3 }	(700-5)	[0000]	B	8	-35
+Corr	A	0601	Greenrok	X560000-5	 	     De Di 		001	Wild	M2 V M5 V	{ -3 }	(400+2)	[0000]	B	14	8
+Corr	A	0603	Taratun	X893000-5	 	     Di 		023	Wild	M5 V	{ -3 }	(600-1)	[0000]	B	12	-6
+Corr	A	0605	Aka Gee	X432000-B	 	     Di Po 		003	Wild	K3 V M0 V	{ -1 }	(A00+3)	[0000]	B	13	30
+Corr	A	0606	Degarla	X611000-A	 	      Di Ic 		010	Wild	K8 V	{ -1 }	(900+3)	[0000]	B	12	27
+Corr	A	0608	Desolate	X9B4000-A	 	     Di Fl 		020	Wild	G5 V	{ -1 }	(900-3)	[0000]	B	8	-27
+Corr	A	0609	Semiplast	X561555-4	 	      Ni Pr 		302	Wild	M1 V M7 V	{ -3 }	(840+2)	[1245]	Bc	9	64
+Corr	E	0611	Ikhur	X756000-5	 	     rg1  Di Ga 		001	Wild	M0 V	{ -3 }	(700+3)	[0000]	B	13	21
+Corr	E	0614	Dywosik	X547000-2	 	      Di 		031	Wild	G5 V M8 V	{ -3 }	(600+3)	[0000]	B	11	18
+Corr	E	0617	Vom	X423000-9	 	     Di Po 		002	Wild	F9 V	{ -2 }	(900-1)	[0000]	B	15	-9
+Corr	M	0638	Esi-obe	X542000-3	 	      Di He Po 		011	Wild	G4 V	{ -3 }	(A00+2)	[0000]	B	8	20
+Corr	A	0701	Gzorraeth	X590000-3	 	      De He Di 		001	Wild	K6 V	{ -3 }	(600-2)	[0000]	B	11	-12
+Corr	A	0709	Mowanda	X200000-A	 	     Di Va 		011	Wild	A9 V	{ -1 }	(900+2)	[0000]	B	11	18
+Corr	E	0714	Teras	X438000-B	 	     Di 		010	Wild	M0 V M3 V	{ -1 }	(500-1)	[0000]	B	7	-5
+Corr	A	0804	Tsetsurri	X435000-6	 	     Di 		023	Wild	F4 V	{ -3 }	(900-3)	[0000]	B	9	-27
+Corr	A	0807	Bersha	X552000-3	 	     Di Po 		002	Wild	K2 V M0 V	{ -3 }	(500-5)	[0000]	B	10	-25
+Corr	E	0815	Lysio	X594000-3	 	      Di 		001	Wild	M0 V	{ -3 }	(700+1)	[0000]	B	7	7
+Corr	E	0816	Antiquity	X423000-C	 	    An  Di Po 		014	Wild	F6 V	{ -1 }	(B00-3)	[0000]	B	8	-33
+Corr	B	0901	Ruedzu Vounga	D541000-5	 	     Di He Po 		022	Wild	F0 V	{ -3 }	(600-3)	[0000]	B	10	-18
+Corr	B	0906	Yopogirp	X548000-3	 	     Di 		001	Wild	G7 V M2 V	{ -3 }	(500+5)	[0000]	B	14	25
+Corr	B	0910	Drayne	X6749AA-4	 	     RsB  Hi In 		201	Wild	F4 V M4 V	{ 0 }	(B8A+1)	[8964]	BE	13	880
+Corr	F	0912	Toddie-lee	X566337-3	 	      Lo 		901	Wild	M2 V M7 V	{ -3 }	(620+1)	[4124]	B	14	12
+Corr	F	0913	Heald	X541000-8	 	      Di He Po 		022	Wild	K9 V M7 V	{ -3 }	(C00-1)	[0000]	B	10	-12
+Corr	F	0916	Strand	X545000-2	 	     An  Di 		024	Wild	F3 V	{ -3 }	(800+1)	[0000]	B	12	8
+Corr	F	0918	Ahngrim	X9D6000-2	 	     Di 		001	Wild	M2 V M8 V	{ -3 }	(800-2)	[0000]	B	8	-16
+Corr	N	0931	Ashishinipar	X894687-0	 	      Ag Ni 		910	Wild	G0 V K5 V	{ -2 }	(B50+2)	[6431]	BC	13	110
+Corr	B	1003	Tylupa	X000000-B	 	      As Va Di 		013	Wild	M4 V	{ -1 }	(800+1)	[0000]	B	15	8
+Corr	B	1005	Mount	C675851-5	 	      Pa Pi Ph 		101	Wild	M1 V M8 V	{ -1 }	(A77-1)	[8743]	BcDe	11	-490
+Corr	B	1006	Wieresh	D559320-4	 	     Lo 		903	Wild	M1 V	{ -3 }	(620+2)	[7146]	B	11	24
+Corr	B	1010	Byla Hoso	X554000-6	 	      Di 		024	Wild	G1 V	{ -3 }	(700+1)	[0000]	B	13	7
+Corr	F	1011	Tobibak	X96A474-4	 	    (Tobai)  Ni Wa 		201	Wild	M2 V M3 V	{ -3 }	(630-4)	[3148]	B	8	-72
+Corr	F	1013	Demick	X532000-D	 	      Di Po 		002	Wild	K6 V	{ -1 }	(C00+2)	[0000]	B	12	24
+Corr	N	1033	Nadnamnarni	X200000-9	 	     Di Va 		003	Wild	M4 V	{ -2 }	(700+1)	[0000]	B	14	7
+Corr	B	1103	Senizue	D591000-5	 	     Di He 		020	Wild	F9 V	{ -3 }	(700-1)	[0000]	B	9	-7
+Corr	B	1104	Goseghi	X557526-0	 	     Ag Ni 		303	Wild	M1 V	{ -2 }	(742+4)	[1361]	BC	8	224
+Corr	B	1107	Formation	X511000-C	 	     Di Ic 		004	Wild	K0 III D	{ -1 }	(900+4)	[0000]	B	7	36
+Corr	B	1109	Shushaka	X772000-0	 	      Ba He 		015	Wild	K2 V M0 V	{ -3 }	(B00-4)	[0000]	B	11	-44
+Corr	F	1111	Biinersa	X849000-8	 	     Di 		022	Wild	K6 V	{ -3 }	(A00+2)	[0000]	B	15	20
+Corr	F	1112	Buagki	X426000-C	 	      Di 		023	Wild	M1 V	{ -1 }	(A00-3)	[0000]	B	8	-30
+Corr	N	1140	Tristira	E87A000-4	 	     Di Wa 		013	Wild	F7 V	{ -3 }	(900-1)	[0000]	B	10	-9
+Corr	B	1201	New Vland	X797777-0	 	      rg2  Ag Pi 		401	Wild	M1 V	{ -1 }	(A62-3)	[9661]	BCD	11	-360
+Corr	B	1203	Voorghish	X556433-0	 	     Ni Pa 		203	Wild	G0 V M5 V	{ -3 }	(630-4)	[4181]	Bc	8	-72
+Corr	B	1204	Tetraggoe	X692000-5	 	     Di He 		003	Wild	M0 V	{ -3 }	(500+3)	[0000]	B	8	15
+Corr	B	1205	Durima	X420000-E	 	         De He Di Po 		034	Wild	F7 V	{ -1 }	(K00-2)	[0000]	B	11	-38
+Corr	B	1207	Courage	X400000-7	 	        Di Va 		001	Wild	M0 V	{ -3 }	(A00-1)	[0000]	B	6	-10
+Corr	B	1209	Kaasu	XA7A000-3	 	        Di Oc 		022	Wild	K6 V	{ -3 }	(B00+4)	[0000]	B	16	44
+Corr	B	1210	Latu	E87A000-A	 	      Di Wa 		002	Wild	K4 V M2 V	{ -1 }	(800+1)	[0000]	B	15	8
+Corr	F	1213	Vigh	X200000-A	 	     Di Va 		002	Wild	G5 V M3 V	{ -1 }	(600+1)	[0000]	B	13	6
+Corr	F	1216	Six Lights	X577000-3	 	      Di 		001	Wild	M2 V	{ -3 }	(600+2)	[0000]	B	10	12
+Corr	F	1218	Emfashi	X658000-1	 	     Di 		020	Wild	G9 V M4 V	{ -3 }	(500-5)	[0000]	B	9	-25
+Corr	B	1301	Nakeremma	X523000-7	 	     Di Po 		001	Wild	M0 V	{ -3 }	(300-1)	[0000]	B	11	-3
+Corr	B	1304	Iceball	X635000-6	 	     Di 		024	Wild	F4 V	{ -3 }	(600+1)	[0000]	B	14	6
+Corr	B	1307	Sebastion	E568000-3	 	      Di 		003	Wild	K1 V	{ -3 }	(600-1)	[0000]	B	6	-6
+Corr	B	1309	Naasakiira	X556000-6	 	      Di 		023	Wild	K7 V	{ -3 }	(800+3)	[0000]	B	17	24
+Corr	B	1401	Oegongrek	X000000-A	 	      As Va Di 		020	Wild	G6 V	{ -1 }	(600-3)	[0000]	B	15	-18
+Corr	B	1402	Zontra'Lee	X78887B-2	 	      Pa Ri Ph 		403	Wild	M3 V	{ -1 }	(A79+4)	[D731]	BcCe	11	2520
+Corr	B	1404	Vwogeck	X573000-5	 	    rg3  Di 		024	Wild	F0 V	{ -3 }	(500+1)	[0000]	B	11	5
+Corr	B	1405	Sluru	X76A958-5	 	    Hi Pr Wa 		123	Wild	M1 V	{ -1 }	(983+2)	[D852]	BcE	8	432
+Corr	B	1408	Xinox	X87A000-5	 	     Di Wa 		024	Wild	M4 V	{ -3 }	(800-1)	[0000]	B	9	-8
+Corr	B	1409	Draack Elka	X572000-3	 	     Di He 		022	Wild	G6 V M2 V	{ -3 }	(700+1)	[0000]	B	11	7
+Corr	F	1413	Itasis	E542000-5	 	    la9 rg0  Di He Po 		002	Wild	F7 V	{ -3 }	(500-3)	[0000]	B	13	-15
+Corr	F	1414	Valeneg	X412000-7	 	     Di Ic 		022	Wild	F7 V M9 V	{ -3 }	(300+5)	[0000]	B	17	15
+Corr	F	1415	Zudagim	X682677-0	 	     Ni Ri 		222	Wild	F4 V	{ -2 }	(B52-2)	[9414]	BC	13	-220
+Corr	F	1418	Kearb	XAC8000-9	 	     Di Fl 		022	Wild	M9 III	{ -2 }	(900-2)	[0000]	B	10	-18
+Corr	J	1430	Lasher	X8C2000-9	 	      Di Fl He 		025	Wild	K4 III	{ -2 }	(B00+1)	[0000]	B	10	11
+Corr	N	1432	Tarin Sink	XAE5000-6	 	    RsG  Di 		035	Wild	K7 V M1 V	{ -3 }	(500+1)	[0000]	B	19	5
+Corr	B	1501	Gvan	X543000-8	 	     Di Po 		010	Wild	M1 V M5 V	{ -3 }	(800-1)	[0000]	B	14	-8
+Corr	B	1504	Buianah	X797000-7	 	     rg6  Di 		023	Wild	G9 V K7 V	{ -3 }	(700-1)	[0000]	B	10	-7
+Corr	B	1506	Errd Lomon	X410000-9	 	      Di 		003	Wild	K5 V	{ -2 }	(900+4)	[0000]	B	7	36
+Corr	F	1511	Depot	X686000-4	 	      (Miiminri)0   Di Ga 		023	Wild	M4 V	{ -3 }	(600-1)	[0000]	B	8	-6
+Corr	F	1513	Nubotech	X562557-3	 	     Ni Pr 		222	Wild	M4 V M8 V	{ -3 }	(740-4)	[4256]	Bc	9	-112
+Corr	F	1514	Justends Four	X567000-1	 	     Di 		012	Wild	F8 V M3 V	{ -3 }	(300+4)	[0000]	B	11	12
+Corr	F	1515	Ashima	X543000-6	 	      Di Po 		010	Wild	G6 V	{ -3 }	(B00+5)	[0000]	B	6	55
+Corr	B	1602	Koorfagh	X673000-5	 	     Di 		023	Wild	M1 V	{ -3 }	(900-5)	[0000]	B	11	-45
+Corr	B	1603	Gagh Veth	X556300-3	 	       Lo 		834	Wild	G2 V	{ -3 }	(620-1)	[3124]	B	12	-12
+Corr	B	1605	Silibast Ti	X550000-7	 	     De Di Po 		013	Wild	F3 V M1 V	{ -3 }	(700+1)	[0000]	B	9	7
+Corr	B	1606	Khukish	X77A000-1	 	       Di Wa 		023	Wild	G9 V	{ -3 }	(B00-1)	[0000]	B	8	-11
+Corr	B	1607	Shishkala	X686531-3	 	     Ursa2  Ag Pr Ga Ni 		913	Wild	M2 V	{ -2 }	(842+1)	[1334]	BcC	11	64
+Corr	B	1609	Veu Belle	X421000-8	 	     Di He Po 		012	Wild	M3 V	{ -3 }	(A00-3)	[0000]	B	13	-30
+Corr	F	1611	Vanquet	X63A000-9	 	     Di Wa 		001	Wild	M4 V	{ -2 }	(B00+2)	[0000]	B	11	22
+Corr	C	1703	Tyee	X436000-6	 	     Di 		013	Wild	G1 V M8 V	{ -3 }	(800+1)	[0000]	B	9	8
+Corr	C	1704	Ngeroull	D766000-6	 	       Di Ga 		024	Wild	K1 V	{ -3 }	(800+2)	[0000]	B	15	16
+Corr	G	1711	Naadi	X578000-4	 	       Di 		002	Wild	M2 V	{ -3 }	(700+1)	[0000]	B	9	7
+Corr	G	1712	Getz	E553000-5	 	     Di Po 		010	Wild	M0 V M4 V	{ -3 }	(400+4)	[0000]	B	8	16
+Corr	G	1713	Denlaar	E695000-3	 	      Di 		022	Wild	K9 V	{ -3 }	(600+2)	[0000]	B	12	12
+Corr	C	1803	Llaefong	X423000-B	 	     Di Po 		012	Wild	M4 III	{ -1 }	(A00-4)	[0000]	B	8	-40
+Corr	C	1808	Lemish	X795000-0	 	        Ba 		001	Wild	M1 V M2 V	{ -3 }	(800-2)	[0000]	B	8	-16
+Corr	C	1810	Munhofen	E543000-6	 	     Di Po 		023	Wild	G7 V	{ -3 }	(400-2)	[0000]	B	8	-8
+Corr	G	1811	Antezeno	X637000-9	 	     Di 		024	Wild	F6 V	{ -2 }	(B00-1)	[0000]	B	11	-11
+Corr	O	1832	Emephdee	X551389-0	 	      Lo Po 		901	Wild	G2 V M2 V	{ -3 }	(620-2)	[5151]	B	9	-24
+Corr	O	1840	Jafla	X898000-6	 	     Di 		013	Wild	G5 V	{ -3 }	(300+3)	[0000]	B	9	9
+Corr	C	1904	Ighoth	X433000-C	 	     Di Po 		023	Wild	K9 V	{ -1 }	(B00+1)	[0000]	B	8	11
+Corr	C	1905	Dazeys World	X438000-B	 	     Di 		010	Wild	M3 V	{ -1 }	(500+3)	[0000]	B	13	15
+Corr	C	1906	Sutton	X420000-C	 	      De He Di Po 		015	Wild	K5 V	{ -1 }	(D00+1)	[0000]	B	13	13
+Corr	C	1908	Weyland	X435000-9	 	      Di 		002	Wild	M3 V	{ -2 }	(600+1)	[0000]	B	5	6
+Corr	G	1912	Enrick Down	E542000-5	 	     Di He Po 		010	Wild	F7 V M1 V	{ -3 }	(600-4)	[0000]	B	12	-24
+Corr	G	1913	Shargishu	X000000-7	 	       As Va Di 		023	Wild	F7 II	{ -3 }	(600-5)	[0000]	B	9	-30
+Corr	K	1923	Rill	X688658-1	 	     Chir6  Ag Ri Ni 		102	Wild	K0 V M3 V	{ -1 }	(851+1)	[4582]	BC	10	40
+Corr	C	2003	Kfotsaen	X100000-9	 	     Di Va 		015	Wild	F3 V	{ -2 }	(C00+5)	[0000]	B	18	60
+Corr	C	2004	Eghani Nivek	X654000-3	 	      Di 		022	Wild	M1 V	{ -3 }	(600+2)	[0000]	B	12	12
+Corr	C	2006	Tamilaa	C788796-8	 	     Ursa0  Ag Ri 		401	Wild	K3 IV M6 V	{ 1 }	(A66+2)	[8848]	BC	4	720
+Corr	C	2009	Specti	X773000-5	 	     Di 		022	Wild	F1 V	{ -3 }	(300-1)	[0000]	B	8	-3
+Corr	C	2010	Dianah	E564443-7	 	      Ni Pa 		321	Wild	K8 V	{ -3 }	(733-1)	[5185]	Bc	9	-63
+Corr	G	2012	Faplion	X525000-7	 	     Di 		010	Wild	F7 V M3 V	{ -3 }	(500-1)	[0000]	B	11	-5
+Corr	O	2037	Sinta	X201000-D	 	         Di Ic Va 		013	Wild	F9 V	{ -1 }	(E00+4)	[0000]	B	12	56
+Corr	O	2039	Ea'tiva	D686000-7	 	     Di Ga 		001	Wild	K1 V M9 V	{ -3 }	(300+1)	[0000]	B	5	3
+Corr	O	2040	Tainbee	X757341-2	 	      Ga Lo 		804	Wild	K0 V	{ -3 }	(620+1)	[1184]	B	14	12
+Corr	C	2101	Vikenngis	X000000-C	 	        As Va Di 		014	Wild	G9 IV	{ -1 }	(F00+2)	[0000]	B	10	30
+Corr	C	2102	Foengos	E662000-3	 	      Di 		014	Wild	G7 V	{ -3 }	(700-5)	[0000]	B	13	-35
+Corr	C	2106	Angi	X541000-6	 	     Di He Po 		001	Wild	M0 V	{ -3 }	(800-2)	[0000]	B	7	-16
+Corr	C	2108	Ginning	X631000-B	 	      Di Po 		023	Wild	G2 V	{ -1 }	(C00+1)	[0000]	B	10	12
+Corr	C	2109	Amwaz	X592000-2	 	      Di He 		010	Wild	M1 V	{ -3 }	(500+4)	[0000]	B	13	20
+Corr	G	2111	Darkmoon	X78A630-3	 	      Ni Ri Wa 		612	Wild	G1 V	{ -2 }	(850-1)	[6433]	BC	8	-40
+Corr	G	2116	Farplace	X550000-6	 	     De Di Po 		020	Wild	F4 V	{ -3 }	(600-1)	[0000]	B	11	-6
+Corr	K	2121	Atu'l	E898000-7	 	     Di 		004	Wild	G8 V M3 V	{ -3 }	(400+4)	[0000]	B	10	16
+Corr	O	2135	Kacxhun	X427000-7	 	     Di 		014	Wild	G1 V G2 V	{ -3 }	(600+3)	[0000]	B	11	18
+Corr	O	2136	Whikee	X423000-9	 	       Di Po 		001	Wild	K4 V M2 V	{ -2 }	(900-3)	[0000]	B	13	-27
+Corr	O	2137	Inarli	X677000-4	 	      Di 		014	Wild	M0 V	{ -3 }	(B00-2)	[0000]	B	11	-22
+Corr	O	2140	Dodardudos	E583475-4	 	      Ni 		303	Wild	M2 V	{ -3 }	(730+1)	[2151]	B	9	21
+Corr	C	2201	Dhouthits	D540575-2	 	      De He Ni Po 		323	Wild	M3 V	{ -3 }	(741+1)	[4256]	B	14	28
+Corr	C	2202	Dzaedenforr	X877000-5	 	      Di 		001	Wild	F4 V M1 V	{ -3 }	(600-3)	[0000]	B	6	-18
+Corr	C	2205	Brariun	X629000-9	 	     Di 		001	Wild	G6 V M1 V	{ -2 }	(700+5)	[0000]	B	14	35
+Corr	C	2206	Aurolee	X000000-D	 	        As Va Di 		024	Wild	A8 IV	{ -1 }	(F00-2)	[0000]	B	10	-30
+Corr	C	2208	Luuga	X410000-C	 	       Di 		022	Wild	G5 V K4 V	{ -1 }	(D00-3)	[0000]	B	14	-39
+Corr	C	2209	Alfive	X578876-2	 	       Pa Pi Ph 		203	Wild	K4 V M2 V	{ -2 }	(A7A-3)	[B676]	BcDe	6	-2100
+Corr	G	2212	Sent'ere	X400000-B	 	      Di Va 		010	Wild	M2 V	{ -1 }	(500-2)	[0000]	B	5	-10
+Corr	O	2234	Setii Goek	X436000-8	 	      Di 		010	Wild	K0 V M2 V	{ -3 }	(900-2)	[0000]	B	11	-18
+Corr	O	2235	Kysar II	X310000-F	 	     Di 		020	Wild	K3 V M2 V	{ -1 }	(500+1)	[0000]	B	11	5
+Corr	O	2238	Divad	X8C0000-9	 	     (Brinn)9  Di He 		022	Wild	M5 V	{ -2 }	(E00-3)	[0000]	B	12	-42
+Corr	O	2239	Kloackin	B572883-9	N 	     He Ph Pi 		110	Wild	M3 V	{ 1 }	(B74+5)	[B939]	BDe	11	1540
+Corr	C	2303	Voegrr	X587000-6	 	     Di 		001	Wild	M3 V	{ -3 }	(400+1)	[0000]	B	10	4
+Corr	C	2304	Double Sun	X000000-7	 	       As Va Di 		011	Wild	A7 V M6 V	{ -3 }	(600-1)	[0000]	B	10	-6
+Corr	C	2306	Pruughoe	X9C7000-9	 	     rgW  Di Fl 		001	Wild	M2 V	{ -2 }	(900-2)	[0000]	B	7	-18
+Corr	C	2307	Aking	X200000-A	 	      Di Va 		001	Wild	M4 V	{ -1 }	(800+4)	[0000]	B	12	32
+Corr	G	2311	Hishumaki	X545000-5	 	      Di 		010	Wild	K5 V M9 V	{ -3 }	(700+1)	[0000]	B	13	7
+Corr	O	2333	Fabeticu	X566744-1	 	       Ag Ri 		235	Wild	F4 V G0 V	{ 0 }	(96A-2)	[4751]	BC	13	-1080
+Corr	O	2334	Kikasad	E76A000-4	 	    Re  Di Wa 		021	Wild	G1 V M3 V	{ -3 }	(600-2)	[0000]	B	8	-12
+Corr	O	2335	Tahspeck	XA9A000-8	 	     Di Oc 		004	Wild	M2 V	{ -3 }	(C00-4)	[0000]	B	14	-48
+Corr	O	2336	Mok-Retinae	E556434-5	 	     Ni Pa 		103	Wild	M3 V	{ -3 }	(631+1)	[1176]	Bc	9	18
+Corr	O	2338	Terragesh	X560000-2	 	     De Di 		024	Wild	G0 V	{ -3 }	(600-2)	[0000]	B	9	-12
+Corr	C	2403	Ngaethaena	X666000-5	 	     Di Ga 		013	Wild	M1 V	{ -3 }	(400-2)	[0000]	B	9	-8
+Corr	C	2405	Gravista	E553846-2	 	     Ph Po 		621	Wild	M1 V	{ -2 }	(A75+5)	[8653]	Be	10	1750
+Corr	C	2409	Treedisk	X420000-9	 	      De He Di Po 		001	Wild	M1 V M3 V	{ -2 }	(600-2)	[0000]	B	10	-12
+Corr	O	2435	Knofodu	X8B4000-8	 	     Di Fl 		020	Wild	M1 V	{ -3 }	(A00+1)	[0000]	B	11	10
+Corr	O	2439	Ackang	X9B4000-8	 	     Di Fl 		022	Wild	F6 V K6 V	{ -3 }	(C00-1)	[0000]	B	10	-12
+Corr	O	2440	Doyaterfit	X543000-5	 	     Di Po 		001	Wild	G1 V M0 V	{ -3 }	(300+1)	[0000]	B	14	3
+Corr	D	2502	Ackaeck	X586653-1	 	     Ag Ri Ni 		914	Wild	K7 V	{ -1 }	(952-1)	[9555]	BC	18	-90
+Corr	D	2503	Kidagir	X542000-4	 	      Di He Po 		022	Wild	M2 V	{ -3 }	(500+1)	[0000]	B	9	5
+Corr	D	2505	Plunge	X540787-2	 	         De He Pi Po 		324	Wild	G7 V	{ -2 }	(B63+2)	[8541]	BD	9	396
+Corr	D	2506	Jed	E757897-4	 	      Ga Pa Ph 		613	Wild	G1 V M4 V	{ -2 }	(A79+4)	[C675]	Bce	9	2520
+Corr	H	2511	Naagasa	X527000-9	 	       Di 		024	Wild	F4 V	{ -2 }	(G00+3)	[0000]	B	10	48
+Corr	P	2534	Zendiisica	X400000-C	 	       Di Va 		023	Wild	F2 III K6 V	{ -1 }	(E00-2)	[0000]	B	11	-28
+Corr	P	2535	Desolation	X570000-4	 	      De He Di 		001	Wild	F7 V K8 V	{ -3 }	(400+1)	[0000]	B	12	4
+Corr	P	2536	Sorrock	X300000-A	 	      Di Va 		020	Wild	G1 V	{ -1 }	(900+2)	[0000]	B	11	18
+Corr	P	2537	Nowbee	C552774-4	 	      Po 		623	Wild	G4 V K2 V	{ -1 }	(961-3)	[7644]	B	8	-162
+Corr	P	2538	Riyten	X692000-6	 	     Di He 		024	Wild	M2 V	{ -3 }	(500+2)	[0000]	B	13	10
+Corr	P	2540	Ression	X400000-C	 	     Di Va 		023	Wild	K4 V	{ -1 }	(800-1)	[0000]	B	13	-8
+Corr	D	2603	Chosen	X534000-8	 	    RsA  Di 		003	Wild	M1 V	{ -3 }	(A00-5)	[0000]	B	11	-50
+Corr	D	2606	Nuplae	X64A000-4	 	     Di Wa 		002	Wild	M0 V	{ -3 }	(400-2)	[0000]	B	12	-8
+Corr	H	2611	Mee	X9D8000-9	 	      Di 		020	Wild	M0 V	{ -2 }	(A00+2)	[0000]	B	6	20
+Corr	P	2631	Umaraag	X569888-3	 	     LancW  Ph Ri 		333	Wild	F3 V G3 V	{ -1 }	(A78+4)	[B731]	BCe	10	2240
+Corr	P	2632	Sumeszu	X100000-F	 	     Di Va 		010	Wild	M0 V	{ -1 }	(600+3)	[0000]	B	12	18
+Corr	P	2634	Glenn	X573000-3	 	     Di 		001	Wild	M1 V	{ -3 }	(600-3)	[0000]	B	7	-18
+Corr	P	2636	Conn	X572676-2	 	      He Ni 		902	Wild	M1 V	{ -3 }	(950-2)	[7321]	B	12	-90
+Corr	P	2640	Sintoshee	X65678B-0	 	     Ag Ga 		203	Wild	M3 V	{ -1 }	(967-2)	[9651]	BC	12	-756
+Corr	D	2701	Hesaim	X424000-E	 	     Di 		001	Wild	M0 V	{ -1 }	(700+1)	[0000]	B	9	7
+Corr	D	2710	Brytsee	X79A000-0	 	     Ba Wa 		004	Wild	M1 V	{ -3 }	(400+1)	[0000]	B	11	4
+Corr	P	2733	Kanorb	X573000-7	 	     LancW  Di 		024	Wild	M1 V	{ -3 }	(B00-5)	[0000]	B	9	-55
+Corr	P	2735	Nart-roft	E575653-7	 	      Ag Ni 		724	Wild	M3 V	{ -2 }	(A54+3)	[8453]	BC	12	600
+Corr	P	2738	Viewday	E673000-5	 	     Di 		001	Wild	K5 V M7 V	{ -3 }	(500-5)	[0000]	B	14	-25
+Corr	P	2740	Tatsnank Defu	D561000-6	 	     Di 		022	Wild	K6 V M2 V	{ -3 }	(500-3)	[0000]	B	7	-15
+Corr	D	2801	Vellutsaer	X9B3000-8	 	     Di Fl 		023	Wild	A8 V	{ -3 }	(C00+3)	[0000]	B	18	36
+Corr	D	2804	Neghu Oug	X63A000-9	 	    (Ojehshodu)4  Di Wa 		002	Wild	M3 V	{ -2 }	(A00+4)	[0000]	B	8	40
+Corr	D	2806	Uughrae	X766000-1	 	      Di Ga 		010	Wild	K5 V M1 V	{ -3 }	(500-2)	[0000]	B	14	-10
+Corr	D	2810	Atudew	X595000-4	 	     Di 		020	Wild	M1 V	{ -3 }	(400-3)	[0000]	B	11	-12
+Corr	H	2811	Kiiguuroesa	X200000-7	 	      Di Va 		001	Wild	M7 V	{ -3 }	(600+1)	[0000]	B	9	6
+Corr	P	2831	Radical	D559479-7	 	     Ni 		210	Wild	F5 V G9 V	{ -3 }	(730+2)	[5163]	B	8	42
+Corr	P	2833	Starting	X430000-A	 	     De Di Po 		023	Wild	F3 V	{ -1 }	(B00+1)	[0000]	B	14	11
+Corr	P	2836	Igudi	X586625-0	 	      Ag Ri Ni 		614	Wild	K0 V	{ -1 }	(852-1)	[6551]	BC	10	-80
+Corr	P	2837	Sepstar	X568000-3	 	      Di 		020	Wild	M1 V	{ -3 }	(600+1)	[0000]	B	9	6
+Corr	D	2901	Oqwee	X423000-D	 	     Di Po 		004	Wild	M4 V	{ -1 }	(A00-4)	[0000]	B	8	-40
+Corr	D	2902	Oegoerrvu	X410000-8	 	    Huma7  Di 		002	Wild	K0 V	{ -3 }	(800+1)	[0000]	B	8	8
+Corr	D	2903	Uerrgno	X86798A-0	 	     Ga Hi Pr 		301	Wild	K5 V K9 V	{ -1 }	(B88+1)	[6893]	BcE	8	704
+Corr	D	2904	Krroughf	X577000-4	 	      Di 		002	Wild	M0 V M1 V	{ -3 }	(700-2)	[0000]	B	8	-14
+Corr	D	2905	Shinaashag	X543000-6	 	      Di Po 		011	Wild	K6 V M2 V	{ -3 }	(A00+2)	[0000]	B	11	20
+Corr	D	2906	Kifrusis	X568000-5	 	     Di 		012	Wild	K6 V	{ -3 }	(400+2)	[0000]	B	13	8
+Corr	D	2907	Seplus	E797000-8	 	      Di 		012	Wild	M0 V	{ -3 }	(B00-1)	[0000]	B	9	-11
+Corr	D	2908	Twophur	C653732-5	 	     Po 		424	Wild	G7 V	{ -1 }	(969+1)	[6675]	B	12	486
+Corr	L	2930	Tucker	E879000-5	 	     Di 		022	Wild	K3 V	{ -3 }	(800-3)	[0000]	B	11	-24
+Corr	P	2932	Ecktars Eckto	D589000-4	 	     Di 		022	Wild	G1 V	{ -3 }	(500+5)	[0000]	B	11	25
+Corr	P	2933	Sashrakusha	XAB4000-C	 	     LancW  Di Fl 		001	Wild	M5 V	{ -1 }	(B00-2)	[0000]	B	14	-22
+Corr	P	2934	Yull-jettii	X86A000-8	 	     Di Wa 		023	Wild	G2 V M9 V	{ -3 }	(800+1)	[0000]	B	14	8
+Corr	P	2935	Trickster	X420000-C	 	      De He Di Po 		024	Wild	G2 V	{ -1 }	(D00+1)	[0000]	B	9	13
+Corr	P	2937	Hendrick	X420000-9	 	     RsD  De He Di Po 		014	Wild	M0 V	{ -2 }	(A00-1)	[0000]	B	12	-10
+Corr	P	2940	United	X66A589-4	 	     Ni Pr Wa 		110	Wild	F7 V M9 V	{ -3 }	(841-1)	[82A6]	Bc	12	-32
+Corr	D	3004	Rustsoura	X400000-B	 	     Di Va 		012	Wild	M3 V	{ -1 }	(600-4)	[0000]	B	10	-24
+Corr	D	3010	Habretic	D663000-6	 	     Di 		012	Wild	M1 V	{ -3 }	(300-2)	[0000]	B	11	-6
+Corr	L	3030	Betters	XA87551-2	 	      Ag Pr Ni 		101	Wild	K1 V M2 V M2 V	{ -2 }	(744+1)	[7315]	BcC	6	112
+Corr	P	3032	Stagers	E543000-7	 	     Di Po 		024	Wild	F7 V	{ -3 }	(400-1)	[0000]	B	9	-4
+Corr	P	3033	Sinist III	X426000-7	 	     Di 		010	Wild	K7 V M3 V	{ -3 }	(400+3)	[0000]	B	9	12
+Corr	P	3036	Dialreck	D58589C-5	 	     LancW  Pa Ri Ph 		210	Wild	M0 V M1 V	{ -1 }	(A78+1)	[A753]	BcCe	10	560
+Corr	P	3038	Yur Hur Ged	X311000-9	 	      Di Ic 		020	Wild	G7 V K5 V	{ -2 }	(B00-4)	[0000]	B	14	-44
+Corr	P	3039	Prefostered	X420000-B	 	      De He Di Po 		024	Wild	M1 V	{ -1 }	(C00-3)	[0000]	B	9	-36
+Corr	P	3040	Shishashu	X312000-D	 	     Di Ic 		022	Wild	A6 V	{ -1 }	(800+2)	[0000]	B	9	16
+Corr	D	3104	Salite	X554000-1	 	     Di 		010	Wild	M0 V M3 V	{ -3 }	(500-3)	[0000]	B	11	-15
+Corr	D	3106	Long Shot	X000000-B	 	        As Va Di 		014	Wild	M1 V	{ -1 }	(D00+1)	[0000]	B	9	13
+Corr	D	3107	Desiver	E570323-7	 	      De He Lo 		920	Wild	G1 V	{ -3 }	(620+1)	[6144]	B	7	12
+Corr	L	3129	Kivu	C565555-7	 	      Ag Pr Ni 		522	Wild	F5 V	{ -1 }	(843+1)	[5495]	BcC	10	96
+Corr	P	3131	Xapoqoz	X8537BA-0	 	    (Xapoqi)0  Po 		201	Wild	K8 V K8 V M1 V	{ -2 }	(960-4)	[5591]	B	5	-216
+Corr	P	3132	Unikeejaf	X768521-1	 	      Ag Pr Ni 		302	Wild	M0 V	{ -2 }	(740+4)	[1376]	BcC	5	112
+Corr	P	3135	Cafad	X666532-0	 	     (Cafadians)  Ag Pr Ga Ni 		310	Wild	M3 V	{ -2 }	(743-1)	[3342]	BcC	12	-84
+Corr	P	3136	Wenty-ruu	X201000-C	 	       Di Ic Va 		001	Wild	M1 V M5 V	{ -1 }	(A00+2)	[0000]	B	14	20
+Corr	P	3137	Idanchy	X789000-7	 	     Di 		003	Wild	K4 V M6 V	{ -3 }	(500+5)	[0000]	B	9	25
+Corr	P	3138	Yigh	X999000-3	 	     Di 		020	Wild	M0 V	{ -3 }	(800-3)	[0000]	B	9	-24
+Corr	P	3139	Mappeh	X997725-2	 	      Ag Pi 		524	Wild	F9 V	{ -1 }	(964-3)	[6655]	BCD	10	-648
+Corr	P	3140	Creading	X66A323-2	 	     Lo Wa 		901	Wild	M2 V	{ -3 }	(620+1)	[2182]	B	9	12
+Corr	D	3201	Esuto	X572000-3	 	     Di He 		001	Wild	F5 V M1 V	{ -3 }	(800-1)	[0000]	B	5	-8
+Corr	D	3202	Kotsingdifir	E544000-6	 	       Di 		001	Wild	F4 V M2 V	{ -3 }	(800-2)	[0000]	B	9	-16
+Corr	D	3207	Gerbetord	X75A000-5	 	     Di Wa 		002	Wild	K7 V	{ -3 }	(700+4)	[0000]	B	12	28
+Corr	D	3208	Dilub Rou	X420000-F	 	       De He Di Po 		013	Wild	F5 V K8 V	{ -1 }	(B00+1)	[0000]	B	11	11
+Corr	D	3209	R'tinh Kills	E646000-4	 	     Di 		020	Wild	M1 V	{ -3 }	(300-4)	[0000]	B	5	-12
+Corr	L	3225	Uiolksdah	X426000-C	 	     Di 		010	Wild	M1 V	{ -1 }	(A00+4)	[0000]	B	7	40
+Corr	L	3229	Center	E543000-5	 	     Di Po 		034	Wild	M2 V	{ -3 }	(800+1)	[0000]	B	10	8
+Corr	L	3230	Emm	X643000-3	 	      Di Po 		003	Wild	M1 V	{ -3 }	(500-4)	[0000]	B	13	-20
+Corr	P	3231	Pink Sky	X574000-2	 	      Di 		001	Wild	M0 V M1 V	{ -3 }	(700+1)	[0000]	B	8	7
+Corr	P	3232	Above	X726000-D	 	     LancW  Di 		003	Wild	M3 V	{ -1 }	(D00+1)	[0000]	B	10	13
+Corr	P	3234	Seshotinam	X200000-9	 	     Di Va 		023	Wild	G8 III	{ -2 }	(C00-1)	[0000]	B	14	-12
+Corr	P	3235	Sharkhagu	X541000-1	 	      Di He Po 		001	Wild	M1 V M9 V	{ -3 }	(600-2)	[0000]	B	4	-12
+Corr	P	3238	Lesha	D988000-5	 	      Di 		022	Wild	K8 V	{ -3 }	(300-5)	[0000]	B	15	-15
+Corr	P	3240	Palama	X597000-6	 	     Di 		001	Wild	M0 V M7 V	{ -3 }	(300+2)	[0000]	B	10	6

--- a/res/Sectors/M1900/Corridor.xml
+++ b/res/Sectors/M1900/Corridor.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<Sector Abbreviation="Corr" Tags="Unreviewed">
+  <Y>-1</Y>
+  <X>-2</X>
+  <Name>Corridor</Name>
+  <Name Lang="vi">Amshagi</Name>
+  <Name Lang="vi">Eneri</Name>
+  <Name Lang="va">Roughantz</Name>
+  <Name Lang="va">Llananae Tourz</Name>
+  <Credits>
+    <![CDATA[
+
+             <b>Corridor</b> sector was designed by Marc W. Miller and
+             appears in <cite>Atlas of the Imperium</cite> (GDW,
+             1984).
+
+             It was refined by David Riddell. Portions appear in
+             <cite>The Travellers Digest</cite>.
+             
+             TNE Data from Zhodani Base http://zho.berka.com/data/TNE/sector.pl?sector=CORRIDOR
+
+    ]]>
+  </Credits>
+  <DataFile Source="Traveller 5 Second Survey" Milieu="M1201" Type="TabDelimited">Corridor.tab</DataFile>
+  <Subsectors>
+    <Subsector Index="A">Khouth</Subsector>
+    <Subsector Index="B">Khukish</Subsector>
+    <Subsector Index="C">Lemish</Subsector>
+    <Subsector Index="D">The Narrows</Subsector>
+    <Subsector Index="E">Ian</Subsector>
+    <Subsector Index="F">Strand</Subsector>
+    <Subsector Index="G">Naadi</Subsector>
+    <Subsector Index="H">Uantil</Subsector>
+    <Subsector Index="I">Shush</Subsector>
+    <Subsector Index="J">The Empty Void</Subsector>
+    <Subsector Index="K">Atu'l</Subsector>
+    <Subsector Index="L">Kivu</Subsector>
+    <Subsector Index="M">Two Worlds</Subsector>
+    <Subsector Index="N">Ashishinipar</Subsector>
+    <Subsector Index="O">Sinta</Subsector>
+    <Subsector Index="P">Sashrakusha</Subsector>
+  </Subsectors>
+
+  <Stylesheet>
+    border.Br { color: purple; }
+  </Stylesheet>
+
+  <Allegiances>
+    <Allegiance Code="Br">Brinn</Allegiance>
+    <Allegiance Code="Wi">Wilds</Allegiance>
+  </Allegiances>
+
+  <Routes>
+
+  </Routes>
+  <Borders>
+    <Border Color="Green"  Allegiance="Br" Label="Brinn">2238 2239 2238</Border>
+    <Border Color="Orange" Allegiance="Wi">0000 0100 0200 0300 0400 0500 0600 0700 0800 0900 1000 1100 1200 1300 1400 1500 1600 1700 1800 1900 2000 2100 2200 2300 2400 2500 2600 2700 2800 2900 3000 3001 3102 3201 3200 3301 3302 3202 3103 3104 3105 3106 3107 3207 3308 3309 3310 3209 3110 3010 2911 2811 2711 2611 2511 2411 2312 2212 2112 2012 1913 1813 1714 1614 1515 1415 1416 1417 1418 1318 1218 1118 1017 0918 0817 0717 0617 0517 0417 0318 0218 0119 0019 0018 0017 0016 0015 0014 0013 0012 0011 0010 0009 0008 0007 0006 0005 0004 0003 0002 0001 0000 </Border>
+    <Border Color="Orange" Allegiance="Wi">1140 1141 1140 </Border>
+    <Border Color="Orange" Allegiance="Wi">1741 1840 1940 2039 2038 2037 2137 2136 2135 2234 2233 2333 2432 2532 2631 2731 2830 2930 3029 3129 3228 3227 3226 3225 3325 3326 3327 3328 3329 3330 3331 3332 3333 3334 3335 3336 3337 3338 3339 3340 3341 3241 3141 3041 2941 2940 2839 2740 2741 2641 2541 2441 2341 2440 2439 2438 2338 2237 2138 2139 2140 2141 2041 1941 1841 1741 </Border>
+  </Borders>
+</Sector>

--- a/res/Sectors/M1900/m1900.xml
+++ b/res/Sectors/M1900/m1900.xml
@@ -32,4 +32,11 @@
     <DataFile Author="Robert Eaglestone" Type="TabDelimited">Dene.tab</DataFile>
     <MetadataFile>Dene.xml</MetadataFile>
   </Sector>
+  <Sector Abbreviation="Corr" Selected="true" Milieu="M1900">
+    <Y>-1</Y>
+    <X>-2</X>
+    <Name>Corridor</Name>
+    <DataFile Author="Robert Eaglestone" Type="TabDelimited">Corridor.tab</DataFile>
+    <MetadataFile>Corridor.xml</MetadataFile>
+  </Sector>
 </Sectors>


### PR DESCRIPTION
Started with t5ss data, generated 1201 data, then fast-forwarded through 1508 to 1900.
Saved the Brinn from extinction.

No routes in the XML metafile.

Dieback causes TL linter errors; all other lint issues are resolved.

Added to m1900.xml.
