### PR TITLE
task: (1900) removed zones from Vilis subsector

### DIFF
--- a/res/Sectors/M1900/Spin.tab
+++ b/res/Sectors/M1900/Spin.tab
@@ -145,9 +145,9 @@ Spin	N	1138	Tarsus	D584000-A	 	Di 		002	Wild	K9 V	{ -1 }	(A00+1)	[0000]	B	7	10
 Spin	B	1201	Ao-dai	E410673-7	 	Na Ni 		312	Wild	K2 V M3 V	{ -3 }	(853+3)	[3387]	B	10	360
 Spin	B	1204	Mongo	A5686BD-A	N 	Ag Ri Ni 		503	Wild	M6 III M0 V	{ 3 }	(B58+1)	[191D]	BC	7	440
 Spin	B	1209	Utoland	C573452-8	 	Ni 		410	NaHu	M0 V	{ -2 }	(732-4)	[4237]	B	8	-168
-Spin	B	1210	Pequan	E565677-4	 	Ag Ri Ni 	A	710	NaHu	K5 V	{ -1 }	(854+1)	[4551]	BC	5	160
+Spin	B	1210	Pequan	E565677-4	 	Ag Ri Ni 		710	NaHu	K5 V	{ -1 }	(854+1)	[4551]	BC	5	160
 Spin	F	1212	Digitis	E536745-6	 			120	NaHu	M3 V	{ -2 }	(866-2)	[6583]	B	8	-576
-Spin	F	1213	Edinina	E400212-7	 	Lo Va 	A	401	CsIm	K6 V M0 V	{ -3 }	(410-4)	[3153]	B	6	-16
+Spin	F	1213	Edinina	E400212-7	 	Lo Va 		401	CsIm	K6 V M0 V	{ -3 }	(410-4)	[3153]	B	6	-16
 Spin	F	1214	728-907	E955000-0	 	Ba 		010	Na	F1 V M2 V	{ -3 }	(200+1)	[0000]	B	10	2
 Spin	F	1216	Stellatio	D5A4448-8	 	Fl Ni Px 		210	Na	M3 V	{ -3 }	(730-5)	[215A]	B	14	-105
 Spin	F	1217	Arkadia	E546875-6	 	Pa Pi Ph 		302	Na	G8 V	{ -2 }	(A75+1)	[764A]	BcDe	7	350
@@ -184,9 +184,9 @@ Spin	N	1434	Tarkine	E566000-7	 	Di 		010	Wild	M0 V M2 V	{ -3 }	(800+5)	[0000]	B	
 Spin	N	1435	Dallia	B8858A9-9	 	Ga Pa Ri Ph 		310	Wild	F2 V	{ 2 }	(B7D+1)	[8A97]	BcCe	9	1001
 Spin	N	1436	Talos	E433000-9	 	Di Po 		020	Wild	F9 V M1 V	{ -2 }	(900-1)	[0000]	B	9	-9
 Spin	B	1510	Lee	E722000-0	 	Ba He Po 		001	NaXX	M3 V M8 V	{ -3 }	(200-4)	[0000]	B	7	-8
-Spin	F	1511	Tionale	C674375-8	 	(minor) Lo 	A	810	CsIm	M2 V M5 V	{ -2 }	(620+1)	[4127]	B	11	12
+Spin	F	1511	Tionale	C674375-8	 	(minor) Lo 		810	CsIm	M2 V M5 V	{ -2 }	(620+1)	[4127]	B	11	12
 Spin	F	1515	Calit	C434877-7	 	(Llellewyloly)2 Ph 		701	Na	K9 V M1 V	{ -1 }	(A76+1)	[7749]	Be	4	420
-Spin	F	1519	Asgard	X54379B-5	 	Pi Po 	R	420	Na	F5 V M1 V	{ -2 }	(964+1)	[A556]	BD	13	216
+Spin	F	1519	Asgard	X54379B-5	 	Pi Po 		420	Na	F5 V M1 V	{ -2 }	(964+1)	[A556]	BD	13	216
 Spin	F	1520	Tavonni	E567000-0	 	Ba 		034	Na	G6 V	{ -3 }	(200+3)	[0000]	B	10	6
 Spin	J	1522	Dyrnwyn	B958838-A	 	Pa Ph 		201	Na	K4 V M8 V	{ 2 }	(B7A+5)	[8A88]	Bce	7	3850
 Spin	J	1523	Durendal	B687778-B	 	Ag Ri Ga 		514	Na	M1 V	{ 4 }	(E69+1)	[BB46]	BCf	11	756


### PR DESCRIPTION
There were still a few Amber and Red zones leftover from 1105 data. 