### PR TITLE
T5ss 1900 Deneb

### DIFF
--- a/res/Sectors/M1900/Deneb.tab
+++ b/res/Sectors/M1900/Deneb.tab
@@ -1,0 +1,387 @@
+Sector	SS	Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W	RU
+Dene	A	0108	New Ramma	D56557C-6	S	                           Ag Pr Ni 		803	Na	G6 V K6 V M6 V	{ -2 }	(742+1)	[2365]	BcC	8	56
+Dene	E	0113	Saarinen	B566226-8	 	             RsE           Lo 		513	Na	K6 V M6 V	{ -1 }	(810-4)	[717C]	B	10	-32
+Dene	I	0123	Rena	D596200-8	S	                       Lo 		603	Na	G4 V	{ -3 }	(710+2)	[116B]	B	12	14
+Dene	I	0124	Gulistan	CAB5436-7	S	                      Fl Ni Px 		120	Na	K6 III	{ -2 }	(533+1)	[125C]	B	12	45
+Dene	I	0130	Chaosheo	E87A77C-5	 	           (Shi'awei)              Pi Wa 		325	Wild	K8 V	{ -2 }	(963+4)	[6553]	BD	10	648
+Dene	M	0138	Iruku	B310443-9	 	                       Ni 		201	Wild	F1 V M2 V	{ 0 }	(734+3)	[44A6]	B	13	252
+Dene	A	0201	Marz	A5848BB-8	S	          (Marzians)                 Pa Ri Ph 		501	Wild	G4 V G6 V	{ 1 }	(C77-2)	[6959]	BcCe	10	-1176
+Dene	A	0202	Carthage	B310751-D	 	                            Na Pi 		424	Wild	M2 V	{ 2 }	(F69+1)	[B99D]	BD	13	810
+Dene	A	0203	Enaaka	D777000-6	 	             An            Di 		022	Wild	F5 V	{ -3 }	(900+1)	[0000]	B	10	9
+Dene	A	0207	Rubrak	C554586-7	S	                       Ag Ni 		801	Rr	K3 V M7 V	{ -1 }	(745+1)	[745A]	BC	12	140
+Dene	A	0208	Teh	D563100-6	S	                       Lo 		802	Na	M2 V	{ -3 }	(300-2)	[111A]	B	7	-6
+Dene	A	0209	Kretikaa	B200548-C	 	                       Ni Va 		723	Rr	K2 V	{ 1 }	(C43+3)	[764B]	B	8	432
+Dene	E	0211	Suvfoto	D954846-6	S	                       Pa Ph 		304	Na	K6 V	{ -2 }	(A74-2)	[4675]	Bce	7	-560
+Dene	E	0214	Musayid	E544898-5	 	                            Pa Pi Ph 	A	514	Na	K5 V	{ -2 }	(A73+1)	[7625]	BcDe	18	210
+Dene	E	0217	Umiikam	DAA6377-7	 	                       Fl Lo 		201	Na	M0 V M1 V	{ -3 }	(520+1)	[117A]	B	14	10
+Dene	E	0218	Vanzeti	C52A500-D	S	                       Ni 		601	Na	M3 V M7 V	{ 0 }	(844+3)	[354E]	B	14	384
+Dene	I	0221	Mater Nova	B575743-9	 	                           Ag Pi 		114	Na	G8 V M6 V	{ 2 }	(E6B+1)	[6926]	BCD	10	924
+Dene	I	0222	Breslow	X540641-4	 	                            De He Ni Po 	R	202	Na	K8 V M4 V	{ -3 }	(750+4)	[8323]	B	11	140
+Dene	I	0223	Daumier	B88A443-D	 	                       Ni Wa 		510	Na	K7 V M9 V	{ 1 }	(733+1)	[75AB]	B	10	63
+Dene	I	0224	Adapam	E796434-7	 	                       Ni Pa 		722	Na	K8 V	{ -3 }	(630-1)	[4148]	Bc	7	-18
+Dene	I	0226	Wroclaw	C566772-7	 	                            Ag Ri 	A	723	Na	G8 V K2 V	{ 1 }	(968-1)	[8883]	BC	12	-432
+Dene	I	0228	Rimkuku	D9A8887-8	S	                       Fl Ph 		324	Na	G1 V M3 V	{ -2 }	(G74-2)	[7697]	Be	15	-896
+Dene	I	0229	Aziziyah	E86A000-B	 	                       Di Wa 		024	Wild	G3 V	{ -1 }	(C00-2)	[0000]	B	9	-24
+Dene	M	0233	Inkekush	A540545-D	N 	                           De He Ni Po 		131	Wild	F9 V M2 V	{ 1 }	(B47+2)	[765G]	B	14	616
+Dene	M	0235	Saguenay	E438000-E	 	                       Di 		024	Wild	M0 V	{ -1 }	(A00-2)	[0000]	B	9	-20
+Dene	M	0237	Taman	E874000-5	 	                       Di 		010	Wild	G7 V M3 V	{ -3 }	(500+1)	[0000]	B	11	5
+Dene	M	0238	Nouakchat	E532000-6	 	                       Di Po 		003	Wild	M4 V	{ -3 }	(300+1)	[0000]	B	14	3
+Dene	A	0303	Kiiga	D530620-7	 	                            De Na Po Ni 		101	Wild	M0 V M7 V	{ -3 }	(852+2)	[8356]	B	11	160
+Dene	A	0304	Riacon	B666375-8	N 	                        Ga Lo 		801	Wild	G6 V M8 V	{ -1 }	(720+2)	[622B]	B	11	28
+Dene	A	0306	Saki	D576657-7	 	                       Ag Ni 		701	Na	K8 V	{ -2 }	(852-2)	[746A]	BC	8	-160
+Dene	A	0310	Horizon	E310798-8	 	                           Na Pi 		224	Na	F2 V K0 V	{ -2 }	(F68-2)	[658D]	BD	13	-1440
+Dene	E	0311	Fennec	C556876-8	S	                       Pa Ph 		520	Na	K7 V	{ -1 }	(C74+1)	[4787]	Bce	7	336
+Dene	E	0316	Magash	A4009A9-F	S	                            Hi Na In Va 		624	Li	F8 V K7 V	{ 4 }	(H8A+1)	[AD6F]	BEf	10	1360
+Dene	E	0319	Cabrini	C565552-7	S	                           Ag Pr Ni 		323	Na	G9 V	{ -1 }	(745+4)	[1474]	BcC	10	560
+Dene	I	0327	Barbary	C57179B-5	S	                        He Pi 	A	613	Na	F5 V M4 V	{ -1 }	(966+2)	[A658]	BD	7	648
+Dene	I	0328	Dunstan	C649220-8	 	                       Lo 		423	Na	G4 V	{ -2 }	(910+2)	[1124]	B	8	18
+Dene	I	0330	Canisus	C431787-8	S	                            Na Po 		401	Wild	G4 V M9 V M2 V	{ -1 }	(A65+1)	[968B]	B	10	300
+Dene	M	0332	Aosta	E669000-C	 	                       Di 		012	Wild	M1 V	{ -1 }	(700-2)	[0000]	B	12	-14
+Dene	M	0334	Furens	E8A9000-A	 	                       Di Fl 		003	Wild	M2 V M7 V	{ -1 }	(B00+5)	[0000]	B	8	55
+Dene	M	0336	Upuraku	B584579-8	W	                           Ag Pr Ni 		301	Wild	G2 V	{ 1 }	(843+1)	[8679]	BcC	6	96
+Dene	M	0339	Tuwayk	B6728C9-A	 	                       He Ph Pi 		201	Wild	G8 V	{ 2 }	(B7D+5)	[7A89]	BDe	14	5005
+Dene	A	0403	Gessert	E554000-9	 	                       Di 		020	Wild	A2 V G0 V	{ -2 }	(700+1)	[0000]	B	10	7
+Dene	A	0404	Miwald	C533455-B	S	                        Ni Po 		102	Wild	M0 V M5 V	{ 0 }	(834+1)	[742A]	B	10	96
+Dene	A	0406	Pretoria	B6569AB-C	NS	                         Ga Hi 		720	Rr	G5 IV	{ 4 }	(D89+1)	[BD3G]	BEf	13	936
+Dene	A	0409	L'sis	A7648A8-8	N 	                           Pa Ri Ph 		201	Na	F6 V	{ 1 }	(B74+1)	[A959]	BcCe	13	308
+Dene	E	0412	Dhapura	E579744-6	 	                       Pi 		712	Na	F4 V	{ -2 }	(969-3)	[7561]	BD	13	-1458
+Dene	E	0415	Pharos	B593425-8	 	                       Ni 		812	Li	M2 V	{ -1 }	(934+4)	[7377]	B	12	432
+Dene	E	0417	Sui'tang	B55288D-A	 	                        Ph Po 		615	Li	G4 V K3 V	{ 2 }	(G77+1)	[9A27]	Be	13	784
+Dene	E	0419	Ara Pacis	A437659-C	 	                       Ni 		601	Na	M3 V	{ 1 }	(954-3)	[278D]	B	4	-540
+Dene	I	0422	Rouenet	C562211-9	 	                       Lo 		705	Na	K0 V	{ -1 }	(910-1)	[1168]	B	11	-9
+Dene	M	0431	Zyedl	E55147C-5	 	                       Ni Po 		301	Wild	K3 V	{ -3 }	(630-2)	[1121]	B	5	-36
+Dene	M	0436	Endup	D69388C-6	 	                        Ph Pi 		504	Wild	F6 V M4 V	{ -2 }	(B76+4)	[A667]	BDe	7	1848
+Dene	M	0439	Beaxon	D88AA79-C	 	                        Hi Wa 		423	Wild	M1 V	{ 1 }	(H9C-1)	[7B48]	BE	8	-1836
+Dene	M	0440	Noghon	D797000-8	 	                        Di 		021	Wild	F5 V G8 V	{ -3 }	(E00+1)	[0000]	B	7	14
+Dene	A	0502	El D'Nah	E549000-B	 	                       Di 		002	Wild	K6 V	{ -1 }	(800+2)	[0000]	B	8	16
+Dene	A	0503	Spectre	B100654-A	 	                        Na Ni Va 		602	Wild	M8 V	{ 1 }	(A57-2)	[9716]	B	9	-700
+Dene	A	0504	Ash	A540856-9	S	                               De He Ph Pi Po 		101	Wild	M4 V M9 V	{ 1 }	(B74-2)	[9935]	BDe	14	-616
+Dene	A	0508	Caladib	B697257-A	N 	                       Lo 		501	Rr	M2 V	{ 1 }	(511-1)	[4329]	B	11	-5
+Dene	A	0509	Redi	E575579-5	 	          An Chir4               Ag Ni 		612	Na	F3 V M3 V	{ -2 }	(742+1)	[4379]	BC	10	56
+Dene	A	0510	Gra-Bie	C430222-9	 	       Jonk8                 De Lo Po 		320	Na	G7 V	{ -1 }	(610+1)	[411C]	B	12	6
+Dene	E	0514	Marnie's World	AA9A386-B	N 	                       Lo Oc 		510	Li	G3 V	{ 1 }	(621-1)	[1478]	B	12	-12
+Dene	E	0516	Endimyon	X555410-3	 	                        Ni Pa 	 	523	Na	M1 V M3 V	{ -3 }	(630+2)	[4162]	Bc	14	36
+Dene	E	0517	Seleen	A310430-E	 	                        Ni 		804	Li	M6 V	{ 1 }	(A36+1)	[755E]	B	15	180
+Dene	E	0518	Thengin	B5679A9-C	N 	                       Hi Pr 		205	Li	G9 V	{ 3 }	(G8A-2)	[7C1C]	BcE	10	-2560
+Dene	I	0524	Isurkun	A541379-A	 	                       He Lo Po 		521	Na	G4 IV	{ 1 }	(821+3)	[144B]	B	11	48
+Dene	I	0525	Sejmal	C310655-B	 	                       Na Ni 		434	Na	K4 V	{ 0 }	(F52-1)	[661C]	B	10	-150
+Dene	I	0529	Moltke	E646000-8	 	                       Di 		004	Wild	G6 V K6 V	{ -3 }	(700-2)	[0000]	B	8	-14
+Dene	M	0531	Briaxis	C420477-B	 	                           De He Ni Po 		401	Wild	M1 V M9 V	{ 0 }	(732+1)	[844C]	B	11	42
+Dene	M	0534	Maricutin	X764000-A	 	                       Di 		013	Wild	F9 V K5 V	{ -1 }	(700-3)	[0000]	B	11	-21
+Dene	A	0602	Kirklend	A668310-A	N 	                        Lo 		923	Wild	F4 V	{ 1 }	(B21-1)	[346F]	B	12	-22
+Dene	A	0604	Carmel	X546000-9	 	                        Di 		002	Wild	K0 V M0 V	{ -2 }	(800+1)	[0000]	B	9	8
+Dene	A	0609	Urnas	D4209DF-C	S	           Jonk2                          De He Hi Na In Po 	A	210	Na	K7 V	{ 2 }	(C89-2)	[CB3B]	BE	12	-1728
+Dene	E	0615	Anomaly Five	X100000-0	 	                        Ba Va 	R	023	Li	M9 V	{ -3 }	(200-3)	[0000]	B	11	-6
+Dene	E	0619	Sevas Topol	D9C4202-9	 	                       Fl Lo 		723	Na	M2 V	{ -2 }	(910+3)	[118A]	B	9	27
+Dene	I	0622	Mushinag	D575540-7	S	                       Ag Ni 		720	Na	F6 V	{ -2 }	(740+3)	[43A7]	BC	14	84
+Dene	I	0623	Araa	C566200-A	S	                       Lo 		522	Na	F7 V K9 V	{ 0 }	(810+1)	[123B]	B	12	8
+Dene	I	0624	Helmuth	C846323-7	S	                       Lo 		222	Na	K9 V	{ -2 }	(420-2)	[2148]	B	9	-16
+Dene	I	0626	Kernal	B5667B8-7	 	              (Yafizethe)              Ag Ri 		423	Na	G3 V	{ 2 }	(969+1)	[5938]	BC	9	486
+Dene	I	0629	Askigaak	E549000-B	 	              (Sigka)           Di 		001	Wild	M1 V	{ -1 }	(D00+4)	[0000]	B	9	52
+Dene	M	0633	Preslin	B430635-C	N 	        Jonk9                    De Na Po Ni 		110	Wild	M2 V	{ 1 }	(952+1)	[575B]	B	11	90
+Dene	M	0638	Brufort	D669000-6	 	                        Di 		020	Wild	F5 V G5 V	{ -3 }	(800-5)	[0000]	B	7	-40
+Dene	A	0701	Taa	X651000-4	 	                       Di Po 		030	Wild	G7 V	{ -3 }	(800+4)	[0000]	B	12	32
+Dene	A	0702	Dilex	X626000-7	 	                        Di 		002	Wild	M1 V	{ -3 }	(A00+1)	[0000]	B	5	10
+Dene	A	0709	Hylaxis	B7B2356-A	 	                          Fl He Lo Px 		522	Na	K7 V	{ 1 }	(921-4)	[1445]	B	9	-72
+Dene	A	0710	Naali	C61657A-8	S	                       Ic Ni 		424	Na	M4 V	{ -2 }	(D44+2)	[7389]	B	9	416
+Dene	E	0713	Amirante	D31089B-7	S	                           Na Pi Ph 		702	Na	K5 V	{ -2 }	(A77+2)	[4696]	BDe	11	980
+Dene	E	0715	Bahadur	A426110-E	N 	                       Lo 		802	Li	M5 V	{ 1 }	(601+1)	[221A]	B	12	6
+Dene	E	0717	Rhinom	B77688B-8	N 	                            Pa Pi Ph 	A	401	Na	G9 V	{ 0 }	(B76+3)	[787C]	BcDe	6	1386
+Dene	I	0727	Shen-Yang	C665575-5	S	                           Ag Pr Ga Ni 		302	Wild	F7 V K1 V	{ -1 }	(745-5)	[6449]	BcC	14	-700
+Dene	I	0729	Norg	E000000-D	 	                           As Va Di 		010	Wild	M7 V	{ -1 }	(400+4)	[0000]	B	4	16
+Dene	I	0730	Sultana	E649000-9	 	                       Di 		021	Wild	M4 V	{ -2 }	(900-2)	[0000]	B	6	-18
+Dene	M	0731	Qevar	A432646-E	NS	                               Na Px Po Ni 		403	Wild	M6 V	{ 2 }	(B55+5)	[581F]	B	6	1375
+Dene	M	0734	Raguseppe	B410531-A	 	                       Ni 		110	Wild	M0 V M0 V	{ 1 }	(843-4)	[663B]	B	14	-384
+Dene	M	0735	Kiangya	E7C2000-B	 	                           Di Fl He 		014	Wild	M3 V	{ -1 }	(900+1)	[0000]	B	14	9
+Dene	M	0737	Taomina	D421000-7	 	                         Di He Po 		034	Wild	G8 V	{ -3 }	(800-4)	[0000]	B	10	-32
+Dene	M	0740	Mtensc	D551000-8	 	                       Di Po 		023	Wild	M0 V	{ -3 }	(B00-3)	[0000]	B	13	-33
+Dene	A	0803	Retion	E558000-4	 	                        Di 		001	Wild	K7 V M4 V	{ -3 }	(600+3)	[0000]	B	12	18
+Dene	A	0805	Jode	E9A6000-B	 	          rg1 (Serpents)              Di Fl 		010	Wild	F3 IV	{ -1 }	(900-1)	[0000]	B	14	-9
+Dene	A	0809	Therm	D9B4455-9	S	                       Fl Ni 		313	Na	M9 V	{ -2 }	(A31-1)	[7279]	B	7	-30
+Dene	E	0812	Cicus	E310323-7	 	                       Lo 		621	Na	G0 V K0 V M4 V	{ -3 }	(520+2)	[317B]	B	10	20
+Dene	E	0813	Makeni	E100554-9	 	                       Ni Va 		402	Na	M1 V	{ -2 }	(942-3)	[A32C]	B	9	-216
+Dene	E	0814	Amritsar	C897576-8	 	          An              Ag Ni 		213	Na	F3 V	{ -1 }	(B41-2)	[4465]	BC	12	-88
+Dene	E	0815	Pangumo	C552578-9	 	                        Ni Po 	 	301	Li	K0 V M8 V	{ -1 }	(843+2)	[944B]	B	8	192
+Dene	E	0816	Coshecawat	X100658-8	 	                        Na Ni Va 	 	213	Na	M3 V M6 V	{ -3 }	(C50+2)	[5379]	B	9	120
+Dene	E	0819	Jehun	E667635-6	 	                            Ag Ri Ga Ni 		901	Na	K2 V M4 V	{ -1 }	(853+2)	[3548]	BC	10	240
+Dene	I	0824	Tlaza	C303122-9	 	                           Ic Va Lo 		913	Na	M6 V	{ -1 }	(700+1)	[1149]	B	12	7
+Dene	I	0826	Imone	D9C4000-F	 	                       Di Fl 		013	Wild	M0 V	{ -1 }	(B00-3)	[0000]	B	8	-33
+Dene	I	0827	Skopyeh	B500455-D	 	                       Ni Va 		602	Wild	F9 V K3 V	{ 1 }	(933+2)	[153C]	B	12	162
+Dene	I	0828	Burnham	D664000-8	 	                       Di 		001	Wild	K3 V	{ -3 }	(600-5)	[0000]	B	9	-30
+Dene	I	0830	Bukit Seng	X542000-8	 	                       Di He Po 		004	Wild	M4 V	{ -3 }	(900-3)	[0000]	B	7	-27
+Dene	M	0833	Mephit	E9B8000-8	 	                       Di Fl 		002	Wild	G6 V K4 V	{ -3 }	(800+3)	[0000]	B	8	24
+Dene	B	0902	Ghatsokie	DA86652-5	 	            (Crenduthaar)8 rg2                 Ag Ri Ni 		304	Wild	K7 V	{ -1 }	(850+3)	[B553]	BC	7	120
+Dene	B	0903	Matsa	X434000-E	 	                       Di 		002	Wild	G3 IV M5 V	{ -1 }	(800+3)	[0000]	B	5	24
+Dene	B	0905	Aksofouta	X5567A8-0	 	                       Ag 		312	Wild	G6 V	{ -1 }	(966+1)	[3663]	BC	13	324
+Dene	B	0906	Waalikii	X525000-B	 	                       Di 		034	Wild	F8 V	{ -1 }	(E00+4)	[0000]	B	11	56
+Dene	B	0907	Malkei	B659836-8	 	                        Ph 		310	Wild	M1 V	{ 0 }	(B74-3)	[D849]	Be	10	-924
+Dene	B	0910	Gyrfal	C8B6599-9	 	                       Fl Ni 		203	Na	M8 V	{ -1 }	(A40-3)	[845B]	B	14	-120
+Dene	F	0912	Kayu	E9B7555-9	 	                       Fl Ni 		412	Na	M2 V	{ -2 }	(A43-1)	[3359]	B	6	-120
+Dene	F	0913	Amarkimi	B546400-B	W	                       Ni Pa 		702	Na	K8 V	{ 2 }	(833+1)	[5658]	Bc	8	72
+Dene	F	0914	Otomisi	B5A557A-C	S	                       Fl Ni 		403	Na	G6 V M9 V	{ 1 }	(A43+1)	[764G]	B	11	120
+Dene	F	0915	Skold	B764201-B	 	                       Lo 		824	Na	K0 V	{ 1 }	(B11+2)	[332A]	B	15	22
+Dene	F	0917	Kubishush	B8B6A88-F	 	        (Gl'lu)                 Fl Hi In 	A	201	Li	M3 V M8 V	{ 4 }	(C9C+3)	[9EAF]	BEf	9	3888
+Dene	J	0921	Northammon	B764647-A	NS	                            Ag Ri Ni 		820	Na	K5 V	{ 4 }	(A59+1)	[4A6A]	BCf	9	450
+Dene	J	0922	Teyobald	B8B3622-B	 	                       Fl Ni 		122	Na	M4 V M4 V	{ 1 }	(B56-5)	[5757]	B	15	-1650
+Dene	J	0925	Ibix Donora	C432344-9	 	                       Lo Po 		201	Na	K1 V M3 V	{ -1 }	(520-1)	[5237]	B	7	-10
+Dene	J	0929	Sipedon	E553676-6	 	                        Ni Po 		402	Wild	M2 V M4 V	{ -3 }	(850-2)	[4363]	B	14	-80
+Dene	J	0930	Arnyl	B683656-9	NS	                       Ni Ri 		523	Wild	G2 V	{ 2 }	(D56+1)	[7845]	BC	10	390
+Dene	N	0933	Echura	C683745-8	 	                        Ri 		103	Wild	M1 V	{ 0 }	(C68+4)	[779B]	BC	7	2304
+Dene	N	0935	Inquar	B8B5772-A	S	                       Fl 		223	Wild	M6 III	{ 2 }	(E6B-1)	[595B]	B	13	-924
+Dene	N	0936	Tullyhome	D669776-5	 	                       Ri 		101	Wild	K2 V M1 V	{ -1 }	(969-1)	[A685]	BC	14	-486
+Dene	N	0939	Sestos	D5A6859-9	 	                       Fl Ph 		503	Wild	K6 V M6 V	{ -1 }	(D72+1)	[C765]	Be	11	182
+Dene	B	1001	Kfathvaedal	X000000-C	 	                            As Va Di 		024	Wild	G5 V	{ -1 }	(E00-1)	[0000]	B	12	-14
+Dene	B	1004	Sisi	X8D3000-8	 	                        Di 		024	Wild	M4 V	{ -3 }	(E00+1)	[0000]	B	14	14
+Dene	B	1006	Kamisaraki	C554435-9	S	                        Ni Pa 		203	Wild	G1 V K1 V	{ -1 }	(930-2)	[336D]	Bc	6	-54
+Dene	F	1011	Jessok	C623597-A	 	                          Ni Px Po 		920	Na	G0 V G8 V	{ 0 }	(946-1)	[9559]	B	7	-216
+Dene	F	1014	Mowebe	C748534-9	 	                       Ag Ni 		601	Na	K9 V M2 V	{ 0 }	(841+2)	[4575]	BC	7	64
+Dene	F	1016	Liiri	B54297A-C	 	                           He Hi In Po 		301	Li	M1 V M4 V	{ 4 }	(C8C+1)	[6D4D]	BEf	14	1152
+Dene	F	1018	Hessel	B658120-B	N 	                       Lo 		801	Na	F4 V K4 V	{ 1 }	(401-1)	[425F]	B	12	-4
+Dene	J	1023	Irumunu	B7B3676-B	W	                      Fl Ni Px 		101	Na	M6 V M6 V	{ 2 }	(956+2)	[981A]	B	14	540
+Dene	J	1025	Frisgar	E4247A7-8	 	                       Pi 		201	Wild	K7 V K7 V M1 V	{ -2 }	(A65-2)	[7596]	BD	9	-600
+Dene	J	1026	Burtrum	C53878B-8	 	                        		301	Wild	M0 V M3 V	{ -1 }	(A62-1)	[9656]	B	14	-120
+Dene	J	1030	Prege	D79A000-9	 	                       Di Wa 		002	Wild	M2 V	{ -2 }	(A00+1)	[0000]	B	9	10
+Dene	N	1032	Quinthept	D521000-A	 	                       Di He Po 		021	Wild	G0 V	{ -1 }	(A00+3)	[0000]	B	11	30
+Dene	N	1035	Storm	DAD6000-A	 	                       Di 		014	Wild	M0 V	{ -1 }	(900+1)	[0000]	B	11	9
+Dene	N	1038	Timmer	C562635-7	S	                       Ni Ri 		114	Wild	G6 V K3 V	{ -1 }	(854-1)	[2586]	BC	8	-160
+Dene	F	1111	Zeen	D653578-7	S	          DroyW              Ni Po 		801	Wild	K6 V	{ -3 }	(843+3)	[6235]	B	7	288
+Dene	F	1115	Pecena	D547000-A	 	                       Di 		022	Wild	M4 V	{ -1 }	(900+1)	[0000]	B	11	9
+Dene	F	1116	Abydos	D435443-9	S	                        Ni 		910	Wild	M5 V	{ -2 }	(932-2)	[223A]	B	14	-108
+Dene	F	1118	Karabeth	E663374-7	 	                        Lo 		502	Wild	K9 V M3 V	{ -3 }	(620+2)	[7129]	B	14	24
+Dene	J	1122	Vincennes	A8999A8-E	 	                        Hi In 		713	Wild	G1 V K7 V K1 V	{ 4 }	(G8C-2)	[9D9E]	BEf	14	-3072
+Dene	J	1123	Erisis	D679000-7	 	                       Di 		013	Wild	M1 V	{ -3 }	(600+1)	[0000]	B	11	6
+Dene	J	1128	Dekha	C100A75-F	S	                           Hi Na In Va 		110	Wild	F3 V M6 V	{ 3 }	(D97-3)	[AD4J]	BE	10	-2457
+Dene	N	1133	Keirei	X310000-B	 	                       Di 		034	Wild	M7 V	{ -1 }	(C00-1)	[0000]	B	10	-12
+Dene	N	1135	Lilad	C547ACA-C	 	                        Hi In 		424	Wild	K6 V	{ 3 }	(J99+4)	[FD5C]	BE	14	5832
+Dene	N	1137	Third Mu	DA7A000-C	 	                       Di Oc 		025	Wild	K3 V	{ -1 }	(B00-4)	[0000]	B	10	-44
+Dene	N	1138	Ushashin	EA9A000-7	 	                       Di Oc 		034	Wild	G7 V	{ -3 }	(400-3)	[0000]	B	11	-12
+Dene	N	1140	Oriryu	B53658C-9	 	                       Ni 		201	Wild	M3 V M4 V	{ 0 }	(842+1)	[1579]	B	8	64
+Dene	B	1202	Lengighdzuerz	X300000-B	 	                       Di Va 		023	Wild	G6 V	{ -1 }	(C00+4)	[0000]	B	12	48
+Dene	B	1203	Naimar Station	X000000-A	 	                           As Va Di 		012	Wild	M5 V M7 V	{ -1 }	(800+1)	[0000]	B	7	8
+Dene	B	1208	Haniiwa	XA9A000-5	 	                        Di Oc 		010	Wild	F4 V	{ -3 }	(800+1)	[0000]	B	6	8
+Dene	F	1212	Prigojin	E100451-9	 	                       Ni Va 		603	Wild	K4 V	{ -2 }	(932-3)	[5269]	B	7	-162
+Dene	F	1213	Inar	A310778-E	N 	                            Na Pi 		603	Wild	M7 V	{ 2 }	(C69-3)	[896E]	BD	6	-1944
+Dene	F	1216	Morninglori	D544000-7	 	                        Di 		013	Wild	M2 V	{ -3 }	(700+2)	[0000]	B	12	14
+Dene	F	1217	Clarissa	X536000-A	 	                       Di 		014	Wild	M4 V	{ -1 }	(B00+4)	[0000]	B	15	44
+Dene	F	1218	Gaagir	X86A000-A	 	                       Di Wa 		001	Wild	K6 V K9 V	{ -1 }	(600+4)	[0000]	B	11	24
+Dene	F	1220	Minde's Star	D435349-9	S	                      Lo Px 		803	Wild	M4 V	{ -2 }	(920-3)	[3136]	B	9	-54
+Dene	J	1221	Peres	X536000-6	 	             (Yaitlat)           Di 		001	Wild	K2 V M6 V	{ -3 }	(400-1)	[0000]	B	10	-4
+Dene	J	1223	Montane	X683000-7	 	                       Di 		022	Wild	G8 V	{ -3 }	(300+4)	[0000]	B	8	12
+Dene	J	1224	Achemadon	E547000-A	 	                         Di 		001	Wild	K7 V M3 V	{ -1 }	(A00+1)	[0000]	B	5	10
+Dene	J	1226	Bishop	B201514-D	S	                           Ic Va Ni 		324	Wild	M6 III	{ 1 }	(D45-2)	[466D]	B	14	-520
+Dene	J	1227	Taburi Nen	D546000-B	 	                        Di 		021	Wild	K7 V	{ -1 }	(A00+1)	[0000]	B	16	10
+Dene	J	1229	Djar	C30079B-7	S	                             Na Pi Va 		702	Wild	F0 V M4 V	{ -1 }	(A63+2)	[8612]	BD	6	360
+Dene	N	1231	Point Ay	C560544-9	S	                       De Ni Pr 		402	Wild	M1 V	{ -1 }	(940+3)	[343A]	Bc	14	108
+Dene	N	1235	Veldt	C567789-7	S	                           Ag Ri 		414	Wild	F6 V	{ 1 }	(96B+2)	[5877]	BC	14	1188
+Dene	N	1238	Muntgumree	B553435-9	NS	                        Ni Po 		103	Wild	K1 V	{ 1 }	(B36+1)	[1559]	B	7	198
+Dene	B	1301	Latros	X688000-0	 	                       Ba 		001	Wild	K3 V M8 V	{ -3 }	(400+1)	[0000]	B	5	4
+Dene	B	1302	Kantra	X301000-9	 	                            Di Ic Va 		022	Wild	M7 V	{ -2 }	(C00+4)	[0000]	B	14	48
+Dene	B	1303	Qi'iri	X554000-6	 	                       Di 		010	Wild	M0 V	{ -3 }	(500-1)	[0000]	B	7	-5
+Dene	B	1306	Lome	E4247A9-8	 	                        Pi 		701	Wild	M0 V M2 V M7 V	{ -2 }	(B62-1)	[A57B]	BD	11	-132
+Dene	B	1309	Lamas	X7A8000-C	 	                       Di Fl 		001	Wild	M5 V	{ -1 }	(800+1)	[0000]	B	6	8
+Dene	F	1311	Quanah	X567000-6	 	                        Di 		023	Wild	K4 V	{ -3 }	(600+1)	[0000]	B	11	6
+Dene	F	1313	Rayel	X693000-8	 	                       Di 		010	Wild	G3 V	{ -3 }	(900-2)	[0000]	B	14	-18
+Dene	F	1314	Modika	D550000-8	 	       Jonk0                 De Di Po 		003	Wild	F5 V M3 V	{ -3 }	(900+1)	[0000]	B	13	9
+Dene	F	1318	Ciprien	X553000-7	 	                       Di Po 		021	Wild	F5 V	{ -3 }	(500+2)	[0000]	B	10	10
+Dene	F	1319	Thane	D585477-7	S	                       Ni Pa 		421	Wild	K3 V	{ -3 }	(630+1)	[6157]	Bc	6	18
+Dene	J	1323	Al-Uqayr	E567000-5	 	                       Di 		013	Wild	M2 V	{ -3 }	(400-5)	[0000]	B	13	-20
+Dene	J	1324	Jonkeer	C5908B8-8	S	         (Jonkeereen)                    De He Ph Pi 		101	Wild	G1 V M1 V	{ -1 }	(B79-1)	[7727]	BDe	14	-693
+Dene	J	1327	Medard	D421000-C	 	                       Di He Po 		001	Wild	K9 V M9 V M7 V	{ -1 }	(700+3)	[0000]	B	14	21
+Dene	N	1332	Giffert	E7A8000-D	 	                       Di Fl 		020	Wild	F5 V K8 V	{ -1 }	(900-1)	[0000]	B	8	-9
+Dene	N	1333	Shiiku	D651758-7	S	                        Po 		222	Wild	M0 V	{ -2 }	(966+4)	[B58B]	B	17	1296
+Dene	N	1334	Giranima	D797873-6	S	           (Khethss)                 Pa Pi Ph 		913	Wild	K9 V M1 V	{ -2 }	(B75+1)	[6685]	BcDe	13	385
+Dene	N	1336	Dawn	XA9A000-C	 	                       Di Oc 		003	Wild	F9 V	{ -1 }	(A00-2)	[0000]	B	7	-20
+Dene	N	1337	Unxava	X677000-7	 	                        Di 		023	Wild	G3 IV	{ -3 }	(800-2)	[0000]	B	13	-16
+Dene	N	1338	Sorel	X539000-C	 	                       Di 		001	Wild	K1 V K6 V	{ -1 }	(400+1)	[0000]	B	10	4
+Dene	N	1339	Zeng	D426000-C	 	                        Di 		011	Wild	M3 V	{ -1 }	(800-2)	[0000]	B	15	-16
+Dene	N	1340	Agdarmi	B56679D-A	 	                           Ag Ri 		324	Wild	M2 V	{ 4 }	(F6A+2)	[6B29]	BCf	10	1800
+Dene	B	1403	Qi'ire	E657000-6	 	                       Di Ga 		002	Wild	K8 V	{ -3 }	(500+1)	[0000]	B	10	5
+Dene	B	1405	Anatre	D578752-7	 	                            Ag Pi 		901	Wild	G3 V	{ -1 }	(A64+1)	[5655]	BCD	5	240
+Dene	B	1406	Borlund	E554A7B-9	 	              (Lurent)           Hi 		301	Wild	K8 V M9 V	{ 0 }	(D93+4)	[AAA7]	BE	13	1404
+Dene	B	1409	Krisna	X84A000-A	 	                       Di Wa 		012	Wild	F8 V	{ -1 }	(B00-1)	[0000]	B	7	-11
+Dene	F	1415	Taillon	C78A633-9	S	                        Ni Ri Wa 		401	Wild	G6 V M6 V	{ 0 }	(954-3)	[9654]	BC	8	-540
+Dene	F	1417	Starn	B000954-G	S	         RsB                       As Va Hi Na In 		422	Wild	K0 V	{ 5 }	(F8E+1)	[CE7L]	BEf	12	1680
+Dene	F	1419	Montcolm	D675000-7	 	                       Di 		022	Wild	K4 V	{ -3 }	(400-1)	[0000]	B	9	-4
+Dene	F	1420	Quebraco	E78A000-5	 	                         Di Wa 		024	Wild	K3 V M1 V	{ -3 }	(700-1)	[0000]	B	11	-7
+Dene	J	1424	Sarden	E552575-7	 	                       Ni Po 		201	Wild	M2 V	{ -3 }	(841-1)	[8245]	B	13	-32
+Dene	J	1426	Kew	E512000-B	 	                       Di Ic 		013	Wild	M3 V	{ -1 }	(700+1)	[0000]	B	13	7
+Dene	J	1428	Condamine	C665572-7	 	                           Ag Pr Ga Ni 		621	Wild	F9 V M0 V	{ -1 }	(744+3)	[5464]	BcC	9	336
+Dene	J	1429	Ishiri	E565855-6	 	                          Pa Ri Ph 		921	Wild	F7 V M0 V K0 V	{ -1 }	(B78+2)	[5741]	BcCe	9	1232
+Dene	J	1430	Eretaro	D9C4000-B	 	                       Di Fl 		001	Wild	M2 V M3 V	{ -1 }	(400+1)	[0000]	B	9	4
+Dene	N	1432	Pashus	A432474-F	S	          RsZ              Ni Po 		312	Wild	F9 V	{ 1 }	(936-4)	[751F]	B	14	-648
+Dene	N	1433	Atab	C540789-8	S	             JonkW                    De He Pi Po 		803	Wild	G7 V M7 V	{ -1 }	(D63+2)	[A617]	BD	12	468
+Dene	N	1435	Quirinal	C651684-8	 	                      Ni Po 		401	Wild	G2 V M9 V M9 V	{ -2 }	(A54-1)	[6449]	B	8	-200
+Dene	N	1436	Isidor	D571000-8	 	                        Di He 		023	Wild	M0 V	{ -3 }	(C00-1)	[0000]	B	13	-12
+Dene	N	1439	Breit-Tuve	X425000-B	 	                       Di 		011	Wild	M1 V	{ -1 }	(900+1)	[0000]	B	12	9
+Dene	N	1440	Fessenden	C43577B-6	 	                        		101	Wild	M1 V	{ -1 }	(965-4)	[C662]	B	9	-1080
+Dene	B	1502	Mur	X100000-A	 	                        Di Va 		020	Wild	F1 V K1 V	{ -1 }	(B00-3)	[0000]	B	10	-33
+Dene	B	1504	Gila	X663000-5	 	                        Di 		001	Wild	K5 V M1 V	{ -3 }	(800-2)	[0000]	B	7	-16
+Dene	B	1505	Lagut	C312588-A	 	                       Ic Ni 		432	Wild	F9 V	{ 0 }	(C41+2)	[452C]	B	10	96
+Dene	B	1508	Pek'e	X541000-7	 	                       Di He Po 		012	Wild	M3 V	{ -3 }	(500+3)	[0000]	B	6	15
+Dene	B	1509	Prolam	B769447-A	N 	                       Ni 		323	Wild	K7 V	{ 1 }	(B32+1)	[4539]	B	8	66
+Dene	F	1518	Trevith	E673000-5	 	                       Di 		022	Wild	G0 V M2 V	{ -3 }	(500+3)	[0000]	B	7	15
+Dene	F	1520	Kauai	BA89488-B	NS	                        Ni 		224	Wild	F8 V K5 V	{ 2 }	(D35+3)	[162E]	B	9	585
+Dene	J	1522	Bumushe	C68A632-6	S	                       Ni Ri Wa 		124	Wild	F9 V	{ -1 }	(855-3)	[5536]	BC	14	-600
+Dene	J	1524	Verd	E550000-6	 	       JonkW                 De Di Po 		002	Wild	G2 V M7 V	{ -3 }	(600+4)	[0000]	B	15	24
+Dene	N	1532	Rajan	D87A000-B	 	          SullW              Di Wa 		021	Wild	M2 V M5 V	{ -1 }	(600-2)	[0000]	B	11	-12
+Dene	B	1601	Gzigorlloe	X311000-A	 	                         Di Ic 		001	Wild	M1 V	{ -1 }	(900+2)	[0000]	B	8	18
+Dene	B	1603	Gzonksoeg	X567000-4	 	                       Di 		001	Wild	G9 V	{ -3 }	(400-4)	[0000]	B	12	-16
+Dene	B	1606	Yef	E543000-5	 	                       Di Po 		002	Wild	M2 V	{ -3 }	(500+1)	[0000]	B	14	5
+Dene	B	1608	Gaashushnu Li	X744000-5	 	                        Di 		004	Wild	F4 V	{ -3 }	(400+1)	[0000]	B	13	4
+Dene	B	1609	Ansirk	E100000-F	 	                       Di Va 		022	Wild	F2 V	{ -1 }	(700+1)	[0000]	B	11	7
+Dene	F	1613	Depot	A100555-H	D 	                          Ni Va 		820	Wild	F9 V	{ 3 }	(A49-2)	[585M]	B	11	-720
+Dene	F	1614	Springarn	E564000-5	 	                       Di 		010	Wild	G9 V K3 V	{ -3 }	(500+2)	[0000]	B	14	10
+Dene	F	1615	Gaza	B430659-B	W	                           De Na Po Ni 		323	Wild	G1 V K5 V	{ 2 }	(D57-2)	[3819]	B	11	-910
+Dene	F	1618	Ashasi	E9D5A85-B	 	                       Hi 		421	Wild	M3 V	{ 1 }	(F95+1)	[7B3C]	BE	7	675
+Dene	F	1619	Neopidan	EA9A000-9	 	                       Di Oc 		024	Wild	K3 V	{ -2 }	(D00+2)	[0000]	B	11	26
+Dene	F	1620	Surisha	D682000-3	 	                       Di 		001	Wild	M1 V M4 V	{ -3 }	(400-2)	[0000]	B	10	-8
+Dene	J	1623	HRD	A401441-F	N 	                            Ic Va Ni 		410	Wild	M5 III	{ 1 }	(936+2)	[754E]	B	9	324
+Dene	J	1626	Risir	E430000-9	 	                       De Di Po 		010	Wild	K1 V M3 V	{ -2 }	(500+1)	[0000]	B	5	5
+Dene	J	1628	Alaungpaya	C540744-8	S	                               De He Pi Po 		301	Wild	M4 V	{ -1 }	(A67+1)	[868B]	BD	12	420
+Dene	J	1630	Brontitor	E9C4000-9	 	                       Di Fl 		004	Wild	K0 IV	{ -2 }	(800+2)	[0000]	B	7	16
+Dene	N	1633	Pikha	B738A75-C	 	                       Hi 		112	Wild	K7 V	{ 3 }	(F9E+1)	[8D3C]	BE	12	1890
+Dene	N	1635	Ibsen	D434520-7	 	                        Ni 		510	Wild	K8 V M2 V	{ -3 }	(840-4)	[6279]	B	12	-128
+Dene	N	1636	Balzac	A552887-C	N 	          (Crocodiles)               Ph Po 		313	Wild	G1 IV M3 V	{ 2 }	(E76-3)	[8A9E]	Be	14	-1764
+Dene	N	1639	Uushadiiru	D551000-A	 	                       Di Po 		021	Wild	G0 V	{ -1 }	(900-2)	[0000]	B	6	-18
+Dene	N	1640	Jecife	A439552-H	N 	                        Ni 		723	Wild	F6 V	{ 2 }	(D45-1)	[174K]	B	8	-260
+Dene	C	1704	Graek	X787997-0	 	        rgW                 Ga Hi Pr 		301	Wild	K4 V	{ -1 }	(B84+1)	[5841]	BcE	11	352
+Dene	C	1706	Dunant	X311000-D	 	                        Di Ic 		023	Wild	G2 V M4 V	{ -1 }	(A00-4)	[0000]	B	8	-40
+Dene	C	1708	Remsen	B788455-B	S	                        Ni Pa 		124	Wild	F9 V K0 V	{ 1 }	(E35-2)	[355C]	Bc	14	-420
+Dene	C	1710	Uakari	C534854-7	 	                        Ph 		212	Wild	K6 V	{ -1 }	(A72-4)	[B74A]	Be	8	-560
+Dene	G	1712	Petrarch	B55487A-7	NS	                       Pa Ph 		110	Wild	K6 V	{ 1 }	(A77-2)	[7914]	Bce	11	-980
+Dene	G	1713	Stoyben	D313000-8	S	                        Di Ic 		011	Wild	M3 V	{ -3 }	(900-5)	[0000]	B	9	-45
+Dene	G	1714	Andalia	E87A000-7	 	                        Di Wa 		003	Wild	G7 V M5 V	{ -3 }	(600-5)	[0000]	B	7	-30
+Dene	G	1716	Reims	C6247AA-7	 	                       Pi 		401	Wild	M0 V M9 V	{ -1 }	(964+3)	[B65B]	BD	11	648
+Dene	G	1717	Kennebec	E978000-6	 	                        Di 		023	Wild	F7 V	{ -3 }	(700+1)	[0000]	B	9	7
+Dene	G	1719	Polizzi	B402596-D	 	                           Ic Va Ni 		623	Wild	K9 V	{ 1 }	(C43-2)	[366F]	B	10	-288
+Dene	K	1722	Redemption	E540553-7	 	         JonkW                    De He Ni Po 		433	Wild	G0 V	{ -3 }	(840-1)	[6254]	B	15	-32
+Dene	K	1726	Woaros	X747000-5	 	                         Di 		014	Wild	K4 V	{ -3 }	(800-2)	[0000]	B	12	-16
+Dene	K	1728	Monogan	E100532-8	 	                        Ni Va 		402	Wild	K2 V M9 V	{ -3 }	(941+1)	[A289]	B	11	36
+Dene	K	1730	Gatooma	E100575-7	 	                        Ni Va 		124	Wild	M8 III	{ -3 }	(741+1)	[5263]	B	9	28
+Dene	O	1732	Rif	X687000-6	 	                       Di Ga 		002	Wild	G4 IV F4 V	{ -3 }	(400+3)	[0000]	B	11	12
+Dene	O	1733	Imazura	C555546-8	S	                       Ag Ni 		103	Wild	K8 V	{ -1 }	(A41-2)	[5449]	BC	11	-80
+Dene	C	1802	Dzoungdzi	X557000-2	 	                       Di 		024	Wild	K7 V	{ -3 }	(500-1)	[0000]	B	14	-5
+Dene	C	1805	Cilnodan	D542000-5	 	                       Di He Po 		032	Wild	M3 V M9 V	{ -3 }	(400+1)	[0000]	B	12	4
+Dene	C	1808	Antra	A537847-D	 	                         Ph 		301	Wild	M0 V M3 V	{ 2 }	(B77-1)	[7A4F]	Be	12	-539
+Dene	C	1810	Syr Darya	E557000-5	 	                         Di 		022	Wild	G3 V K4 V	{ -3 }	(800+1)	[0000]	B	11	8
+Dene	G	1814	Karst	B876622-6	 	                        Ag Ni 		533	Wild	F8 V	{ 0 }	(955+2)	[4658]	BC	13	450
+Dene	K	1821	Rolvaag	E580000-7	 	                       De Di 		004	Wild	F6 V K0 V	{ -3 }	(500-3)	[0000]	B	11	-15
+Dene	K	1823	Tetzel	E643000-B	 	          An               Di Po 		001	Wild	F3 V K2 V	{ -1 }	(500-2)	[0000]	B	7	-10
+Dene	K	1824	Farraco	E200333-9	 	                       Lo Va 		712	Wild	K7 V	{ -2 }	(920-2)	[114A]	B	13	-36
+Dene	K	1826	Eshamlii	E434000-B	 	                       Di 		023	Wild	K2 IV	{ -1 }	(A00+5)	[0000]	B	8	50
+Dene	K	1827	Prefecture	E430720-8	 	                           De Na Po 		324	Wild	G1 V	{ -2 }	(F64+3)	[B566]	B	9	1080
+Dene	K	1829	Bisistra	E557000-B	 	                        Di 		002	Wild	M0 V	{ -1 }	(900-2)	[0000]	B	8	-18
+Dene	K	1830	Ronsard	DA8967B-7	S	          Sull8              Ni Ri 		125	Wild	G5 V K3 V	{ -2 }	(854-5)	[545C]	BC	14	-800
+Dene	O	1831	Takahira	E9C5000-9	 	                       Di Fl 		022	Wild	M2 V	{ -2 }	(800-2)	[0000]	B	12	-16
+Dene	O	1832	Kamlar	B587457-C	N 	                        Ni Pa 		310	Wild	M2 V	{ 1 }	(735-2)	[257G]	Bc	10	-210
+Dene	C	1902	Noscius	X422000-8	 	                        Di He Po 		011	Wild	G3 V M8 V	{ -3 }	(600+1)	[0000]	B	12	6
+Dene	C	1903	Fursuelgigz	X200000-8	 	                        Di Va 		001	Wild	M1 V	{ -3 }	(A00+1)	[0000]	B	5	10
+Dene	C	1904	Marnig	X541000-3	 	       rgW                 Di He Po 		001	Wild	K7 V M8 V	{ -3 }	(300+1)	[0000]	B	14	3
+Dene	C	1905	Ostov	E768520-4	 	                           Ag Pr Ni 		322	Wild	F7 V K6 V	{ -2 }	(742-3)	[1364]	BcC	17	-168
+Dene	C	1910	Uramid	X545000-A	 	                         Di 		021	Wild	M2 V	{ -1 }	(A00+2)	[0000]	B	12	20
+Dene	G	1917	Donu-na	C560875-8	 	                       De Ph Ri 		425	Wild	F6 V M6 V	{ 0 }	(H73-2)	[A86A]	BCe	13	-714
+Dene	G	1918	Shinorasus	E410000-E	 	                       Di 		003	Wild	F8 V K6 V	{ -1 }	(700+5)	[0000]	B	7	35
+Dene	K	1923	Liran	B000896-A	 	                               As Va Na Pi Ph 		311	Wild	M0 V M1 V M5 V	{ 2 }	(C78+1)	[8A49]	BDe	14	672
+Dene	K	1925	Deneb	B537A98-A	N 	             An   (Nenlat)4           Hi 		410	Wild	A2 Ia	{ 3 }	(D99+3)	[9D18]	BE	4	3159
+Dene	K	1926	Amshal	D687000-9	 	                        Di Ga 		022	Wild	M0 V	{ -2 }	(900-2)	[0000]	B	7	-18
+Dene	K	1927	Thussar Ozoam	X545000-5	 	                        Di 		015	Wild	G3 V M1 V	{ -3 }	(300+2)	[0000]	B	11	6
+Dene	K	1928	Exile	X799000-5	 	                         Di 		010	Wild	F8 V	{ -3 }	(400+5)	[0000]	B	14	20
+Dene	K	1930	Turkoman	B9C6745-9	 	                        Fl 		120	Wild	A4 V	{ 1 }	(B69+4)	[7878]	B	5	2376
+Dene	C	2001	Filangger	X76A658-2	 	                       Ni Ri Wa 		223	Wild	G1 V G6 V	{ -2 }	(851-4)	[2425]	BC	13	-160
+Dene	G	2011	Orenberg	B430655-D	 	        Jonk8                    De Na Po Ni 		101	Wild	M1 V M5 V	{ 1 }	(955+2)	[875F]	B	10	450
+Dene	G	2013	Twinian	C404453-8	S	                           Ic Va Ni 		102	Wild	M5 V	{ -2 }	(833+3)	[1246]	B	7	216
+Dene	G	2014	Zinuun	E43679D-6	 	                        		311	Wild	M8 V	{ -2 }	(964+2)	[A561]	B	14	432
+Dene	G	2016	Ugrik	E300000-0	 	                       Ba Va 		021	Wild	F7 V	{ -3 }	(200-1)	[0000]	B	13	-2
+Dene	G	2017	Ruwenzori	E749000-7	 	                       Di 		003	Wild	K8 V	{ -3 }	(600-1)	[0000]	B	8	-6
+Dene	G	2019	Namidshur	B31067B-C	S	                       Na Ni 		115	Wild	G9 V	{ 1 }	(E55+1)	[477C]	B	10	350
+Dene	K	2023	Bruyere	C544777-5	S	              Chir9               Ag Pi 		422	Wild	F4 V	{ 0 }	(96A-1)	[4785]	BCD	7	-540
+Dene	K	2024	Minocoy	X422000-D	 	                       Di He Po 		020	Wild	G4 V K5 V	{ -1 }	(900-1)	[0000]	B	9	-9
+Dene	K	2027	Avernus	E886534-4	 	                           Ag Pr Ga Ni 		202	Wild	G3 V M9 V	{ -2 }	(740-5)	[4326]	BcC	9	-140
+Dene	K	2028	Nyassl	B300432-D	N 	                        Ni Va 		124	Wild	F0 V M2 V	{ 1 }	(E34-2)	[8549]	B	15	-336
+Dene	C	2105	Torrens	X100000-C	 	                       Di Va 		004	Wild	M4 V	{ -1 }	(800+5)	[0000]	B	13	40
+Dene	C	2109	Bangwe	X78A000-8	 	                       Di Wa 		012	Wild	F5 V	{ -3 }	(800+1)	[0000]	B	10	8
+Dene	G	2111	Diiski	E66A000-8	 	                       Di Wa 		012	Wild	K7 V	{ -3 }	(700-5)	[0000]	B	6	-35
+Dene	G	2114	Kadidun	D5A2000-9	S	                           Di Fl He 		020	Wild	K1 IV K0 V	{ -2 }	(500+1)	[0000]	B	7	5
+Dene	G	2116	Piram	E311772-7	 	                           Ic Na Pi 		311	Wild	G2 V	{ -2 }	(965+3)	[9568]	BD	11	810
+Dene	G	2117	Cunha	C626677-7	 	                       Ni 		824	Wild	M3 V	{ -2 }	(954+2)	[A456]	B	9	360
+Dene	G	2120	Teatro	E8A7000-8	 	                        Di Fl 		003	Wild	F8 V M7 V	{ -3 }	(D00+2)	[0000]	B	11	26
+Dene	K	2126	Arcanum	X43489E-6	 	               RsA           Ph 		410	Wild	M6 V	{ -2 }	(A72+3)	[4686]	Be	10	420
+Dene	K	2127	Nusukha	E310000-7	 	                       Di 		015	Wild	G7 V G7 V	{ -3 }	(300+1)	[0000]	B	9	3
+Dene	O	2131	Javan	X77A000-A	 	                       Di Wa 		010	Wild	M0 V	{ -1 }	(400+2)	[0000]	B	13	8
+Dene	C	2202	Gounuerz	X435000-A	 	                       Di 		010	Wild	G9 V	{ -1 }	(600+2)	[0000]	B	7	12
+Dene	C	2204	Dofil	X593000-4	 	                       Di 		010	Wild	F3 V M1 V	{ -3 }	(800+1)	[0000]	B	9	8
+Dene	C	2210	Mazirbe	D553652-5	 	                      Ni Po 		524	Wild	F6 V K7 V	{ -3 }	(951-1)	[6376]	B	10	-45
+Dene	G	2212	Imlaar	D677000-6	S	                        Di 		023	Wild	G5 V K5 V	{ -3 }	(700-2)	[0000]	B	11	-14
+Dene	G	2220	Torm	C556341-9	S	                        Lo 		534	Wild	K5 V	{ -1 }	(D20+1)	[1276]	B	13	26
+Dene	K	2223	Byblos	C673846-7	S	                        Ph Pi 		301	Wild	M1 V	{ -1 }	(A75-1)	[5747]	BDe	10	-350
+Dene	K	2224	Revoc	D9AA000-A	 	                       Di Fl 		002	Wild	F7 V K5 V	{ -1 }	(900+1)	[0000]	B	10	9
+Dene	K	2225	Usani	A552676-C	NS	                        Ni Po 		202	Wild	K0 V	{ 2 }	(A57-3)	[A84E]	B	13	-1050
+Dene	O	2234	Catacomb	X8A7000-B	 	          (Sulliji)              Di Fl 		001	Wild	K1 V K6 V	{ -1 }	(800-3)	[0000]	B	9	-24
+Dene	C	2309	Malory	X420000-7	 	         Jonk9                    De He Di Po 		023	Wild	K8 V M0 V	{ -3 }	(900+1)	[0000]	B	11	9
+Dene	G	2316	Giikusu	E64799D-8	 	           (Kirissukyoya)              Hi In 		505	Wild	K8 V	{ 0 }	(H82+1)	[891D]	BE	10	272
+Dene	G	2317	Lan-chou	D855686-6	S	                      Ag Ga Ni 		520	Wild	K5 V K8 V	{ -2 }	(950+3)	[546A]	BC	5	135
+Dene	K	2322	Sage	D563000-7	 	                       Di 		020	Wild	K5 V M1 V	{ -3 }	(500+2)	[0000]	B	10	10
+Dene	K	2323	Azed Bek	D766000-A	 	                       Di Ga 		010	Wild	G5 V	{ -1 }	(600-4)	[0000]	B	13	-24
+Dene	C	2403	Tchien	X696000-3	 	                        Di 		010	Wild	K5 V	{ -3 }	(400-4)	[0000]	B	12	-16
+Dene	C	2405	Gagaridir	X420000-A	 	                           De He Di Po 		001	Wild	K2 V M1 V	{ -1 }	(600-3)	[0000]	B	6	-18
+Dene	C	2406	Insi Kar	X311000-B	 	                       Di Ic 		024	Wild	K4 V	{ -1 }	(C00-2)	[0000]	B	14	-24
+Dene	C	2407	Syrenaica	E669000-5	 	                        Di 		003	Wild	F4 V M6 V	{ -3 }	(600-1)	[0000]	B	13	-6
+Dene	C	2409	Haggard	E777000-5	 	                       Di 		013	Wild	K1 V M9 V	{ -3 }	(400+1)	[0000]	B	9	4
+Dene	G	2411	Nibel	X688000-3	 	                       Di 		001	Wild	K5 V M1 V	{ -3 }	(500+3)	[0000]	B	9	15
+Dene	G	2412	Pagamin	E571000-7	 	                       Di He 		002	Wild	K7 V	{ -3 }	(300+5)	[0000]	B	10	15
+Dene	G	2413	Dunmag	X427000-C	 	                       Di 		001	Wild	F7 V M3 V M7 V	{ -1 }	(400-2)	[0000]	B	14	-8
+Dene	G	2414	Jurburk	D554000-B	 	                       Di 		002	Wild	G9 V K6 V K9 V	{ -1 }	(600-3)	[0000]	B	11	-18
+Dene	K	2424	Ayers	X430000-A	 	                         De Di Po 		023	Wild	F8 V	{ -1 }	(D00-3)	[0000]	B	11	-39
+Dene	K	2425	Hysyl	E540535-6	 	                           De He Ni Po 		202	Wild	M3 V	{ -3 }	(941-4)	[5254]	B	14	-144
+Dene	D	2502	Tubb	X89A000-4	 	                       Di Wa 		001	Wild	G7 V M6 V	{ -3 }	(900-1)	[0000]	B	9	-9
+Dene	D	2506	Moskene	X200000-A	 	                       Di Va 		003	Wild	F5 V G7 V	{ -1 }	(600+1)	[0000]	B	13	6
+Dene	H	2512	Niven	X9C4000-9	 	                        Di Fl 		034	Wild	F3 V M3 V	{ -2 }	(B00+3)	[0000]	B	14	33
+Dene	H	2515	Kasmar	X631000-8	 	                       Di Po 		001	Wild	M0 V M3 V	{ -3 }	(A00+1)	[0000]	B	13	10
+Dene	H	2519	Erita	E99A000-8	 	                       Di Wa 		013	Wild	G8 V K9 V	{ -3 }	(B00+1)	[0000]	B	7	11
+Dene	H	2520	Kiirindor	D546000-A	 	                         Di 		010	Wild	G0 V G9 V	{ -1 }	(900+1)	[0000]	B	14	9
+Dene	L	2521	Geniishir	E310000-D	 	                       Di 		002	Wild	K8 V	{ -1 }	(500-3)	[0000]	B	9	-15
+Dene	L	2522	Maelstrom	B79A832-C	 	       Chir5 RsG                 Ph Pi Wa 		502	Wild	G3 V M0 V M3 V	{ 2 }	(C75+1)	[3A48]	BDe	12	420
+Dene	L	2523	Exotrope	X300000-7	 	                        Di Va 		001	Wild	M6 V M6 V	{ -3 }	(800+1)	[0000]	B	11	8
+Dene	D	2603	Unekh	X200000-7	 	                         Di Va 		002	Wild	M1 V	{ -3 }	(A00+4)	[0000]	B	10	40
+Dene	H	2615	Berora	X100000-D	 	                        Di Va 		022	Wild	G7 V M8 V	{ -1 }	(C00-4)	[0000]	B	11	-48
+Dene	D	2702	Fosfog	E575000-7	 	                         Di 		014	Wild	G5 IV M3 V	{ -3 }	(700+2)	[0000]	B	14	14
+Dene	D	2704	Talon	X543000-7	 	           (Souggvuez)8 rg2              Di Po 		024	Wild	K4 V	{ -3 }	(B00-2)	[0000]	B	18	-22
+Dene	H	2713	Wal-ta-ka	D560358-8	 	                       De Lo 		801	Wild	G5 V	{ -3 }	(720+4)	[7156]	B	12	56
+Dene	H	2715	Dophkah	D6477BB-4	 	                           Ag Pi 		224	Wild	K9 V	{ -1 }	(96A+1)	[7623]	BCD	14	540
+Dene	H	2716	Errogel	D550579-5	 	                       De Ni Po 		124	Wild	G9 V	{ -3 }	(740+1)	[9256]	B	14	28
+Dene	H	2717	Segan	D550778-6	 	            (Segani)              De Po 		404	Wild	F4 V K4 V	{ -2 }	(B63+2)	[7555]	B	11	396
+Dene	L	2721	Newpenton	X595000-3	 	             (Kurakhash)           Di 		003	Wild	M2 V	{ -3 }	(500+2)	[0000]	B	15	10
+Dene	P	2734	Lorin Antune	X525000-7	 	                        Di 		010	Wild	M2 V M2 V	{ -3 }	(A00-3)	[0000]	B	11	-30
+Dene	D	2802	495-524	E785000-0	 	          An              Ba Ga 		022	Wild	F3 V M6 V	{ -3 }	(500-4)	[0000]	B	9	-20
+Dene	D	2804	Akkip	E542000-8	 	                       Di He Po 		022	Wild	F8 V	{ -3 }	(C00+1)	[0000]	B	16	12
+Dene	D	2807	Gabrael	X573000-5	 	             rg3           Di 		024	Wild	K4 V	{ -3 }	(800+4)	[0000]	B	13	32
+Dene	D	2810	Tensas	E556515-3	 	                       Ag Ni 		104	Wild	K8 V	{ -2 }	(744-2)	[8328]	BC	10	-224
+Dene	H	2812	Og Bere'	D564577-4	 	                           Ag Pr Ni 		123	Wild	G7 V	{ -2 }	(741-2)	[6321]	BcC	9	-56
+Dene	H	2813	Doho	X696000-7	 	                        Di 		021	Wild	F8 V F8 V	{ -3 }	(600+3)	[0000]	B	13	18
+Dene	H	2820	Gampin	X66848B-3	 	                        Ni Pa 		533	Wild	G2 IV G7 V	{ -3 }	(830-3)	[5142]	Bc	9	-72
+Dene	D	2903	Metare	X424000-E	 	                       Di 		001	Wild	M2 V M8 V	{ -1 }	(900-2)	[0000]	B	9	-18
+Dene	D	2904	Fel	X7A7000-A	 	                       Di Fl 		022	Wild	M3 V	{ -1 }	(E00+2)	[0000]	B	10	28
+Dene	D	2905	Ikhaba	D675000-5	 	                         Di 		033	Wild	M4 V	{ -3 }	(700-2)	[0000]	B	10	-14
+Dene	D	2906	Nurara	X5A5000-A	 	                       Di Fl 		004	Wild	M0 V	{ -1 }	(A00-2)	[0000]	B	9	-20
+Dene	D	2907	Hammand	X736000-6	 	                        Di 		020	Wild	M2 V M9 V	{ -3 }	(300-2)	[0000]	B	13	-6
+Dene	D	2908	Wyn	E546000-2	 	                        Di 		001	Wild	M2 V	{ -3 }	(600-1)	[0000]	B	12	-6
+Dene	D	2910	Crozat	X410000-7	 	                       Di 		004	Wild	M4 V M6 V	{ -3 }	(600+1)	[0000]	B	12	6
+Dene	H	2913	Atsah	X656737-2	 	                        Ag Ga 		523	Wild	K4 V	{ -1 }	(966-4)	[C643]	BC	11	-1296
+Dene	H	2918	Khishuda	E856000-3	 	                       Di Ga 		001	Wild	G8 V M1 V	{ -3 }	(500-4)	[0000]	B	10	-20
+Dene	D	3004	Oluk Dzas	D563423-3	 	                        Ni 		214	Wild	K8 V	{ -3 }	(733-4)	[6153]	B	14	-252
+Dene	D	3005	Arleshanu	X562000-2	 	                       Di 		020	Wild	F4 V	{ -3 }	(500+1)	[0000]	B	13	5
+Dene	D	3008	Taproban	X8A8000-B	 	                       Di Fl 		020	Wild	M2 V	{ -1 }	(B00+3)	[0000]	B	15	33
+Dene	H	3011	Corfinium	D543000-8	 	                       Di Po 		022	Wild	M2 V	{ -3 }	(C00-2)	[0000]	B	10	-24
+Dene	H	3013	Ivora	X999000-3	 	                       Di 		001	Wild	F5 V	{ -3 }	(700-5)	[0000]	B	9	-35
+Dene	H	3015	Atadl	X310000-E	 	                         Di 		001	Wild	M1 V M1 V	{ -1 }	(C00-1)	[0000]	B	14	-12
+Dene	H	3016	Zerderu	D541000-7	 	                       Di He Po 		001	Wild	M1 V M1 V	{ -3 }	(800+1)	[0000]	B	12	8
+Dene	P	3031	Asharam	E7627BD-2	 	                       Ri 		322	Wild	F5 V K4 V	{ -1 }	(966+2)	[9611]	BC	13	648
+Dene	D	3104	Aerfor	X584416-3	 	           RsD              Ni Pa 		134	Wild	F7 V	{ -3 }	(731+1)	[6156]	Bc	15	21
+Dene	D	3110	Olokono	X6A5000-8	 	                       Di Fl 		001	Wild	M0 V	{ -3 }	(500-1)	[0000]	B	14	-5
+Dene	H	3111	Lamar	X410000-7	 	                       Di 		023	Wild	M1 V	{ -3 }	(600+2)	[0000]	B	9	12
+Dene	H	3112	Berth	X547000-4	 	                       Di 		001	Wild	K5 V M5 V	{ -3 }	(500+4)	[0000]	B	11	20
+Dene	H	3113	Prevsla	X543000-4	 	                       Di Po 		010	Wild	M4 V M5 V	{ -3 }	(500-4)	[0000]	B	9	-20
+Dene	H	3115	Arabah	X877000-2	 	                       Di 		020	Wild	F8 IV	{ -3 }	(400+1)	[0000]	B	12	4
+Dene	H	3116	Sherad	X000000-E	 	                           As Va Di 		013	Wild	M6 V	{ -1 }	(A00+3)	[0000]	B	8	30
+Dene	D	3201	Goukhsar	E563000-4	 	                       Di 		010	Wild	K6 V	{ -3 }	(400+2)	[0000]	B	11	8
+Dene	H	3213	Salaam	X576000-4	 	                       Di 		022	Wild	M4 V M7 V	{ -3 }	(500+3)	[0000]	B	10	15

--- a/res/Sectors/M1900/Deneb.xml
+++ b/res/Sectors/M1900/Deneb.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Sector Abbreviation="Dene" Tags="Unreviewed">
+  <Y>-1</Y>
+  <X>-3</X>
+  <Name>Deneb</Name>
+  <Name Lang="zh">Nieklsdia</Name>
+  <Credits>
+    <![CDATA[
+
+             <b>Deneb</b> sector was designed by Marc W. Miller and
+             appears in <cite>Atlas of the Imperium</cite> (GDW,
+             1984).
+
+             It was refined by James Holden. Portions appear in
+             <cite>The Travellers Digest</cite> and <cite>The
+             MegaTraveller Journal #3</cite> (Digest Group
+             Publications, 1992).
+
+             Lately, the "fast-forward" script ran this data up to
+             years 1508 and 1900.
+
+    ]]>
+  </Credits>
+  <Product Publisher="Far Future Enterprises" Author="Rob Eaglestone" Title="Beowulf Operations Manual" />
+  <DataFile Source="Traveller 5 Second Survey" Milieu="M1900" Type="TabDelimited">Deneb.tab</DataFile>
+  <Subsectors Source="MegaTraveller Journal #1">
+    <Subsector Index="A">Pretoria</Subsector>
+    <Subsector Index="B">Lamas</Subsector>
+    <Subsector Index="C">Antra</Subsector>
+    <Subsector Index="D">Million</Subsector>
+    <Subsector Index="E">Sabine</Subsector>
+    <Subsector Index="F">Inar</Subsector>
+    <Subsector Index="G">Dunmag</Subsector>
+    <Subsector Index="H">Atsah</Subsector>
+    <Subsector Index="I">Star Lane</Subsector>
+    <Subsector Index="J">Vincennes</Subsector>
+    <Subsector Index="K">Usani</Subsector>
+    <Subsector Index="L">Geniishir</Subsector>
+    <Subsector Index="M">Gulf</Subsector>
+    <Subsector Index="N">Zeng</Subsector>
+    <Subsector Index="O">Kamlar</Subsector>
+    <Subsector Index="P">Vast Heavens</Subsector>
+  </Subsectors>
+
+  <Routes Source="Beowulf Operations Manual">
+    <Route Start="0124" End="0524" />
+    <Route Start="0208" End="0406" />
+    <Route Start="0208" End="3209" EndOffsetX="-1" />
+    <Route Start="0311" End="0514" />
+    <Route Start="0311" End="3212" EndOffsetX="-1" />
+    <Route Start="0316" End="0514" />
+    <Route Start="0316" End="0518" Source="Update from 0517 to 0518 per Rob Eaglestone, T5 cleanup"/>
+    <Route Start="0316" End="0715" />
+    <Route Start="0406" End="0805" />
+    <Route Start="0514" End="0715" />
+    <Route Start="0518" End="0715" Source="Update from 0517 to 0518 per Rob Eaglestone, T5 cleanup" />
+    <Route Start="0524" End="0826" />
+    <Route Start="0715" End="0917" />
+    <Route Start="0715" End="1016" />
+    <Route Start="0917" End="1018" />
+    <Route Color="Red" Start="1016" End="1314" Source="SR-101" />
+    <Route Color="Red" Start="1314" End="1712" Source="SR-102" />
+    <Route Color="Red" Start="1712" End="2011" Source="SR-103" />
+    <Route Color="Red" Start="2011" End="2409" Source="SR-104" />
+    <Route Color="Red" Start="2409" End="2807" Source="SR-105" />
+    <Route Color="Red" Start="2807" End="3004" Source="SR-106" />
+    <Route Color="Red" Start="3004" End="3404" Source="SR-107" />
+    <Route Color="Red" Start="0805" End="1006" Source="SR-201" />
+    <Route Color="Red" Start="1006" End="1406" Source="SR-202" />
+    <Route Color="Red" Start="1406" End="1808" Source="SR-203" />
+    <Route Color="Red" Start="1808" End="2011" Source="SR-204" />
+
+  </Routes>
+  <Borders>
+    <Border Color="Green" Allegiance="Li" Label="Limmu Bukara">0316 0415 0515 0514 0614 0715 0815 0916 1016 0917 0916 0815 0716 0616 0517 0518 0417 0416 0316 </Border>
+    <Border Color="Blue" Allegiance="Rr" Label="Republic of Regina">0207 0307 0406 0407 0508 0408 0309 0209 0309 0308 0207 </Border>
+    <Border Color="Orange" Allegiance="Wild" Label="Wilds">0000 0100 0200 0300 0400 0500 0600 0700 0800 0900 1000 1100 1200 1300 1400 1500 1600 1700 1800 1900 2000 2100 2200 2300 2400 2500 2600 2700 2800 2900 3000 3100 3200 3301 3302 3303 3304 3305 3306 3307 3308 3309 3310 3311 3312 3313 3314 3213 3114 3115 3116 3016 2917 2918 2818 2819 2820 2721 2621 2522 2523 2423 2424 2425 2326 2226 2127 2128 2129 2130 2131 2031 1932 1832 1733 1633 1634 1635 1636 1637 1638 1639 1640 1741 1641 1541 1441 1341 1241 1141 1041 0941 0841 0741 0641 0541 0441 0341 0241 0141 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030 0029 0130 0229 0330 0429 0529 0628 0728 0727 0826 0926 1025 1125 1124 1123 1122 1121 1120 1119 1118 1117 1116 1115 1114 1113 1112 1111 1110 1109 1108 1007 0907 0906 0805 0705 0604 0504 0404 0304 0203 0103 0003 0002 0001 0000 </Border>
+  </Borders>
+</Sector>

--- a/res/Sectors/M1900/m1900.xml
+++ b/res/Sectors/M1900/m1900.xml
@@ -29,7 +29,7 @@
     <X>-3</X>
     <Name>Deneb</Name>
     <Name Lang="zh">Nieklsdia</Name>
-    <DataFile Author="Robert Eaglestone" Type="TabDelimited">Dene.tab</DataFile>
+    <DataFile Author="Robert Eaglestone" Type="TabDelimited">Deneb.tab</DataFile>
     <MetadataFile>Dene.xml</MetadataFile>
   </Sector>
 </Sectors>


### PR DESCRIPTION
Started over with t5ss data, generating 1201 data, then fast-forwarding through 1508 to 1900.

Dieback causes TL linter errors; all other lint issues are resolved.

Updated m1900.xml.
