### PR TITLE
T5ss 1900 Vland

### DIFF
--- a/res/Sectors/M1900/Vland.tab
+++ b/res/Sectors/M1900/Vland.tab
@@ -1,0 +1,533 @@
+Sector	SS	Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W	RU
+Vlan	A	0101	Aakhorn	X5567AC-2	 	                 Ag 		104	Wild	F5 V G6 V	{ -1 }	(966+4)	[6641]	BC	11	1296
+Vlan	A	0102	Rokii	X799000-5	 	                 Di 		010	Wild	M3 V	{ -3 }	(500-4)	[0000]	B	11	-20
+Vlan	A	0104	Maluuf	X432000-9	 	                 Di Po 		010	Wild	K8 V K9 V	{ -2 }	(600-4)	[0000]	B	8	-24
+Vlan	A	0105	Gikkon	X543000-4	 	                 Di Po 		032	Wild	G0 V G8 V	{ -3 }	(700+3)	[0000]	B	11	21
+Vlan	A	0107	Taraddiin	X656410-3	 	                  Ga Ni Pa 		811	Wild	M3 V	{ -3 }	(731+1)	[3127]	Bc	13	21
+Vlan	A	0109	Hakkat	E658876-4	 	                 Pa Ph 		523	Wild	G1 V	{ -2 }	(A78-2)	[7632]	Bce	13	-1120
+Vlan	A	0110	Ossin	X100000-C	 	                    Di Va 		005	Wild	M1 V	{ -1 }	(F00+4)	[0000]	B	9	60
+Vlan	M	0131	Skasputin	E763000-6	 	                 Di 		024	Wild	M2 V	{ -3 }	(500+2)	[0000]	B	10	10
+Vlan	M	0132	Kald	D550000-7	S	                  De Di Po 		001	Wild	M1 V M1 V	{ -3 }	(B00-3)	[0000]	B	8	-33
+Vlan	M	0134	Zanagud	X66A000-7	 	                  Di Wa 		023	Wild	M2 V	{ -3 }	(800+1)	[0000]	B	14	8
+Vlan	M	0135	Sakin	X430000-A	 	                   De Di Po 		014	Wild	F9 V M4 V	{ -1 }	(D00+1)	[0000]	B	10	13
+Vlan	M	0137	Shaaki	X9B4000-C	 	                Di Fl 		020	Wild	F1 V M1 V	{ -1 }	(B00+1)	[0000]	B	15	11
+Vlan	A	0202	Kalkako	X544000-3	 	                  Di 		024	Wild	F8 V K2 V	{ -3 }	(600+2)	[0000]	B	17	12
+Vlan	A	0203	Bannon's World	X100000-A	 	                 Di Va 		020	Wild	K6 V M3 V	{ -1 }	(800-3)	[0000]	B	13	-24
+Vlan	A	0205	Khankari	X885000-2	 	                  Di Ga 		010	Wild	M2 V	{ -3 }	(600+2)	[0000]	B	13	12
+Vlan	A	0209	Lankhi	X746000-5	 	                  Di 		003	Wild	M2 V	{ -3 }	(700-1)	[0000]	B	8	-7
+Vlan	A	0210	Khalgun	X576000-3	 	                  Di 		001	Wild	M1 V	{ -3 }	(900+5)	[0000]	B	12	45
+Vlan	E	0211	Giikur	X689420-2	 	                  Ni 		210	Wild	M2 V M9 V	{ -3 }	(730+1)	[1135]	B	8	21
+Vlan	I	0221	Keshiil	X530000-9	 	                  De Di Po 		020	Wild	M2 V	{ -2 }	(C00-1)	[0000]	B	9	-12
+Vlan	M	0232	Tratami	X9C7000-9	 	                 Di Fl 		023	Wild	F7 III M2 V	{ -2 }	(F00-2)	[0000]	B	8	-30
+Vlan	M	0234	Nurrungar	X649000-7	 	                 Di 		010	Wild	M3 V M3 V	{ -3 }	(300+1)	[0000]	B	11	3
+Vlan	M	0236	Khishugii	X420000-B	 	                    De He Di Po 		010	Wild	M0 V	{ -1 }	(800+1)	[0000]	B	14	8
+Vlan	M	0237	Shashim	X427000-C	 	                 Di 		003	Wild	G8 V	{ -1 }	(B00+1)	[0000]	B	12	11
+Vlan	A	0303	Anert	X9B4000-B	 	                  Di Fl 		010	Wild	G7 V	{ -1 }	(900+2)	[0000]	B	11	18
+Vlan	A	0306	Skathi	C585644-7	S	                    Ag Ri Ni 		310	Wild	K0 V M0 V	{ 0 }	(853-2)	[4646]	BC	14	-240
+Vlan	A	0307	Enard	X8A3000-9	 	                 Di Fl 		001	Wild	M1 V M7 V	{ -2 }	(A00-2)	[0000]	B	9	-20
+Vlan	E	0311	Omero	X430000-F	 	                 De Di Po 		022	Wild	G8 V M3 V	{ -1 }	(900-3)	[0000]	B	13	-27
+Vlan	M	0333	Paspaa	X554373-3	 	                  Lo 		810	Zs	G0 V K3 V	{ -3 }	(620+1)	[3175]	B	11	12
+Vlan	M	0335	Nadud	X97A000-7	 	                 Di Wa 		020	Zs	M1 V	{ -3 }	(500+2)	[0000]	B	13	10
+Vlan	M	0336	Parsi	X989979-3	 	                  Hi Pr 		824	Zs	K9 V	{ -1 }	(C86+1)	[E884]	BcE	12	576
+Vlan	M	0338	Vanessa	X568000-6	 	                 Di 		010	Zs	K8 V M0 V	{ -3 }	(500-3)	[0000]	B	14	-15
+Vlan	M	0340	Jessheim	XAC5000-E	 	                 Di Fl 		025	Wild	M2 V	{ -1 }	(B00-4)	[0000]	B	11	-44
+Vlan	A	0402	Kuk	E540000-7	 	                    De He Di Po 		001	Wild	K2 V K6 V	{ -3 }	(400-5)	[0000]	B	8	-20
+Vlan	A	0403	Apkeraas	X438000-9	 	                 Di 		020	Wild	G2 V	{ -2 }	(900-1)	[0000]	B	8	-9
+Vlan	A	0404	Katti	X8D8000-D	 	                 Di 		004	Wild	M3 V	{ -1 }	(800+1)	[0000]	B	8	8
+Vlan	A	0408	Shaddukan	X622000-D	 	                 Di He Po 		010	Wild	G1 V	{ -1 }	(400-4)	[0000]	B	13	-16
+Vlan	I	0422	Niirka	X300000-F	 	                  Di Va 		022	Zs	M9 III D	{ -1 }	(D00-3)	[0000]	B	15	-39
+Vlan	I	0430	Khulekii	X677743-2	 	                     Ag Pi 		122	Zs	G3 V	{ -1 }	(A63-1)	[8641]	BCD	11	-180
+Vlan	M	0431	Answerin	X584873-2	 	       (Answerin)            Pa Ri Ph 		820	Zs	F7 V G0 V	{ -1 }	(C79+2)	[6793]	BcCe	10	1512
+Vlan	M	0434	Geguru	X000000-9	 	                    As Va Di 		025	Zs	K1 V	{ -2 }	(D00-2)	[0000]	B	11	-26
+Vlan	M	0435	Ganidam	X100000-B	 	                 Di Va 		001	Zs	M2 V M5 V	{ -1 }	(700-3)	[0000]	B	5	-21
+Vlan	M	0436	Meprim	X300000-D	 	                 Di Va 		010	Zs	M1 V	{ -1 }	(400+2)	[0000]	B	10	8
+Vlan	M	0437	Thatii	XA7A000-5	 	                  Di Oc 		024	Zs	K8 V	{ -3 }	(600+3)	[0000]	B	11	18
+Vlan	A	0502	Lugaluru	E859000-8	 	                 Di 		001	Wild	M0 V	{ -3 }	(700+1)	[0000]	B	9	7
+Vlan	A	0506	Gamibuu	X524000-A	 	                 Di 		001	Wild	K0 V M3 V	{ -1 }	(900+2)	[0000]	B	9	18
+Vlan	A	0507	Kharta	X552776-2	 	                 Po 		504	Wild	G9 V K6 V	{ -2 }	(964+1)	[6551]	B	11	216
+Vlan	A	0508	Arfaan	X767475-3	 	                 Ga Ni Pa 		213	Wild	M1 V	{ -3 }	(630+1)	[2125]	Bc	11	18
+Vlan	I	0530	Pirrom	X884302-4	 	                   Lo 		911	Zs	G2 V	{ -3 }	(720+1)	[3163]	B	14	14
+Vlan	M	0531	Seglound	E99A000-8	 	                 Di Wa 		020	Zs	M1 V	{ -3 }	(800-3)	[0000]	B	14	-24
+Vlan	M	0532	Kinswana	X310000-B	 	                  Di 		004	Zs	K6 V	{ -1 }	(C00+4)	[0000]	B	9	48
+Vlan	M	0533	Khi Tai	X668726-2	 	                    Ag Ri 		401	Zs	M3 V M3 V	{ 0 }	(963-1)	[8741]	BC	9	-162
+Vlan	M	0534	Khakkakum	E657722-6	 	                  Ag Ga 		121	Zs	M3 V	{ -1 }	(969+1)	[7677]	BC	12	486
+Vlan	M	0536	Fauski	X420000-E	 	                     De He Di Po 		001	Zs	K0 V M1 V	{ -1 }	(A00+3)	[0000]	B	5	30
+Vlan	A	0601	Athanuez	X100000-B	 	                   Di Va 		001	Wild	K5 V M0 V	{ -1 }	(B00+3)	[0000]	B	8	33
+Vlan	A	0605	Sheshat	X526000-C	 	                 Di 		024	Wild	F8 V	{ -1 }	(900-5)	[0000]	B	9	-45
+Vlan	A	0610	Rakurram	X200000-C	 	                  Di Va 		012	Wild	G7 V	{ -1 }	(800+1)	[0000]	B	13	8
+Vlan	E	0619	Lalaki	X9B4000-D	 	                Di Fl 		002	Zs	M3 V	{ -1 }	(B00+1)	[0000]	B	10	11
+Vlan	I	0622	Beshe	X8B8000-8	 	                 Di Fl 		015	Zs	M2 V	{ -3 }	(G00+1)	[0000]	B	12	16
+Vlan	I	0630	Giraran	X555000-5	 	                 Di 		024	Zs	K3 V	{ -3 }	(400-2)	[0000]	B	10	-8
+Vlan	M	0631	Enbart	X201000-C	 	                     Di Ic Va 		020	Zs	M1 V	{ -1 }	(A00+2)	[0000]	B	8	20
+Vlan	M	0633	Kamar Kurker	X554378-3	 	                  Lo 		910	Zs	K1 V	{ -3 }	(720+2)	[1181]	B	6	28
+Vlan	M	0635	Savvud	E545000-7	 	                  Di 		001	Wild	M1 V	{ -3 }	(600-2)	[0000]	B	14	-12
+Vlan	M	0637	Bood	X540420-2	 	                    De He Ni Po 		810	Zs	M0 V	{ -3 }	(733-2)	[5161]	B	14	-126
+Vlan	M	0639	Liigima	X7C2000-D	 	                    Di Fl He 		003	Wild	K2 V K9 V	{ -1 }	(800+3)	[0000]	B	11	24
+Vlan	M	0640	Aquacade	X67A000-2	 	                 Di Wa 		020	Wild	M2 V	{ -3 }	(400-2)	[0000]	B	8	-8
+Vlan	A	0701	Taegzdueg	E665524-6	 	                    Ag Pr Ga Ni 		114	Wild	G0 V M5 V	{ -2 }	(743+3)	[6378]	BcC	12	252
+Vlan	A	0703	Khigapka	D797000-7	 	                  Di 		002	Wild	M2 V	{ -3 }	(600-1)	[0000]	B	9	-6
+Vlan	A	0705	Shukhuge	X727000-9	 	                  Di 		010	Wild	M1 V	{ -2 }	(B00+4)	[0000]	B	11	44
+Vlan	A	0707	Lenordi	X000000-8	 	                    As Va Di 		010	Wild	M2 V	{ -3 }	(700+1)	[0000]	B	8	7
+Vlan	A	0708	Voskhod	X310000-E	 	                     Di 		001	Wild	M0 V M1 V	{ -1 }	(C00+1)	[0000]	B	12	12
+Vlan	A	0709	Kharzet	X565000-6	 	                   Di 		001	Wild	G3 V M0 V	{ -3 }	(700+3)	[0000]	B	14	21
+Vlan	E	0711	Rishiin	X539000-B	 	                 Di 		010	Wild	M2 V M7 V	{ -1 }	(600-2)	[0000]	B	14	-12
+Vlan	M	0732	Pirumush	X524000-8	 	                 Di 		022	Zs	G4 V M2 V	{ -3 }	(A00-3)	[0000]	B	13	-30
+Vlan	M	0734	Kishbar	X301000-D	 	                    Di Ic Va 		020	Zs	M2 V	{ -1 }	(700-5)	[0000]	B	10	-35
+Vlan	M	0737	Kuzey Anadolu	X500000-9	 	                   Di Va 		003	Zs	K3 V K5 V	{ -2 }	(B00-2)	[0000]	B	9	-22
+Vlan	M	0738	Daglari	X310000-A	 	                  Di 		021	Wild	M3 V	{ -1 }	(B00-1)	[0000]	B	14	-11
+Vlan	M	0739	Trabbon	X554773-1	 	                 Ag 		320	Wild	K7 V	{ -1 }	(969+1)	[7671]	BC	6	486
+Vlan	M	0740	Kirov	X683000-6	 	                  Di 		010	Wild	K4 V K5 V	{ -3 }	(C00+5)	[0000]	B	10	60
+Vlan	A	0801	Ogerrgh	X62A000-8	 	                  Di 		010	Wild	M1 V	{ -3 }	(B00+1)	[0000]	B	9	11
+Vlan	A	0804	Kegirur	X76A675-2	 	                  Ni Ri Wa 		501	Wild	M0 V	{ -2 }	(B50+1)	[6421]	BC	10	55
+Vlan	A	0806	Gadiga	X88A000-3	 	                  Di Wa 		001	Wild	F9 V K8 V M8 V	{ -3 }	(400+3)	[0000]	B	11	12
+Vlan	A	0807	Kunumi	D554000-9	 	                  Di 		021	Wild	K0 V	{ -2 }	(900-5)	[0000]	B	12	-45
+Vlan	M	0831	Igsudi	X572000-0	 	                 Ba He 		020	Zs	G4 V K6 V	{ -3 }	(500-2)	[0000]	B	10	-10
+Vlan	M	0832	Kirlikin	E5406A8-6	 	                     De He Ni Po 		402	Zs	M2 V	{ -3 }	(950+4)	[5376]	B	12	180
+Vlan	M	0833	Karbarlah	X587731-2	 	                     Ag Ri 		910	Zs	M1 V	{ 0 }	(A69+2)	[5762]	BC	12	1080
+Vlan	M	0834	Khisber	E87A000-A	 	                  Di Wa 		023	Zs	F6 V	{ -1 }	(C00+2)	[0000]	B	10	24
+Vlan	M	0835	Zhirka	X000000-A	 	                    As Va Di 		010	Zs	M2 V M9 V	{ -1 }	(400+1)	[0000]	B	12	4
+Vlan	M	0839	Kiimiim	X672000-5	 	                 Di He 		003	Wild	G2 V	{ -3 }	(500-3)	[0000]	B	7	-15
+Vlan	B	0902	Otsaellghue	X425000-E	 	          rg9        Di 		003	Wild	K9 V	{ -1 }	(900-1)	[0000]	B	8	-9
+Vlan	B	0906	Iishashun	X625000-A	 	                  Di 		013	Wild	K3 V	{ -1 }	(A00-1)	[0000]	B	10	-10
+Vlan	B	0909	Jiinasha	X200000-A	 	                  Di Va 		020	Wild	M4 III	{ -1 }	(B00+3)	[0000]	B	7	33
+Vlan	J	0921	Ganiir	X423000-B	 	                 Di Po 		005	Wild	M3 V M5 V	{ -1 }	(A00+1)	[0000]	B	16	10
+Vlan	J	0923	Gazzum	X549000-4	 	                 Di 		020	Wild	M2 V M2 V	{ -3 }	(800+1)	[0000]	B	10	8
+Vlan	J	0924	Shugandarsii	X745000-6	 	                 Di 		001	Wild	M2 V	{ -3 }	(500+3)	[0000]	B	8	15
+Vlan	J	0927	Havland	D7938CE-6	 	                  Ph Pi 		401	Zs	M0 V M2 V	{ -2 }	(B76+1)	[B629]	BDe	8	462
+Vlan	J	0930	Gokodeyo	X5818BA-0	 	                  Ph Ri 		110	Zs	F3 V M0 V	{ -1 }	(A75+1)	[4712]	BCe	14	350
+Vlan	N	0933	Arluk	X411000-C	 	                   Di Ic 		013	Zs	M2 V	{ -1 }	(F00+3)	[0000]	B	11	45
+Vlan	N	0934	Imdakhun	X203000-F	 	                     Di Ic Va 		001	Zs	G5 V M1 V	{ -1 }	(700-4)	[0000]	B	12	-28
+Vlan	N	0938	Rhyolite	E560000-6	 	                 De Di 		024	Wild	K7 V M0 V	{ -3 }	(500-1)	[0000]	B	9	-5
+Vlan	N	0939	Gashumu	X76A514-5	 	                 Ni Pr Wa 		202	Wild	G8 V	{ -3 }	(840-2)	[4216]	Bc	5	-64
+Vlan	B	1001	Odhughe	X525000-9	 	          rg9        Di 		010	Wild	K0 V M6 V	{ -2 }	(800+3)	[0000]	B	13	24
+Vlan	B	1003	Anaanika	D540000-7	 	                    De He Di Po 		011	Wild	M1 V	{ -3 }	(700+5)	[0000]	B	8	35
+Vlan	B	1004	Esngougz	XA7A000-4	 	                 Di Oc 		020	Wild	M2 V	{ -3 }	(600+5)	[0000]	B	8	30
+Vlan	B	1007	Laaru	X69A852-5	 	                  Ph Pi Wa 		324	Wild	G7 V	{ -2 }	(B77-1)	[8634]	BDe	9	-539
+Vlan	F	1011	Iren	X8C3000-C	 	                  Di Fl 		014	Wild	K7 V M3 V	{ -1 }	(F00+1)	[0000]	B	10	15
+Vlan	F	1012	Askhu	E554000-7	 	                 Di 		002	Wild	G8 V M0 V	{ -3 }	(300-1)	[0000]	B	9	-3
+Vlan	J	1028	Apurshish	E555000-6	 	                  Di 		023	Zs	G8 V	{ -3 }	(C00+1)	[0000]	B	17	12
+Vlan	N	1032	Umaanshar	X432000-9	 	                  Di Po 		023	Zs	K2 V K6 V	{ -2 }	(C00+1)	[0000]	B	10	12
+Vlan	N	1033	Komirex	X200000-9	 	                  Di Va 		020	Zs	F8 V G7 V	{ -2 }	(600-4)	[0000]	B	7	-24
+Vlan	N	1038	Isle	X68A775-3	 	                 Ri Wa 		601	Wild	K0 V M3 V	{ -1 }	(C68-2)	[9663]	BC	9	-1152
+Vlan	B	1102	Azu	X547000-3	 	            rg2        Di 		001	Wild	M1 V M3 V	{ -3 }	(A00+3)	[0000]	B	5	30
+Vlan	B	1104	Gvaellekh	D885000-6	 	                 Di Ga 		010	Wild	K2 V K6 V	{ -3 }	(400-1)	[0000]	B	8	-4
+Vlan	B	1107	Sikilar	X432000-A	 	                   Di Po 		022	Wild	G2 V	{ -1 }	(E00+1)	[0000]	B	7	14
+Vlan	B	1108	Vakhoneri	D76A758-9	 	                   Ri Wa 		110	Wild	K8 V	{ 0 }	(C65+1)	[A798]	BC	14	360
+Vlan	B	1109	Suragginsu	X433000-A	 	                 Di Po 		011	Wild	F6 V M8 V	{ -1 }	(700+1)	[0000]	B	13	7
+Vlan	B	1110	Liwar	X550000-4	 	                 De Di Po 		005	Wild	K2 V	{ -3 }	(500-1)	[0000]	B	9	-5
+Vlan	F	1112	Vallae	D897000-8	 	          An         Di 		010	Wild	F3 V	{ -3 }	(A00+3)	[0000]	B	13	30
+Vlan	F	1113	Thogho	E898000-7	 	                   Di 		020	Wild	M3 V	{ -3 }	(800-2)	[0000]	B	11	-16
+Vlan	F	1114	Gukhaga	X877000-5	 	                  Di 		010	Wild	G4 V M6 V	{ -3 }	(700+1)	[0000]	B	14	7
+Vlan	F	1116	Darmagu	X412000-D	 	                 Di Ic 		001	Wild	K5 V M3 V	{ -1 }	(600-3)	[0000]	B	11	-18
+Vlan	F	1117	The Uris Belt	X000000-E	 	                     As Va Di 		011	Wild	K5 V M1 V	{ -1 }	(800-5)	[0000]	B	6	-40
+Vlan	F	1119	Daku	X432000-A	 	                  Di Po 		004	Wild	K2 V	{ -1 }	(C00-1)	[0000]	B	8	-12
+Vlan	F	1120	Ideshe	B969852-A	 	                 Ph Ri 		420	Wild	G6 V M1 V	{ 3 }	(87D-3)	[CB5A]	BCe	10	-2184
+Vlan	J	1128	Shakshim	XAA5000-A	 	                 Di Fl 		001	Zs	M1 V M4 V	{ -1 }	(800+1)	[0000]	B	8	8
+Vlan	N	1131	Neegak	X537000-B	 	                  Di 		022	Zs	F8 V	{ -1 }	(C00-1)	[0000]	B	9	-12
+Vlan	N	1134	Jupset	X8C3000-B	 	                  Di Fl 		023	Zs	M1 V	{ -1 }	(B00-3)	[0000]	B	8	-33
+Vlan	N	1135	Abalakova	C56588A-C	 	                     Pa Ri Ph 		222	Zs	F5 V M3 V	{ 2 }	(A7E-1)	[8A4D]	BcCe	10	-980
+Vlan	N	1136	Daangiilu	B565957-D	 	                   Hi Pr 		203	Wild	G2 V M4 V	{ 3 }	(78F-1)	[9C7F]	BcE	16	-840
+Vlan	N	1137	Usaamkirkhiir	X564000-6	 	                    Di 		014	Wild	K1 V	{ -3 }	(700-3)	[0000]	B	13	-21
+Vlan	N	1138	Chrysantheum	X430000-9	 	                 De Di Po 		001	Wild	M0 V M1 V	{ -2 }	(A00-4)	[0000]	B	13	-40
+Vlan	N	1139	Uureg	B553887-9	 	                 Ph Po 		112	Wild	M2 V	{ 1 }	(A79+2)	[99AC]	Be	8	1260
+Vlan	N	1140	Hiroshi	E675000-3	 	                   Di 		001	Wild	K5 V M3 V	{ -3 }	(900+5)	[0000]	B	10	45
+Vlan	B	1201	Erim	A5737A8-E	 	                 Pi 		401	Wild	K0 V M1 V	{ 2 }	(96A-3)	[894E]	BD	9	-1620
+Vlan	B	1202	Anghurr	X430000-7	 	                   De Di Po 		020	Wild	K9 V	{ -3 }	(A00+1)	[0000]	B	9	10
+Vlan	B	1203	Angvae	X422000-9	 	      rg5            Di He Po 		034	Wild	F3 V K0 V	{ -2 }	(C00+4)	[0000]	B	14	48
+Vlan	B	1206	Kummus	X434000-9	 	                 Di 		002	Wild	M1 V	{ -2 }	(900+1)	[0000]	B	8	9
+Vlan	B	1208	Vhodan	X758831-0	 	                 Pa Ph 		523	Wild	K0 IV G1 V	{ -2 }	(C73+3)	[5652]	Bce	11	756
+Vlan	F	1211	Gagzoe	A585878-D	 	                  Pa Ri Ph 		802	Wild	M2 V M3 V	{ 3 }	(678+3)	[9B4F]	BcCe	9	1008
+Vlan	F	1215	Siruga	X100000-D	 	                 Di Va 		001	Wild	K3 V M0 V	{ -1 }	(800+3)	[0000]	B	13	24
+Vlan	F	1217	Estoff	X6B6000-C	 	                 Di Fl 		020	Wild	M2 V	{ -1 }	(700-1)	[0000]	B	11	-7
+Vlan	F	1219	Ramir	X66A000-1	 	        (Tagi)          Di Wa 		001	Wild	K8 V M2 V	{ -3 }	(500+1)	[0000]	B	9	5
+Vlan	F	1220	Imik	X563000-6	 	                 Di 		024	Wild	K1 V	{ -3 }	(500+2)	[0000]	B	9	10
+Vlan	J	1227	Sumabaal	X432000-9	 	                 Di Po 		001	Zs	M0 V M3 V	{ -2 }	(700+2)	[0000]	B	11	14
+Vlan	N	1232	Lekziika	C885845-B	 	                    Ga Pa Ri Ph 		220	Zs	K9 V	{ 2 }	(779+1)	[4A1D]	BcCe	10	441
+Vlan	N	1235	Themistocles	X433000-D	 	                  Di Po 		001	Wild	F6 V M1 V	{ -1 }	(800+1)	[0000]	B	7	8
+Vlan	N	1236	Fymur	E551789-6	 	                 Po 		310	Wild	M1 V	{ -2 }	(965-1)	[2513]	B	14	-270
+Vlan	N	1237	Kanumshikaa	X755589-2	 	                 Ag Ga Ni 		220	Wild	M0 V	{ -2 }	(743-1)	[4381]	BC	5	-84
+Vlan	N	1238	Iplukaddesh	X000000-9	 	                    As Va Di 		011	Wild	K1 V	{ -2 }	(700-3)	[0000]	B	12	-21
+Vlan	N	1240	Nelson	X200000-A	 	                 Di Va 		020	Wild	M0 V	{ -1 }	(600-2)	[0000]	B	6	-12
+Vlan	B	1309	Enpar Konal	X5777B8-2	 	                    Ag Pi 		221	Wild	K8 V	{ -1 }	(964+1)	[A622]	BCD	7	216
+Vlan	F	1311	Kema	X100000-A	 	                 Di Va 		010	Wild	M2 V	{ -1 }	(500+1)	[0000]	B	8	5
+Vlan	F	1312	Taksar	X432000-A	 	                 Di Po 		010	Wild	K4 V	{ -1 }	(600-1)	[0000]	B	10	-6
+Vlan	F	1313	Hisus	E778724-5	 	                      Ag Pi 		414	Wild	M0 V	{ -1 }	(A66+4)	[B62A]	BCD	12	1440
+Vlan	F	1317	Anik	X541000-5	 	                  Di He Po 		011	Wild	M1 V	{ -3 }	(700+1)	[0000]	B	13	7
+Vlan	F	1319	Ganar	X200000-8	 	                 Di Va 		021	Wild	M0 V	{ -3 }	(A00-2)	[0000]	B	12	-20
+Vlan	J	1323	Robbuun	X524000-E	 	                 Di 		002	Wild	K0 V K7 V	{ -1 }	(900+2)	[0000]	B	13	18
+Vlan	N	1332	Nii Khu	C554953-9	 	                 Hi 		301	Zs	K0 V M3 V	{ 1 }	(C88-4)	[CA2B]	BE	13	-3072
+Vlan	N	1334	Lukham	X564752-2	 	                     Ag Ri 		402	Zs	K1 V K6 V	{ 0 }	(C67+1)	[67A1]	BC	9	504
+Vlan	N	1336	Pygmy	X540000-5	 	                    De He Di Po 		011	Wild	F8 V K3 V	{ -3 }	(600-4)	[0000]	B	9	-24
+Vlan	N	1337	Borealis	X511000-9	 	                   Di Ic 		004	Wild	F5 V M5 V	{ -2 }	(C00-1)	[0000]	B	11	-12
+Vlan	N	1339	Darm	X100000-F	 	                  Di Va 		024	Wild	M1 V	{ -1 }	(B00+5)	[0000]	B	16	55
+Vlan	N	1340	Anishda	X614000-8	 	                 Di Ic 		002	Wild	M0 V	{ -3 }	(700-2)	[0000]	B	8	-14
+Vlan	B	1403	Deraan	X426000-C	 	                 Di 		010	Wild	M2 V	{ -1 }	(900+1)	[0000]	B	7	9
+Vlan	B	1405	Diiron	X89A000-7	 	                   Di Wa 		004	Wild	G3 V	{ -3 }	(A00-1)	[0000]	B	10	-10
+Vlan	B	1406	Timat	D98A77B-5	 	                 Ri Wa 		321	Wild	M0 V	{ -1 }	(965-1)	[9685]	BC	12	-270
+Vlan	B	1407	Guusimka	X539000-C	 	                 Di 		011	Wild	M0 V	{ -1 }	(E00+2)	[0000]	B	9	28
+Vlan	B	1408	Maran	X552000-5	 	                 Di Po 		022	Wild	M1 V	{ -3 }	(C00-3)	[0000]	B	8	-36
+Vlan	B	1410	Zentove	X8A3000-9	 	                 Di Fl 		020	Wild	G4 V K3 V	{ -2 }	(900+2)	[0000]	B	10	18
+Vlan	F	1412	Karka	X200000-8	 	                   Di Va 		001	Zs	M0 V	{ -3 }	(B00-3)	[0000]	B	13	-33
+Vlan	F	1414	Centra	X592000-1	 	                 Di He 		024	Wild	M1 V	{ -3 }	(700-3)	[0000]	B	16	-21
+Vlan	F	1417	Astira	B552523-9	 	                  Ni Po 		420	Zs	M0 V	{ 0 }	(641-3)	[657A]	B	11	-72
+Vlan	N	1431	Daalurge	X558535-3	 	                 Ag Ni 		210	Zs	M1 V M2 V	{ -2 }	(741-2)	[5364]	BC	11	-56
+Vlan	N	1432	Agagir	X430000-B	 	                 De Di Po 		010	Wild	M4 V	{ -1 }	(800+2)	[0000]	B	14	16
+Vlan	N	1435	Dakeshir	X401000-C	 	                    Di Ic Va 		002	Wild	M1 V	{ -1 }	(800+1)	[0000]	B	14	8
+Vlan	N	1437	Igikuuni	X797785-2	 	                    Ag Pi 		222	Wild	G0 V	{ -1 }	(963+2)	[5661]	BCD	14	324
+Vlan	N	1438	Zaal	X896000-3	 	                  Di 		001	Wild	K4 V M5 V	{ -3 }	(700-2)	[0000]	B	12	-14
+Vlan	B	1505	Odinaga	X201000-C	 	                     Di Ic Va 		003	Wild	M0 V M5 V	{ -1 }	(B00+1)	[0000]	B	10	11
+Vlan	B	1509	Audhumla	X98A000-0	 	                 Ba Wa 		001	Wild	G1 V M1 V	{ -3 }	(600+4)	[0000]	B	9	24
+Vlan	F	1515	Luunbu	X8D6000-9	 	                  Di 		010	Zs	M2 V	{ -2 }	(500-1)	[0000]	B	13	-5
+Vlan	F	1516	Duam	A5648AB-E	 	                     Pa Ri Ph 		410	Zs	M1 V	{ 3 }	(A7B+2)	[BB5J]	BcCe	11	1540
+Vlan	F	1519	Kagamira	X577000-3	 	                   Di 		025	Zs	G4 V	{ -3 }	(C00+1)	[0000]	B	10	12
+Vlan	F	1520	Shulishu	X552587-3	 	                  Ni Po 		110	Zs	K1 V M0 V	{ -3 }	(740+5)	[6232]	B	10	140
+Vlan	J	1523	Ilma	X510000-7	 	           (Qiceteu)        Di 		001	Zs	M0 V	{ -3 }	(900+5)	[0000]	B	9	45
+Vlan	J	1530	Bakog	X8D9000-F	 	                 Di 		032	Zs	G8 V	{ -1 }	(A00-1)	[0000]	B	12	-10
+Vlan	N	1531	Kolrado	X422000-A	 	                  Di He Po 		010	Zs	M0 V	{ -1 }	(700+1)	[0000]	B	9	7
+Vlan	N	1533	Samotk	X100000-F	 	                 Di Va 		001	Wild	M1 V M8 V	{ -1 }	(700-3)	[0000]	B	8	-21
+Vlan	N	1534	Senkon	X510000-9	 	                 Di 		023	Wild	G6 V M3 V	{ -2 }	(800+1)	[0000]	B	9	8
+Vlan	N	1535	Malapaan	X426000-A	 	                  Di 		020	Wild	K0 V	{ -1 }	(C00+4)	[0000]	B	9	48
+Vlan	N	1536	Pamiimkhi	X000000-D	 	                    As Va Di 		020	Wild	M0 V	{ -1 }	(800-1)	[0000]	B	14	-8
+Vlan	N	1539	Zarurza	X95A411-2	 	                 Ni Wa 		412	Wild	F6 V M1 V G6 V	{ -3 }	(733+3)	[5191]	B	9	189
+Vlan	N	1540	Limed	X430000-B	 	                  De Di Po 		013	Wild	M2 V	{ -1 }	(C00+2)	[0000]	B	11	24
+Vlan	B	1604	Gamgilebo	X000000-B	 	                     As Va Di 		012	Wild	F4 IV M1 V M1 V	{ -1 }	(C00+1)	[0000]	B	11	12
+Vlan	B	1606	Dannar	X200000-A	 	                  Di Va 		020	Wild	F6 V M3 V	{ -1 }	(A00+1)	[0000]	B	15	10
+Vlan	B	1608	Riinel	X746000-7	 	                  Di 		001	Zs	M3 V	{ -3 }	(800-5)	[0000]	B	11	-40
+Vlan	B	1609	Sakkuum	X310000-A	 	                   Di 		001	Zs	M1 V	{ -1 }	(A00+1)	[0000]	B	10	10
+Vlan	F	1612	Ersii	X561479-3	 	                 Ni 		110	Zs	F6 V	{ -3 }	(631+2)	[6145]	B	12	36
+Vlan	F	1619	Midku	X764420-1	 	                  Ni Pa 		110	Zs	M3 V	{ -3 }	(730+1)	[4121]	Bc	10	21
+Vlan	J	1623	Etsur	X410000-A	 	                 Di 		020	Zs	M4 III K3 V	{ -1 }	(900-2)	[0000]	B	7	-18
+Vlan	J	1624	Zushar	X631000-A	 	                  Di Po 		011	Zs	K9 V M2 V	{ -1 }	(C00+1)	[0000]	B	14	12
+Vlan	J	1625	Bashimus	X542000-2	 	                  Di He Po 		020	Zs	M4 V	{ -3 }	(700+3)	[0000]	B	12	21
+Vlan	J	1626	Lalazim	X8C4000-9	 	                 Di Fl 		010	Zs	M1 V	{ -2 }	(700+1)	[0000]	B	10	7
+Vlan	J	1628	Akumid	X867400-4	 	                  Ga Ni Pa 		123	Zs	K0 V	{ -3 }	(633-3)	[6177]	Bc	14	-162
+Vlan	J	1630	Kanoka	X7B2000-8	 	                    Di Fl He 		003	Zs	M2 V	{ -3 }	(A00+1)	[0000]	B	12	10
+Vlan	N	1632	Imdur	X540000-6	 	                    De He Di Po 		010	Wild	M1 V	{ -3 }	(300-4)	[0000]	B	8	-12
+Vlan	N	1633	Darkishar	X420000-D	 	                    De He Di Po 		010	Wild	K0 V M3 V	{ -1 }	(800-3)	[0000]	B	12	-24
+Vlan	N	1634	Isuugi	X75647A-1	 	                 Ga Ni Pa 		813	Wild	G0 V G6 V	{ -3 }	(730+3)	[4181]	Bc	12	63
+Vlan	N	1637	Preserve	X551000-6	 	                 Di Po 		001	Wild	M1 V	{ -3 }	(400+1)	[0000]	B	11	4
+Vlan	N	1638	Twana	E553434-7	 	                 Ni Po 		220	Wild	G8 V M8 V M2 V	{ -3 }	(732+1)	[414C]	B	6	42
+Vlan	C	1701	Taksarrgh	X624000-A	 	          rg4        Di 		010	Wild	M1 V	{ -1 }	(900+3)	[0000]	B	8	27
+Vlan	C	1703	Dathsuts	X310000-A	 	          rg3        Di 		001	Wild	F7 V M0 V	{ -1 }	(500+3)	[0000]	B	8	15
+Vlan	C	1704	Rronaetuts	X424000-7	 	          rg6        Di 		020	Wild	M1 V	{ -3 }	(300+3)	[0000]	B	10	9
+Vlan	C	1705	Ugarun	X7C2000-9	 	                   Di Fl He 		002	Wild	G8 V	{ -2 }	(B00-4)	[0000]	B	7	-44
+Vlan	C	1708	Zelaklaka	X7B2000-B	 	                    Di Fl He 		001	Wild	M2 V M2 V	{ -1 }	(600-2)	[0000]	B	8	-12
+Vlan	C	1709	Zigaadig	X541000-0	 	                 Ba He Po 		023	Zs	G9 V K6 V	{ -3 }	(500+1)	[0000]	B	9	5
+Vlan	C	1710	Tollori	X88449D-1	 	                  Ni Pa 		201	Wild	M3 V	{ -3 }	(733-1)	[4163]	Bc	7	-63
+Vlan	G	1716	Enaa	X300000-B	 	                   Di Va 		002	Zs	M2 V	{ -1 }	(C00-5)	[0000]	B	9	-60
+Vlan	G	1717	Vland	A967973-F	NS	        [Vilani]          Hi Pr 		410	Zs	F8 V	{ 4 }	(C88-5)	[8D5C]	BcEf	7	-3840
+Vlan	G	1718	Kirma	X797000-3	 	                 Di 		025	Wild	G8 V K2 V	{ -3 }	(300+1)	[0000]	B	11	3
+Vlan	G	1719	Sazisi	X58679A-2	 	                    Ag Ri 		603	Zs	M0 V M2 V	{ 0 }	(967-1)	[8731]	BC	7	-378
+Vlan	K	1722	Asanik	X554000-4	 	                 Di 		004	Zs	G4 V G6 V	{ -3 }	(500-1)	[0000]	B	16	-5
+Vlan	K	1725	Kalimgar	D799000-6	 	                  Di 		024	Zs	K8 V	{ -3 }	(800-2)	[0000]	B	13	-16
+Vlan	K	1726	Gunavarum	X553587-3	 	                 Ni Po 		104	Zs	K0 V K1 V	{ -3 }	(743-1)	[4214]	B	14	-84
+Vlan	K	1728	Ashok	D698000-8	 	                 Di 		020	Zs	G0 V	{ -3 }	(500-3)	[0000]	B	15	-15
+Vlan	K	1729	Kargem	X310000-9	 	                  Di 		020	Zs	G8 V M1 V	{ -2 }	(A00+1)	[0000]	B	5	10
+Vlan	K	1730	Lurkha	X674755-3	 	           An            Ag Pi 		620	Zs	F7 V	{ -1 }	(A66-3)	[5663]	BCD	9	-1080
+Vlan	O	1732	Nikham	X89A000-7	 	                 Di Wa 		010	Zs	M3 V	{ -3 }	(600-4)	[0000]	B	11	-24
+Vlan	O	1734	Miku	X8C3000-E	 	                 Di Fl 		004	Wild	M1 V	{ -1 }	(B00-1)	[0000]	B	8	-11
+Vlan	O	1735	Zhinutar	X312000-F	 	                  Di Ic 		004	Wild	G6 V M0 V	{ -1 }	(B00-1)	[0000]	B	9	-11
+Vlan	O	1736	Ake	X528000-A	 	                 Di 		001	Wild	A9 V M1 V	{ -1 }	(700+1)	[0000]	B	12	7
+Vlan	O	1740	Glanidarn	X435000-A	 	                  Di 		023	Wild	M2 V	{ -1 }	(G00-2)	[0000]	B	11	-32
+Vlan	C	1801	Newcastle	B56788A-D	 	                   Pa Ri Ph 		402	Wild	M2 V	{ 3 }	(97B-3)	[4B69]	BcCe	8	-2079
+Vlan	C	1802	Zannokh	D545000-5	 	                 Di 		020	Wild	G8 V	{ -3 }	(400-1)	[0000]	B	13	-4
+Vlan	C	1803	Ronni	X645000-2	 	           (Ronnin)        Di 		022	Wild	G7 V	{ -3 }	(700+3)	[0000]	B	9	21
+Vlan	C	1804	Kashiin	X540000-4	 	                      De He Di Po 		020	Wild	M2 V M8 V	{ -3 }	(A00+1)	[0000]	B	12	10
+Vlan	C	1807	Ranilson	D999000-8	 	                 Di 		001	Wild	G5 V K1 V	{ -3 }	(700+4)	[0000]	B	10	28
+Vlan	C	1810	Eshu	X560000-6	 	                 De Di 		022	Zs	K3 V	{ -3 }	(300-1)	[0000]	B	9	-3
+Vlan	G	1811	Anaam	X424000-B	 	                 Di 		010	Zs	G1 V	{ -1 }	(A00+1)	[0000]	B	11	10
+Vlan	G	1813	Khusher	B6467CA-9	 	                    Ag Pi 		622	Zs	G5 V G9 V	{ 2 }	(969+3)	[8968]	BCD	11	1458
+Vlan	G	1816	Shinla	E560000-5	 	                  De Di 		034	Zs	K2 V M9 V	{ -3 }	(A00+5)	[0000]	B	16	50
+Vlan	G	1817	Tauri	X430000-F	 	                  De Di Po 		020	Zs	K3 V	{ -1 }	(D00+3)	[0000]	B	7	39
+Vlan	G	1819	Dusu	X9E4000-A	 	                 Di 		020	Zs	F3 V	{ -1 }	(800-5)	[0000]	B	6	-40
+Vlan	G	1820	Kha	D86A67A-6	 	                 Ni Ri Wa 		224	Wild	K6 V	{ -2 }	(851-2)	[5434]	BC	11	-80
+Vlan	K	1821	Iikhok	X434000-D	 	                 Di 		024	Wild	M2 V	{ -1 }	(C00-2)	[0000]	B	16	-24
+Vlan	K	1822	Kasear	X547000-0	 	                    Ba 		020	Wild	G5 V M2 V	{ -3 }	(B00+1)	[0000]	B	11	11
+Vlan	K	1825	Karfir	X753978-3	 	                 Hi Po 		623	Zs	K4 V	{ -1 }	(C85-1)	[A894]	BE	12	-480
+Vlan	K	1830	Sindal	X9B8000-A	 	                 Di Fl 		001	Zs	G6 V M3 V	{ -1 }	(600+5)	[0000]	B	13	30
+Vlan	O	1831	Mekhe	E546000-7	 	                   Di 		025	Zs	K3 V M1 V	{ -3 }	(700+2)	[0000]	B	11	14
+Vlan	O	1833	Shadi	X597000-3	 	                  Di 		001	Wild	G6 V M3 V	{ -3 }	(600+1)	[0000]	B	11	6
+Vlan	O	1839	Kordanor	X778000-4	 	                  Di 		003	Wild	M3 V	{ -3 }	(900+2)	[0000]	B	16	18
+Vlan	C	1901	Ghurrllekh	E560442-7	 	                  De Ni 		320	Wild	M3 V	{ -3 }	(730+3)	[8148]	B	7	63
+Vlan	C	1903	Gemid	X423000-E	 	                   Di Po 		024	Wild	K0 V	{ -1 }	(H00+1)	[0000]	B	10	17
+Vlan	C	1904	Daama	D576000-8	 	                  Di 		001	Wild	K4 V M2 V	{ -3 }	(800+1)	[0000]	B	8	8
+Vlan	C	1906	Envar	X9C5000-9	 	                 Di Fl 		001	Wild	M2 V	{ -2 }	(600+5)	[0000]	B	8	30
+Vlan	C	1907	Kakkin	X423000-C	 	                 Di Po 		002	Wild	G8 V	{ -1 }	(700-1)	[0000]	B	9	-7
+Vlan	C	1909	Nashazi	X300000-F	 	                 Di Va 		020	Zs	M2 III F7 IV	{ -1 }	(600-2)	[0000]	B	8	-12
+Vlan	G	1915	Giinam	X565000-3	 	                 Di 		004	Zs	M3 V	{ -3 }	(500-1)	[0000]	B	14	-5
+Vlan	G	1916	Kipii	X430000-D	 	                 De Di Po 		002	Zs	M3 V	{ -1 }	(600-1)	[0000]	B	8	-6
+Vlan	G	1918	Kusheggi	X596779-1	 	                    Ag Pi 		420	Zs	F8 V	{ -1 }	(969+1)	[8631]	BCD	7	486
+Vlan	G	1919	Khula	X575000-0	 	            (Khulans)        Ba 		010	Wild	M0 V	{ -3 }	(C00+3)	[0000]	B	10	36
+Vlan	G	1920	Inkha	X797000-2	 	                  Di 		010	Zs	M0 V M4 V	{ -3 }	(600+1)	[0000]	B	9	6
+Vlan	K	1923	Sagida	X423000-C	 	                    Di Po 		002	Wild	M0 V M0 V	{ -1 }	(D00+1)	[0000]	B	14	13
+Vlan	K	1928	Nimmer	X420000-D	 	                    De He Di Po 		024	Zs	G4 V	{ -1 }	(900-1)	[0000]	B	9	-9
+Vlan	K	1929	Sakhem	X404000-D	 	                    Di Ic Va 		010	Zs	M0 V	{ -1 }	(700+1)	[0000]	B	7	7
+Vlan	K	1930	Ziirkago	X878000-5	 	                  Di 		013	Zs	M0 V	{ -3 }	(800-1)	[0000]	B	7	-8
+Vlan	O	1931	Shorlon	X430000-9	 	                 De Di Po 		002	Zs	M1 V	{ -2 }	(900+3)	[0000]	B	9	27
+Vlan	O	1932	Sharan	E765000-6	 	                 Di Ga 		024	Zs	G8 V	{ -3 }	(500+1)	[0000]	B	9	5
+Vlan	O	1933	Kaskar	E673699-5	 	                  Ni 		301	Zs	K6 V M0 V	{ -3 }	(850+2)	[5315]	B	12	80
+Vlan	O	1936	Ekhin	X400000-7	 	                  Di Va 		001	Wild	M0 III M7 V	{ -3 }	(800+2)	[0000]	B	8	16
+Vlan	O	1937	Nulisud	X8A3000-D	 	                  Di Fl 		021	Wild	K3 V	{ -1 }	(B00+1)	[0000]	B	15	11
+Vlan	C	2005	Gadushan	X536000-A	 	                 Di 		010	Wild	M4 V M5 V	{ -1 }	(700+1)	[0000]	B	10	7
+Vlan	C	2006	Niitomok	E552552-8	 	                 Ni Po 		301	Wild	M2 V	{ -3 }	(840-2)	[6249]	B	9	-64
+Vlan	C	2007	Kaaka	E898000-6	 	           An         Di 		001	Wild	F7 V M8 V	{ -3 }	(800-1)	[0000]	B	7	-8
+Vlan	C	2008	Morimur	X550000-1	 	                  De Di Po 		013	Wild	M0 V	{ -3 }	(C00-2)	[0000]	B	14	-24
+Vlan	G	2013	Isbudin	X9C5000-B	 	                  Di Fl 		023	Zs	F6 V M7 V	{ -1 }	(G00+1)	[0000]	B	8	16
+Vlan	G	2016	Zurrian	X563424-3	 	                  Ni 		902	Zs	M1 V M1 V	{ -3 }	(732-3)	[2158]	B	10	-126
+Vlan	G	2017	Tahaver	X769988-1	 	       (Tahavi)          Hi Pr 		110	Zs	M2 V	{ -1 }	(C88+1)	[B831]	BcE	13	768
+Vlan	G	2019	Lobode	X554000-5	 	                   Di 		010	Zs	M2 V M3 V	{ -3 }	(800+2)	[0000]	B	8	16
+Vlan	G	2020	Shushguum	X522000-B	 	                 Di He Po 		024	Zs	G6 V	{ -1 }	(D00-1)	[0000]	B	13	-13
+Vlan	K	2022	Emrim	X100000-9	 	                 Di Va 		001	Zs	M0 V	{ -2 }	(700+2)	[0000]	B	14	14
+Vlan	K	2023	Zhattar	X88A000-2	 	                 Di Wa 		010	Zs	M3 V	{ -3 }	(400-1)	[0000]	B	9	-4
+Vlan	K	2027	Gaarluzargu	D775000-5	 	                  Di 		020	Zs	M0 V M1 V	{ -3 }	(900+1)	[0000]	B	7	9
+Vlan	K	2029	Gabik	X512000-D	 	                 Di Ic 		033	Zs	F2 V	{ -1 }	(900+1)	[0000]	B	11	9
+Vlan	K	2030	Duusan	X9CA000-D	 	                 Di Fl 		022	Zs	M3 V	{ -1 }	(C00-1)	[0000]	B	13	-12
+Vlan	O	2032	Vuldaan	X522000-9	 	                   Di He Po 		023	Zs	F8 V	{ -2 }	(E00+4)	[0000]	B	12	56
+Vlan	O	2035	Hykluitt	X540000-6	 	                      De He Di Po 		004	Wild	M1 V	{ -3 }	(B00+4)	[0000]	B	9	44
+Vlan	O	2036	Diinagar	X560000-2	 	                 De Di 		010	Wild	K0 V M2 V	{ -3 }	(600-2)	[0000]	B	14	-12
+Vlan	O	2039	Miizam	D573000-6	 	                 Di 		010	Wild	M0 V M2 V	{ -3 }	(700-3)	[0000]	B	5	-21
+Vlan	C	2101	Miiko Belt	X000000-9	 	                    As Va Di 		020	Wild	F1 V	{ -2 }	(600+2)	[0000]	B	7	12
+Vlan	C	2103	Hteh Hut	X000000-E	 	                    As Va Di 		011	Wild	K7 V M5 V	{ -1 }	(900-4)	[0000]	B	8	-36
+Vlan	C	2105	Ninnigam	X9D5000-9	 	                 Di 		010	Wild	M1 V	{ -2 }	(A00+1)	[0000]	B	13	10
+Vlan	C	2106	Hellvaplace	XAB5000-8	 	                 Di Fl 		001	Wild	G2 V M2 V	{ -3 }	(700+1)	[0000]	B	10	7
+Vlan	C	2107	Sadniben	E7787BC-2	 	                     Ag Pi 		904	Wild	M1 V	{ -1 }	(B66-1)	[6653]	BCD	15	-396
+Vlan	G	2111	Flire	E779000-B	 	                  Di 		023	Zs	K8 V	{ -1 }	(H00-1)	[0000]	B	9	-17
+Vlan	G	2113	Ishala	E866651-7	 	                   Ag Ri Ga Ni 		904	Wild	M1 V	{ -1 }	(952+1)	[4537]	BC	13	90
+Vlan	G	2115	Zedu Gisla	X533000-6	 	                 Di Po 		001	Zs	M1 V M2 V	{ -3 }	(700-2)	[0000]	B	6	-14
+Vlan	G	2117	Uri	X313000-E	 	                  Di Ic 		020	Zs	F9 V	{ -1 }	(A00+2)	[0000]	B	12	20
+Vlan	G	2120	Pyam	X799000-4	 	                 Di 		020	Zs	M1 V	{ -3 }	(500+1)	[0000]	B	15	5
+Vlan	K	2122	Lekkon	X540343-3	 	                    De He Lo Po 		902	Zs	K8 V M1 V	{ -3 }	(720-5)	[3161]	B	12	-70
+Vlan	K	2123	Blikig	E544000-6	 	                  Di 		001	Zs	K7 V M9 V	{ -3 }	(800+1)	[0000]	B	14	8
+Vlan	K	2124	Razzun	D572000-6	 	                  Di He 		010	Zs	M2 V M2 V	{ -3 }	(900-3)	[0000]	B	7	-27
+Vlan	K	2125	Shib	X799000-5	 	                 Di 		010	Zs	K2 V M2 V	{ -3 }	(800-2)	[0000]	B	7	-16
+Vlan	K	2126	Dekhuun	X578689-2	 	                 Ag Ni 		620	Zs	M3 V	{ -2 }	(953+1)	[9482]	BC	13	135
+Vlan	K	2129	Gunnar	X000000-9	 	                     As Va Di 		010	Zs	M2 V	{ -2 }	(A00-2)	[0000]	B	10	-20
+Vlan	O	2132	Imshiig	X574000-5	 	                  Di 		020	Zs	M3 V	{ -3 }	(700+1)	[0000]	B	12	7
+Vlan	O	2133	Iddun	X583000-7	 	          An        Di 		020	Wild	F7 V	{ -3 }	(400+2)	[0000]	B	10	8
+Vlan	O	2134	Zemal	D699000-4	S	                 Di 		010	Wild	M3 V M5 V	{ -3 }	(300+1)	[0000]	B	8	3
+Vlan	O	2137	Shaka	X410000-A	 	                 Di 		012	Wild	F0 V	{ -1 }	(700+1)	[0000]	B	9	7
+Vlan	O	2138	Istuary	X582000-4	 	                  Di 		022	Wild	M1 V	{ -3 }	(C00+2)	[0000]	B	14	24
+Vlan	O	2139	Zolo	X628000-9	 	                  Di 		001	Wild	M1 V	{ -2 }	(900+4)	[0000]	B	12	36
+Vlan	C	2203	Angvae	D657588-7	 	                 Ag Ga Ni 		420	Wild	M2 V	{ -2 }	(841-1)	[5327]	BC	12	-32
+Vlan	C	2205	Anarsi	X747000-3	 	                    Di 		020	Wild	G3 V M3 V	{ -3 }	(B00+2)	[0000]	B	15	22
+Vlan	C	2208	Kuzashamir	X54679B-2	 	                     Ag Pi 		120	Wild	M3 V	{ -1 }	(A67+2)	[A621]	BCD	10	840
+Vlan	C	2210	Deglaraarbiis	X737000-7	 	                 Di 		012	Zs	G4 V K2 V K4 V	{ -3 }	(900+3)	[0000]	B	6	27
+Vlan	G	2211	Irila	X568321-1	 	                  Lo 		923	Zs	M1 V	{ -3 }	(620+2)	[1142]	B	8	24
+Vlan	G	2216	Ashbakha	D672000-8	 	                 Di He 		001	Zs	K9 V M2 V	{ -3 }	(800+2)	[0000]	B	14	16
+Vlan	K	2221	Karlum	X57A000-0	 	                 Ba Wa 		020	Zs	K2 V K5 V	{ -3 }	(700+1)	[0000]	B	10	7
+Vlan	K	2222	Markassar	X778888-1	 	                     Pa Pi Ph 		323	Zs	G2 V G4 V	{ -2 }	(A79-5)	[7622]	BcDe	12	-3150
+Vlan	K	2223	Gurzish	X76A000-7	 	                 Di Wa 		001	Zs	M2 V M8 V	{ -3 }	(500-2)	[0000]	B	12	-10
+Vlan	K	2225	Iamone	X310000-E	 	                   Di 		024	Zs	K4 V	{ -1 }	(J00-2)	[0000]	B	11	-36
+Vlan	K	2227	Zikurag	X536000-E	 	                 Di 		024	Zs	F8 V	{ -1 }	(D00+1)	[0000]	B	15	13
+Vlan	K	2229	Munakhiin	X202000-8	 	                      Di Ic Va 		010	Zs	K5 V	{ -3 }	(A00-5)	[0000]	B	7	-50
+Vlan	O	2232	Gikarlum	D999000-5	 	                 Di 		010	Zs	G2 V M3 V	{ -3 }	(700+2)	[0000]	B	14	14
+Vlan	O	2233	Segikin	X768000-6	 	                 Di 		001	Wild	M3 V	{ -3 }	(C00-5)	[0000]	B	11	-60
+Vlan	O	2235	Rishin	X310000-9	 	                 Di 		024	Wild	G0 V	{ -2 }	(D00+1)	[0000]	B	14	13
+Vlan	O	2236	Gaarid	X543740-2	 	                    Pi Po 		213	Wild	K7 V M2 V	{ -2 }	(960-1)	[8553]	BD	10	-54
+Vlan	O	2238	Khugan	X786476-3	 	                 Ga Ni Pa 		104	Wild	M3 V	{ -3 }	(630-1)	[5153]	Bc	13	-18
+Vlan	O	2240	Bakor	D878749-4	 	                      Ag Pi 		410	Wild	K0 V M3 V	{ -1 }	(A67-2)	[9644]	BCD	14	-840
+Vlan	C	2301	Knaeghzoka	X431000-B	 	                 Di Po 		001	Wild	M1 V M1 V	{ -1 }	(A00-4)	[0000]	B	7	-40
+Vlan	C	2306	Nelak	E64A000-8	 	                  Di Wa 		010	Wild	M0 V	{ -3 }	(900-1)	[0000]	B	9	-9
+Vlan	C	2308	Bolziin	X310000-D	 	                 Di 		014	Wild	M3 V	{ -1 }	(900+1)	[0000]	B	14	9
+Vlan	C	2309	Moribur	D550000-3	 	                 De Di Po 		020	Wild	M2 V	{ -3 }	(800+1)	[0000]	B	13	8
+Vlan	C	2310	Barshun	X510000-B	 	                  Di 		020	Wild	F8 V M8 V	{ -1 }	(A00-3)	[0000]	B	12	-30
+Vlan	G	2314	Dangasha	E550673-6	 	                  De Ni Po 		401	Zs	M3 V	{ -3 }	(850-5)	[7386]	B	6	-200
+Vlan	G	2316	Kagush	X736000-A	 	                 Di 		024	Zs	K6 V	{ -1 }	(B00+3)	[0000]	B	9	33
+Vlan	G	2319	Shudi	C766977-6	 	                  Ga Hi Pr 		225	Zs	G2 V G6 V	{ 0 }	(B87-1)	[A927]	BcE	12	-616
+Vlan	G	2320	Gidapisek	X200000-C	 	                  Di Va 		010	Zs	K7 V	{ -1 }	(900+4)	[0000]	B	11	36
+Vlan	K	2321	Gikarlum	X432000-A	 	                 Di Po 		033	Zs	M3 V	{ -1 }	(C00+1)	[0000]	B	9	12
+Vlan	K	2322	Hefas	X775000-8	 	                   Di 		015	Zs	M2 V	{ -3 }	(H00+2)	[0000]	B	9	34
+Vlan	K	2323	Zruub	X5535AB-3	 	                 Ni Po 		203	Zs	M1 V	{ -3 }	(740+1)	[8264]	B	15	28
+Vlan	K	2324	Firdakh	X432000-A	 	                 Di Po 		020	Zs	K9 V	{ -1 }	(800-1)	[0000]	B	14	-8
+Vlan	K	2325	Derkhuun	X310000-9	 	                 Di 		005	Zs	F1 V K5 V	{ -2 }	(900+3)	[0000]	B	12	27
+Vlan	K	2328	Fharnas	X8D8000-B	 	                 Di 		001	Zs	M0 V	{ -1 }	(D00+2)	[0000]	B	9	26
+Vlan	K	2329	Tobrun	X400000-E	 	                 Di Va 		010	Zs	F8 V M9 V	{ -1 }	(800-4)	[0000]	B	14	-32
+Vlan	K	2330	Umzgaa	X000000-C	 	                    As Va Di 		010	Zs	M3 V	{ -1 }	(600+1)	[0000]	B	14	6
+Vlan	O	2331	Aaluggidira	E79A000-7	 	                 Di Wa 		003	Zs	F3 V	{ -3 }	(500-4)	[0000]	B	11	-20
+Vlan	O	2332	Zaakkusham	X583489-3	 	                  Ni 		301	Zs	M1 V M8 V	{ -3 }	(730+2)	[5191]	B	12	42
+Vlan	O	2335	Miiliinlur	X422000-C	 	                   Di He Po 		024	Wild	G7 V M4 V	{ -1 }	(E00+3)	[0000]	B	13	42
+Vlan	O	2336	Kunni	X784501-4	 	                    Ag Pr Ni 		101	Wild	M0 V M2 V	{ -2 }	(740+1)	[7327]	BcC	5	28
+Vlan	O	2337	Idi	X56147C-3	 	                 Ni 		212	Wild	G8 V M6 V	{ -3 }	(630-4)	[1187]	B	10	-72
+Vlan	O	2340	Orguk	X545000-6	 	                  Di 		020	Wild	M3 V	{ -3 }	(800-1)	[0000]	B	7	-8
+Vlan	C	2402	Kfoerudzo	X559000-3	 	                 Di 		021	Wild	M1 V	{ -3 }	(500+5)	[0000]	B	14	25
+Vlan	C	2406	Derekam	E546000-7	 	                    Di 		020	Wild	K6 V	{ -3 }	(A00-3)	[0000]	B	10	-30
+Vlan	C	2407	Gida	X200000-9	 	                  Di Va 		010	Wild	M3 V	{ -2 }	(500+1)	[0000]	B	10	5
+Vlan	C	2408	Shabii	D854000-8	 	                  Di 		001	Wild	G9 V M1 V	{ -3 }	(900+2)	[0000]	B	9	18
+Vlan	C	2409	Sardiika	X544000-2	 	                  Di 		010	Wild	F9 V	{ -3 }	(800+1)	[0000]	B	6	8
+Vlan	C	2410	Karamursel	X438000-A	 	                 Di 		020	Wild	K6 V	{ -1 }	(600+1)	[0000]	B	15	6
+Vlan	G	2412	Ansin	X563000-A	 	                 Di 		020	Zs	K2 V K2 V	{ -1 }	(E00-1)	[0000]	B	8	-14
+Vlan	G	2416	Liisurkhish	C56277A-8	 	                 Ri 		410	Zs	K0 V M2 V	{ 0 }	(A69+1)	[875A]	BC	14	540
+Vlan	G	2419	Nasha	X200000-9	 	                 Di Va 		010	Zs	M0 V M2 V	{ -2 }	(500+2)	[0000]	B	11	10
+Vlan	K	2425	Martle	X540387-3	 	                      De He Lo Po 		924	Zs	M0 V	{ -3 }	(B20+4)	[11A3]	B	10	88
+Vlan	K	2426	Khanaddar	X000000-F	 	                    As Va Di 		012	Wild	K6 V M6 V	{ -1 }	(800+3)	[0000]	B	12	24
+Vlan	K	2429	Irgar	X420000-8	 	                    De He Di Po 		012	Zs	M3 V	{ -3 }	(900+5)	[0000]	B	12	45
+Vlan	O	2431	Dusekhip	X633000-D	 	                   Di Po 		022	Wild	K7 V	{ -1 }	(F00+1)	[0000]	B	10	15
+Vlan	O	2432	Korm	C98789D-8	 	                     Pa Ri Ph 		303	Zs	M0 V	{ 0 }	(D78-4)	[9858]	BcCe	13	-2912
+Vlan	O	2433	Ashuugakher	X310000-8	 	                   Di 		020	Zs	G6 V	{ -3 }	(C00+1)	[0000]	B	8	12
+Vlan	O	2435	Li	X423000-7	 	                   Di Po 		020	Zs	M1 V	{ -3 }	(A00+1)	[0000]	B	9	10
+Vlan	O	2438	Shakir	X626000-F	 	                 Di 		023	Wild	K6 V	{ -1 }	(900-3)	[0000]	B	12	-27
+Vlan	O	2440	Shuurdiikha	E652000-7	 	                  Di Po 		010	Wild	F8 V M5 V	{ -3 }	(700-4)	[0000]	B	11	-28
+Vlan	D	2501	Khugan	X623000-A	 	                 Di Po 		023	Wild	M0 V M1 V	{ -1 }	(C00+2)	[0000]	B	11	24
+Vlan	D	2502	Rhodes	X413000-C	 	                 Di Ic 		002	Wild	F0 III M5 V	{ -1 }	(900+2)	[0000]	B	10	18
+Vlan	D	2507	Shunisar	X556599-3	 	                 Ag Ni 		201	Wild	M3 V M6 V	{ -2 }	(740+1)	[2355]	BC	8	28
+Vlan	D	2508	Nii	X425000-7	 	                  Di 		010	Wild	M1 V	{ -3 }	(700+1)	[0000]	B	14	7
+Vlan	H	2511	Iigshuren	X66A755-5	 	                  Ri Wa 		823	Wild	G5 V	{ -1 }	(965+1)	[4667]	BC	11	270
+Vlan	H	2512	Imziinune	X627000-C	 	                 Di 		020	Wild	M1 V	{ -1 }	(700-1)	[0000]	B	9	-7
+Vlan	H	2513	Shiigus	X571000-3	 	                   Di He 		001	Wild	F5 V M9 V	{ -3 }	(900+1)	[0000]	B	14	9
+Vlan	H	2515	Gookir	X9D7000-A	 	                 Di 		022	Wild	K8 V	{ -1 }	(E00-1)	[0000]	B	10	-14
+Vlan	H	2518	Khe	X433000-8	 	                 Di Po 		001	Wild	M2 V	{ -3 }	(700-2)	[0000]	B	14	-14
+Vlan	H	2519	Muukakam	X523000-A	 	                   Di Po 		011	Zs	M1 V	{ -1 }	(A00-3)	[0000]	B	7	-30
+Vlan	H	2520	Ma	D585000-7	 	                 Di 		010	Zs	M0 V M0 V	{ -3 }	(400+3)	[0000]	B	13	12
+Vlan	L	2524	Kakhashedir	X560000-6	 	                 De Di 		002	Zs	M2 V	{ -3 }	(500+4)	[0000]	B	12	20
+Vlan	L	2526	Daapuken	X564000-6	 	                  Di 		010	Zs	G8 V M1 V	{ -3 }	(400+1)	[0000]	B	12	4
+Vlan	L	2527	Kaple	X421000-9	 	                  Di He Po 		011	Zs	K9 V	{ -2 }	(A00-5)	[0000]	B	11	-50
+Vlan	L	2528	Shuurnnish	X202000-B	 	                    Di Ic Va 		001	Zs	M1 V	{ -1 }	(500+1)	[0000]	B	12	5
+Vlan	L	2530	Thaggesh	D666878-6	 	       (Thaggeshi)              Ga Pa Ri Ph 		501	Zs	F6 V M7 V M6 V	{ -1 }	(A77+3)	[C753]	BcCe	14	1470
+Vlan	P	2531	Kiddinu	X555573-3	 	                 Ag Ni 		134	Wild	M0 V	{ -2 }	(740+2)	[5371]	BC	11	56
+Vlan	P	2533	Aki	X697751-3	 	                     Ag Pi 		310	Wild	F5 V M0 V	{ -1 }	(C65+1)	[7651]	BCD	13	360
+Vlan	P	2534	Zerapii	X411000-A	 	                  Di Ic 		022	Zs	M1 V	{ -1 }	(D00-4)	[0000]	B	12	-52
+Vlan	P	2536	Linissa	X200000-8	 	                  Di Va 		010	Zs	G9 V	{ -3 }	(A00-4)	[0000]	B	12	-40
+Vlan	P	2539	Nunaat	X624000-C	 	                 Di 		024	Wild	M0 V	{ -1 }	(A00+3)	[0000]	B	9	30
+Vlan	P	2540	Kalaalit	X7698BA-3	 	                  Ph Ri 		210	Wild	M3 V	{ -1 }	(A77+5)	[8734]	BCe	6	2450
+Vlan	D	2602	Daztsoun	X556000-3	 	                 Di 		011	Wild	F7 V	{ -3 }	(500+1)	[0000]	B	11	5
+Vlan	D	2603	Kaengtsaelzon	X100000-A	 	          rg8          Di Va 		001	Wild	M3 V M3 V	{ -1 }	(B00-1)	[0000]	B	8	-11
+Vlan	D	2604	Fongknoe	X300000-8	 	                   Di Va 		001	Wild	M0 V	{ -3 }	(B00-4)	[0000]	B	10	-44
+Vlan	D	2605	Raltaedz	X430000-D	 	                  De Di Po 		004	Wild	M1 V	{ -1 }	(800+1)	[0000]	B	15	8
+Vlan	D	2610	Malokh	X571000-6	 	                 Di He 		001	Wild	F8 V M2 V	{ -3 }	(800+2)	[0000]	B	10	16
+Vlan	H	2611	Kimii	X403000-8	 	                     Di Ic Va 		001	Wild	K2 V M3 V	{ -3 }	(A00-4)	[0000]	B	9	-40
+Vlan	H	2612	Gaska Khiin	E544000-5	 	                  Di 		023	Wild	M1 V	{ -3 }	(700+1)	[0000]	B	12	7
+Vlan	H	2613	Kusu	X541000-5	 	                 Di He Po 		002	Wild	K3 IV	{ -3 }	(800+4)	[0000]	B	9	32
+Vlan	H	2615	Malta	X000000-C	 	                     As Va Di 		011	Wild	K6 V M3 V	{ -1 }	(600-1)	[0000]	B	11	-6
+Vlan	H	2616	St. George	X7C5000-D	 	                   Di Fl 		020	Wild	G5 IV	{ -1 }	(D00-3)	[0000]	B	12	-39
+Vlan	H	2618	Dudid	X510000-A	 	                 Di 		001	Wild	M0 V M0 V	{ -1 }	(800-4)	[0000]	B	8	-32
+Vlan	H	2620	Mennoral	X858778-1	 	                 Ag 		221	Wild	K3 V	{ -1 }	(968-1)	[6674]	BC	10	-432
+Vlan	L	2621	Malvar	E68377C-6	 	                 Ri 		424	Zs	F8 V M3 V	{ -1 }	(967-4)	[B657]	BC	12	-1512
+Vlan	L	2624	Shera	E6838C9-6	 	                  Ph Ri 		203	Zs	M1 V	{ -1 }	(A77+1)	[77A5]	BCe	7	490
+Vlan	L	2627	Taluza	X594000-3	 	                  Di 		023	Zs	K6 V	{ -3 }	(700+4)	[0000]	B	13	28
+Vlan	L	2628	Floranus	X8B3000-9	 	                Di Fl 		001	Zs	M0 V M3 V	{ -2 }	(A00+1)	[0000]	B	14	10
+Vlan	L	2629	Rikaan	X8D8000-7	 	                 Di 		010	Zs	M2 V	{ -3 }	(A00+3)	[0000]	B	9	30
+Vlan	P	2631	Kane	X789000-4	 	                  Di 		023	Zs	K9 V	{ -3 }	(C00+1)	[0000]	B	10	12
+Vlan	P	2634	Wakarsat	X68A8BC-3	 	                Ph Ri Wa 		614	Zs	M0 V	{ -1 }	(97B+1)	[C717]	BCe	13	693
+Vlan	P	2636	Kakadan	X9C7000-F	 	                 Di Fl 		001	Zs	M2 V	{ -1 }	(700-3)	[0000]	B	8	-21
+Vlan	P	2637	Akon	X563510-3	 	                 Ni Pr 		203	Wild	K4 V M1 V	{ -3 }	(742+3)	[2261]	Bc	10	168
+Vlan	P	2640	Statia	X300000-D	 	                 Di Va 		010	Wild	M1 V	{ -1 }	(700+3)	[0000]	B	13	21
+Vlan	H	2713	Aanshi	XA8A000-5	 	                 Di Oc 		001	Wild	M3 V	{ -3 }	(C00+4)	[0000]	B	10	48
+Vlan	H	2716	Eriston	E69A000-4	 	                 Di Wa 		020	Wild	G7 V G8 V	{ -3 }	(300-1)	[0000]	B	14	-3
+Vlan	L	2721	Nodden	E774000-8	 	                  Di 		001	Zs	G6 V M0 V	{ -3 }	(800+1)	[0000]	B	12	8
+Vlan	L	2723	Klidon	X763877-2	 	                 Ph Ri 		610	Zs	K7 V	{ -1 }	(A72+2)	[9764]	BCe	4	280
+Vlan	L	2725	Duranus	X000000-C	 	                    As Va Di 		015	Zs	M1 V	{ -1 }	(B00-2)	[0000]	B	16	-22
+Vlan	L	2728	Depot	D594000-7	 	                    Di 		021	Zs	K6 V	{ -3 }	(800-3)	[0000]	B	13	-24
+Vlan	P	2732	Dnak'kritz	X582730-2	 	                 Ri 		104	Zs	G0 V M2 V	{ -1 }	(969-3)	[B642]	BC	7	-1458
+Vlan	P	2733	Jarmat	X310000-D	 	                 Di 		014	Zs	M0 V	{ -1 }	(800+1)	[0000]	B	9	8
+Vlan	P	2734	Rambant	X310000-C	 	                 Di 		004	Zs	F4 V K0 V	{ -1 }	(700-4)	[0000]	B	11	-28
+Vlan	P	2737	Kesali	X200000-E	 	                    Di Va 		003	Wild	M3 V	{ -1 }	(E00+1)	[0000]	B	6	14
+Vlan	P	2738	Tepmaa	X410000-D	 	                 Di 		023	Wild	M0 V	{ -1 }	(900+2)	[0000]	B	12	18
+Vlan	P	2739	Sg'aa	XAB5000-D	 	                 Di Fl 		013	Wild	K6 V M4 V	{ -1 }	(E00-1)	[0000]	B	11	-14
+Vlan	P	2740	P'ginzh	E554544-7	 	                  Ag Ni 		310	Wild	M2 V	{ -2 }	(744+2)	[5358]	BC	14	224
+Vlan	D	2804	Ongvaturr	D989746-3	 	                 Ri 		302	Wild	M3 V	{ -1 }	(969-3)	[6612]	BC	9	-1458
+Vlan	D	2806	Paval	X581000-5	 	                 Di 		024	Wild	M3 V	{ -3 }	(400+1)	[0000]	B	15	4
+Vlan	D	2808	Spinport	X575000-8	 	                  Di 		020	Wild	M2 V	{ -3 }	(E00-3)	[0000]	B	15	-42
+Vlan	H	2812	Alkhaas	X997000-6	 	                   Di 		033	Wild	M1 V M2 V	{ -3 }	(800+1)	[0000]	B	9	8
+Vlan	H	2815	Karmanidora	X310000-B	 	                 Di 		002	Wild	K4 V	{ -1 }	(700+1)	[0000]	B	9	7
+Vlan	H	2816	Faranidon	D656000-7	 	                  Di Ga 		010	Wild	M0 V	{ -3 }	(B00+3)	[0000]	B	12	33
+Vlan	H	2818	Tazaris	X9B4000-9	 	                 Di Fl 		002	Wild	M3 V	{ -2 }	(A00-2)	[0000]	B	12	-20
+Vlan	H	2820	Anzalits	XA9A000-7	 	                 Di Oc 		034	Wild	M3 V M7 V	{ -3 }	(400+3)	[0000]	B	16	12
+Vlan	L	2823	Tektras	X536000-9	 	                 Di 		001	Zs	M2 V M3 V	{ -2 }	(800-1)	[0000]	B	9	-8
+Vlan	L	2824	Jana	X300000-C	 	                    Di Va 		023	Zs	G6 V	{ -1 }	(G00+2)	[0000]	B	18	32
+Vlan	L	2825	Arron	X424000-9	 	          An        Di 		020	Wild	F3 V	{ -2 }	(600+1)	[0000]	B	9	6
+Vlan	L	2826	Zafron	X575000-3	 	                  Di 		035	Zs	F4 V	{ -3 }	(600-5)	[0000]	B	11	-30
+Vlan	L	2827	Hannipur	X100000-B	 	                   Di Va 		001	Zs	F4 IV M2 V	{ -1 }	(C00-1)	[0000]	B	11	-12
+Vlan	L	2829	Luukon	X577000-C	 	                   Di 		001	Zs	K3 V M1 V	{ -1 }	(C00+4)	[0000]	B	11	48
+Vlan	L	2830	Lezaneraz	X547000-6	 	                  Di 		002	Zs	M2 V	{ -3 }	(600+4)	[0000]	B	7	24
+Vlan	P	2831	Kiimzhal	E554435-7	 	                 Ni Pa 		401	Zs	M3 V M7 V	{ -3 }	(733-3)	[4165]	Bc	8	-189
+Vlan	P	2832	Telkaa	X635000-A	 	                 Di 		021	Zs	K3 V M2 V K3 V	{ -1 }	(A00+4)	[0000]	B	10	40
+Vlan	P	2836	Inushir	X989ABE-1	 	                  Hi 		323	Wild	K0 V	{ -1 }	(C96+4)	[A955]	BE	17	2592
+Vlan	P	2837	Piazza	E794000-3	 	                  Di 		022	Wild	K4 V M3 V	{ -3 }	(800+3)	[0000]	B	12	24
+Vlan	P	2839	Zombagu	X684777-1	 	           An          Ag Ri 		324	Wild	F7 V	{ 0 }	(962+2)	[6741]	BC	9	216
+Vlan	D	2905	Zupilak	X553000-7	 	                 Di Po 		034	Wild	K8 V	{ -3 }	(500+1)	[0000]	B	10	5
+Vlan	D	2907	Akkunat	E878000-8	 	                  Di 		001	Wild	K8 V M2 V	{ -3 }	(800-3)	[0000]	B	13	-24
+Vlan	D	2909	Goobsfol	X544000-7	 	                 Di 		023	Wild	M2 V	{ -3 }	(400+4)	[0000]	B	9	16
+Vlan	H	2911	Naalkin	X555000-3	 	                   Di 		001	Wild	K3 V M3 V	{ -3 }	(700-4)	[0000]	B	6	-28
+Vlan	H	2912	Damakho	X998000-8	 	                  Di 		023	Wild	M0 V	{ -3 }	(C00+1)	[0000]	B	8	12
+Vlan	H	2914	Mimere	X9B6000-D	 	                  Di Fl 		010	Wild	M1 V M2 V	{ -1 }	(C00-5)	[0000]	B	12	-60
+Vlan	H	2915	Lormiza	X435000-D	 	                 Di 		010	Wild	M0 V M6 V	{ -1 }	(900-1)	[0000]	B	12	-9
+Vlan	H	2916	Iizmarna	X427000-B	 	                 Di 		020	Wild	M3 V	{ -1 }	(800+2)	[0000]	B	12	16
+Vlan	H	2918	Beroni	E563789-6	 	                 Ri 		101	Wild	M1 V M5 V	{ -1 }	(967-1)	[5615]	BC	10	-378
+Vlan	H	2919	Alanidon	X554000-6	 	                  Di 		020	Wild	M0 V M1 V	{ -3 }	(600-1)	[0000]	B	6	-6
+Vlan	H	2920	Sidenis	X310000-8	 	                  Di 		020	Wild	K8 V M1 V	{ -3 }	(A00-5)	[0000]	B	15	-50
+Vlan	L	2921	Iton	XAA7000-9	 	                  Di Fl 		001	Wild	M1 V	{ -2 }	(800+1)	[0000]	B	10	8
+Vlan	L	2923	Zircon	E571000-6	 	                 Di He 		010	Zs	M0 V M6 V	{ -3 }	(300-1)	[0000]	B	7	-3
+Vlan	L	2925	Kaanpush	X430000-D	 	                 De Di Po 		020	Zs	M2 V	{ -1 }	(800-4)	[0000]	B	10	-32
+Vlan	L	2926	Sanderson	X9C4000-D	 	                 Di Fl 		020	Zs	K9 V	{ -1 }	(A00+1)	[0000]	B	9	10
+Vlan	P	2931	Icuspin	X200000-F	 	                    Di Va 		020	Wild	M2 V	{ -1 }	(D00+1)	[0000]	B	13	13
+Vlan	P	2932	Zanski	X585454-4	 	                  Ni Pa 		821	Zs	M3 V	{ -3 }	(731-2)	[4146]	Bc	12	-42
+Vlan	P	2933	Kanat	X567000-3	 	                 Di 		013	Zs	M2 V	{ -3 }	(500+4)	[0000]	B	13	20
+Vlan	P	2934	Assazak	E590000-5	 	                      De He Di 		001	Wild	M1 V	{ -3 }	(A00+1)	[0000]	B	11	10
+Vlan	P	2936	Elafdt	X200000-8	 	                 Di Va 		001	Wild	G0 V K9 V M0 V	{ -3 }	(600-4)	[0000]	B	5	-24
+Vlan	P	2938	Punnari	X737000-D	 	          RsA        Di 		001	Wild	M2 V M5 V	{ -1 }	(600-3)	[0000]	B	13	-18
+Vlan	P	2939	Teralvar	X585000-2	 	                    Di 		001	Wild	G3 V M8 V	{ -3 }	(700+1)	[0000]	B	7	7
+Vlan	D	3002	Ksuerrgh	X427000-8	 	                   Di 		014	Wild	M1 V	{ -3 }	(F00-1)	[0000]	B	16	-15
+Vlan	D	3003	Khughfudz	X999000-7	 	                  Di 		020	Wild	M2 V	{ -3 }	(700-3)	[0000]	B	12	-21
+Vlan	D	3004	Shupin	X511000-B	 	                 Di Ic 		034	Wild	M1 V	{ -1 }	(C00+1)	[0000]	B	17	12
+Vlan	D	3006	Mukata	X310000-E	 	                  Di 		001	Wild	F0 V M3 V	{ -1 }	(700+2)	[0000]	B	6	14
+Vlan	D	3008	Shishaldin	X420000-9	 	                     De He Di Po 		003	Wild	M0 V	{ -2 }	(B00+3)	[0000]	B	12	33
+Vlan	H	3011	Lourer	X594733-2	 	                    Ag Pi 		410	Wild	M3 V M8 V	{ -1 }	(C66+2)	[9644]	BCD	12	864
+Vlan	H	3014	Zaan	X557442-3	 	                  Ni Pa 		204	Wild	G5 V	{ -3 }	(632+3)	[7181]	Bc	7	108
+Vlan	H	3018	Sikal	D545000-5	 	                  Di 		010	Wild	M1 V M1 V	{ -3 }	(800-2)	[0000]	B	11	-16
+Vlan	H	3019	Braldini	E897799-6	 	                    Ag Pi 		220	Wild	M2 V M6 V	{ -1 }	(964+1)	[B666]	BCD	10	216
+Vlan	H	3020	Trilorn	X100000-C	 	                   Di Va 		010	Wild	K3 V M5 V	{ -1 }	(B00-2)	[0000]	B	11	-22
+Vlan	L	3021	Talama	X410000-A	 	                  Di 		002	Wild	M3 V M8 V	{ -1 }	(A00+2)	[0000]	B	7	20
+Vlan	L	3022	Arklin	X9CA000-E	 	                 Di Fl 		034	Wild	M3 III	{ -1 }	(C00+2)	[0000]	B	12	24
+Vlan	L	3024	Bertrand	X200000-7	 	                   Di Va 		013	Wild	M1 V	{ -3 }	(800-2)	[0000]	B	9	-16
+Vlan	L	3025	Shervan	X545775-2	 	                     Ag Pi 		324	Zs	G2 V K6 V	{ -1 }	(96A-2)	[6666]	BCD	10	-1080
+Vlan	L	3029	Kamolad	X8D8000-B	 	                 Di 		001	Zs	G4 V M4 V M1 V	{ -1 }	(600-2)	[0000]	B	12	-12
+Vlan	P	3031	New Salen	X202000-C	 	                      Di Ic Va 		020	Wild	M2 V	{ -1 }	(D00+1)	[0000]	B	13	13
+Vlan	P	3032	Matuyama	X540000-8	 	                     De He Di Po 		023	Zs	G0 V M0 V	{ -3 }	(F00-3)	[0000]	B	8	-45
+Vlan	P	3035	Zhanora	X651611-2	 	                Ni Po 		801	Wild	G2 V M3 V	{ -3 }	(950+1)	[4391]	B	7	45
+Vlan	P	3037	Raanbazziil	X428000-E	 	                 Di 		010	Wild	M0 V	{ -1 }	(600+2)	[0000]	B	10	12
+Vlan	P	3039	Gilnat Paz	X535000-E	 	                 Di 		021	Wild	M1 V	{ -1 }	(800-2)	[0000]	B	11	-16
+Vlan	D	3106	Arga	X300000-C	 	                   Di Va 		010	Wild	M1 V M8 V	{ -1 }	(C00-3)	[0000]	B	8	-36
+Vlan	D	3107	Theton	XABA000-C	 	                  Di Fl 		010	Wild	K1 V M0 V	{ -1 }	(900-5)	[0000]	B	4	-45
+Vlan	H	3111	Kalanuu	X754000-6	 	                  Di 		024	Wild	M1 V	{ -3 }	(700-1)	[0000]	B	9	-7
+Vlan	H	3115	Dusuureg	X404000-B	 	                     Di Ic Va 		022	Wild	F9 V K6 V	{ -1 }	(A00-2)	[0000]	B	10	-20
+Vlan	H	3116	Kirlasesh	E546000-8	 	                  Di 		023	Wild	G5 V	{ -3 }	(D00+3)	[0000]	B	8	39
+Vlan	H	3117	Altman	X561644-1	 	                 Ni Ri 		210	Wild	K6 V	{ -2 }	(850-1)	[6421]	BC	4	-40
+Vlan	H	3119	Aarkhiin	X577000-5	 	                   Di 		025	Wild	M1 V	{ -3 }	(800+1)	[0000]	B	13	8
+Vlan	L	3122	Ekum	X560000-6	 	                   De Di 		024	Wild	G6 V M9 V	{ -3 }	(800-2)	[0000]	B	9	-16
+Vlan	L	3124	Thaar	X87A000-5	 	                 Di Wa 		002	Wild	M1 V M6 V	{ -3 }	(900-1)	[0000]	B	7	-9
+Vlan	L	3125	Inandir	D67687A-6	S	                    Pa Pi Ph 		211	Wild	K9 V M0 V	{ -2 }	(C78-5)	[8628]	BcDe	11	-3360
+Vlan	L	3126	Renbad	E568578-5	 	                    Ag Pr Ni 		310	Wild	K9 V	{ -2 }	(740+1)	[33A9]	BcC	13	28
+Vlan	L	3128	Xantril	X676000-7	 	                  Di 		020	Zs	M3 V	{ -3 }	(800+2)	[0000]	B	9	16
+Vlan	L	3129	Wimorel	E765499-6	 	      An  (Kolzar)            Ga Ni Pa 		924	Zs	F6 V	{ -3 }	(730-1)	[1155]	Bc	13	-21
+Vlan	L	3130	Gamidan	EA5A000-5	 	                 Di Oc 		012	Zs	G1 V M1 V	{ -3 }	(600-2)	[0000]	B	15	-12
+Vlan	P	3131	Maamibrin	C562649-8	 	                  Ni Ri 		720	Zs	F7 V	{ -1 }	(D55+2)	[7539]	BC	13	650
+Vlan	P	3134	Toborit	X424000-8	 	                  Di 		022	Wild	M2 V	{ -3 }	(C00+1)	[0000]	B	10	12
+Vlan	P	3135	Debekov	X572000-4	 	                 Di He 		001	Wild	M2 V	{ -3 }	(500+3)	[0000]	B	11	15
+Vlan	P	3137	Alleman	X200000-F	 	                 Di Va 		002	Wild	K6 III K1 V	{ -1 }	(900+1)	[0000]	B	13	9
+Vlan	P	3138	Nasaa	X425000-9	 	                 Di 		020	Wild	G8 V	{ -2 }	(900-2)	[0000]	B	13	-18
+Vlan	P	3140	Zana	X653000-4	 	                 Di Po 		010	Wild	K0 V M2 V	{ -3 }	(700+1)	[0000]	B	8	7
+Vlan	D	3201	Thoegzknaedz	D676000-2	 	                  Di 		003	Wild	M2 V	{ -3 }	(700-1)	[0000]	B	7	-7
+Vlan	D	3202	Vutsarrgh	X66599A-1	 	                 Ga Hi Pr 		420	Wild	M0 V M8 V	{ -1 }	(B89-1)	[B831]	BcE	9	-792
+Vlan	D	3206	Argonos	X89A000-5	 	        (minor)          Di Wa 		020	Wild	M0 V	{ -3 }	(400+1)	[0000]	B	7	4
+Vlan	D	3208	Sardia	X436000-A	 	                 Di 		033	Wild	K6 V	{ -1 }	(D00+2)	[0000]	B	11	26
+Vlan	D	3209	Veppim	X684556-4	 	                    Ag Pr Ni 		404	Wild	M2 V	{ -2 }	(743-2)	[7387]	BcC	11	-168
+Vlan	D	3210	Tasho	X425000-A	 	                 Di 		022	Wild	K1 IV	{ -1 }	(900-3)	[0000]	B	13	-27
+Vlan	H	3211	Urkimgar	X577000-6	 	                  Di 		010	Wild	M1 V	{ -3 }	(600-4)	[0000]	B	11	-24
+Vlan	H	3212	Amnukun	X410000-E	 	                   Di 		011	Wild	M1 V	{ -1 }	(D00-1)	[0000]	B	12	-13
+Vlan	H	3213	Ami	X567000-5	 	                   Di 		002	Wild	M1 V M3 V	{ -3 }	(700-1)	[0000]	B	15	-7
+Vlan	H	3214	Khunimmam	X9B7000-8	 	                 Di Fl 		002	Wild	M2 V	{ -3 }	(600+3)	[0000]	B	13	18
+Vlan	H	3215	Shaia	X64A000-1	 	                  Di Wa 		010	Wild	M1 V	{ -3 }	(B00-2)	[0000]	B	12	-22
+Vlan	H	3216	Kigirgam	X561000-5	 	                 Di 		013	Wild	M1 V	{ -3 }	(600+1)	[0000]	B	13	6
+Vlan	H	3218	Gisharu	X556415-2	 	                 Ni Pa 		810	Wild	M1 V M7 V	{ -3 }	(730+2)	[4151]	Bc	8	42
+Vlan	L	3221	Sadkha	X836000-C	 	                 Di 		021	Wild	G6 V	{ -1 }	(800-1)	[0000]	B	15	-8
+Vlan	L	3222	Nemsa	X300000-A	 	                 Di Va 		020	Wild	F5 V M1 V	{ -1 }	(700+5)	[0000]	B	10	35
+Vlan	L	3224	Anakod	X796000-2	 	          An        Di 		024	Wild	F7 V	{ -3 }	(400+5)	[0000]	B	13	20
+Vlan	L	3226	Eshdigi	X747000-4	 	                  Di 		023	Wild	K2 V K4 V	{ -3 }	(500-1)	[0000]	B	17	-5
+Vlan	L	3228	Nirnalur	D544000-5	 	                  Di 		023	Wild	G3 V	{ -3 }	(600+1)	[0000]	B	9	6
+Vlan	L	3229	Diikaras	XA9A000-2	 	                 Di Oc 		002	Wild	M2 V	{ -3 }	(800-1)	[0000]	B	9	-8
+Vlan	P	3231	Vanutappan	X547000-4	 	                  Di 		024	Wild	F7 V M9 V	{ -3 }	(700+3)	[0000]	B	14	21
+Vlan	P	3232	Tamayo	X779000-3	 	                  Di 		001	Wild	G6 V M0 V M6 V	{ -3 }	(700-4)	[0000]	B	11	-28
+Vlan	P	3235	Debort	X581737-2	 	                 Ri 		410	Wild	F9 V G4 V	{ -1 }	(968-1)	[3644]	BC	14	-432
+Vlan	P	3237	Zhannag	X534000-A	 	                 Di 		034	Wild	G8 V	{ -1 }	(C00-2)	[0000]	B	13	-24
+Vlan	P	3238	Lamiina	X768000-3	 	                 Di 		013	Wild	K0 V K1 V	{ -3 }	(500-2)	[0000]	B	12	-10
+Vlan	P	3239	Lannazol	X845000-6	 	                 Di 		001	Wild	M3 V	{ -3 }	(300-1)	[0000]	B	12	-3

