### PR TITLE
Update about.html link to point to main branch

### DIFF
--- a/doc/about.html
+++ b/doc/about.html
@@ -103,7 +103,7 @@
     <p>
       Substantial changes to the site, data and APIs are announced and discussed at <a target=_blank rel=noopener href="https://travellermap.blogspot.com/">the Traveller Map Blog</a>. Changes to the code can be found
       by looking at the
-      <a target=_blank rel=noopener href="https://github.com/inexorabletash/travellermap/commits/master">commits on GitHub</a>, or following the <a target=_blank rel=noopener href="https://dice.camp/@travellermap">@TravellerMap Mastodon feed</a>.
+      <a target=_blank rel=noopener href="https://github.com/inexorabletash/travellermap/commits/main">commits on GitHub</a>, or following the <a target=_blank rel=noopener href="https://dice.camp/@travellermap">@TravellerMap Mastodon feed</a>.
     </p>
     <p>
       A "Wish List", including known issues, can be found on the


### PR DESCRIPTION
It was pointing to the nonexistent "master" branch. I don't know why Github doesn't simply redirect to the repository in that case, but it 404s instead.