--- a/res/Sectors/M1900/Vland.xml
+++ b/res/Sectors/M1900/Vland.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<Sector Abbreviation="Vlan" Tags="Unreviewed">
+  <Y>-1</Y>
+  <X>-1</X>
+  <Name>Vland</Name>
+  <Credits>
+    <![CDATA[
+
+             <b>Vland</b> sector was designed by Marc W. Miller and
+             appears in <cite>Atlas of the Imperium</cite> (GDW,
+             1984).
+
+             It was refined by Joe D. Fugate Sr. and appears in
+             <cite>The Travellers Digest</cite> and <cite>The
+             MegaTraveller Alien, Volume 1: Vilani &amp; Vargr</cite>
+             (DGP, 1990)
+
+    ]]>
+  </Credits>
+  <DataFile Source="Zhodani Base" Milieu="M1201" Type="TabDelimited">Vland.tab</DataFile>
+  <Subsectors Source="Vilani and Vargr">
+    <Subsector Index="A">?</Subsector>
+    <Subsector Index="B">?</Subsector>
+    <Subsector Index="C">?</Subsector>
+    <Subsector Index="D">?</Subsector>
+    <Subsector Index="E">?</Subsector>
+    <Subsector Index="F">?</Subsector>
+    <Subsector Index="G">Vland</Subsector>
+    <Subsector Index="H">?</Subsector>
+    <Subsector Index="I">?</Subsector>
+    <Subsector Index="J">?</Subsector>
+    <Subsector Index="K">?</Subsector>
+    <Subsector Index="L">?</Subsector>
+    <Subsector Index="M">?</Subsector>
+    <Subsector Index="N">?</Subsector>
+    <Subsector Index="O">?</Subsector>
+    <Subsector Index="P">?</Subsector>
+  </Subsectors>
+
+  <Allegiances>
+    <Allegiance Code="Zs">Ziru Sirkaa</Allegiance>
+    <Allegiance Code="Wi">Wilds</Allegiance>
+  </Allegiances>
+
+  <Stylesheet>
+    border.Zu { color: lightblue; }
+    route.Zu { color: lightgreen; }
+  </Stylesheet>
+
+    <Borders>
+    <Border Color="Orange" Allegiance="Wild" Label="Wilds">0000 0100 0200 0300 0400 0500 0600 0700 0800 0900 1000 1100 1200 1300 1400 1500 1600 1700 1800 1900 2000 2100 2200 2300 2400 2500 2600 2700 2800 2900 3000 3100 3200 3301 3302 3303 3304 3305 3306 3307 3308 3309 3310 3311 3312 3313 3314 3315 3316 3317 3318 3319 3320 3321 3322 3323 3324 3325 3326 3327 3328 3329 3330 3331 3332 3333 3334 3335 3336 3337 3338 3339 3340 3341 3241 3141 3041 2941 2841 2741 2641 2541 2441 2341 2241 2141 2041 1941 1841 1741 1641 1541 1441 1341 1241 1141 1041 0941 0841 0741 0641 0541 0441 0341 0241 0141 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030 0131 0132 0232 0233 0234 0235 0236 0237 0238 0239 0340 0439 0539 0638 0738 0837 0937 1036 1136 1235 1335 1434 1433 1432 1533 1632 1733 1833 1934 2033 2133 2233 2234 2335 2336 2436 2537 2637 2737 2836 2936 2935 2934 3033 3133 3232 3231 3230 3229 3228 3227 3226 3126 3125 3024 3023 3022 3021 2921 2820 2720 2620 2619 2618 2518 2517 2516 2515 2514 2513 2512 2511 2410 2310 2209 2109 2008 1908 1807 1708 1607 1508 1509 1409 1410 1311 1312 1313 1314 1414 1315 1316 1317 1318 1319 1320 1321 1322 1323 1222 1123 1023 0924 0923 0922 0921 1020 1120 1119 1118 1117 1116 1115 1114 1113 1012 0912 0811 0711 0610 0510 0410 0311 0211 0112 0012 0011 0010 0009 0008 0007 0006 0005 0004 0003 0002 0001 0000 </Border>
+    <Border Color="Orange" Allegiance="Wild" Label="Wilds">1820 1821 1822 1923 1822 1821 1820 </Border>
+    <Border Color="Orange" Allegiance="Wild" Label="Wilds">2931 3031 2931 </Border>
+    <Border Color="Green"  Allegiance="Zs"   Label="Ziru Sirka">0333 0432 0431 0430 0530 0630 0730 0829 0929 0928 0927 1027 1128 1227 1327 1426 1526 1625 1624 1623 1523 1522 1521 1520 1519 1518 1417 1517 1516 1515 1514 1513 1412 1512 1611 1610 1609 1608 1709 1809 1909 2009 2110 2210 2211 2312 2412 2413 2414 2415 2416 2417 2418 2519 2520 2521 2621 2721 2722 2822 2923 2924 2925 3025 3026 3027 3128 3129 3130 3131 3132 3032 2933 2833 2734 2634 2635 2636 2536 2435 2434 2433 2333 2232 2132 2032 1933 1832 1732 1631 1531 1431 1332 1333 1334 1234 1135 1035 0936 0836 0737 0637 0537 0437 0338 0337 0336 0335 0334 0333 </Border>
+    <Border Color="Green"  Allegiance="Zs"   Label="Ziru Sirka">0422 0522 0621 0620 0619 0620 0621 0622 0522 0422 </Border>
+  </Borders>
+
+</Sector>

--- a/res/Sectors/M1900/m1900.xml
+++ b/res/Sectors/M1900/m1900.xml
@@ -32,4 +32,12 @@
     <DataFile Author="Robert Eaglestone" Type="TabDelimited">Dene.tab</DataFile>
     <MetadataFile>Dene.xml</MetadataFile>
   </Sector>
+  <Sector Abbreviation="Vlan" Selected="true" Milieu="M1900">
+    <Y>-1</Y>
+    <X>-1</X>
+    <Name>Vland</Name>
+    <DataFile Author="Robert Eaglestone" Type="TabDelimited">Vland.tab</DataFile>
+    <MetadataFile>Vland.xml</MetadataFile>
+  </Sector>
+
 </Sectors>


### PR DESCRIPTION
Started with t5ss data, generated 1201 data, then fast-forwarded through 1508 to 1900.

Built a proposed successor state to the Ziru Sirka.  No routes in the XML metafile.

Dieback causes TL linter errors; all other lint issues are resolved.

Added to m1900.xml.
