### PR TITLE
Fix stellar data in Undeveloped Sectors , round 1

### DIFF
--- a/res/Sectors/M1105/VegVergakh.sec
+++ b/res/Sectors/M1105/VegVergakh.sec
@@ -14,100 +14,100 @@ Veg Vergakh
 .             0601 X598000-0    Ba Lo Ni           002 --     G5V 
 .             0901 X563000-0    Ba Lo Ni           010 --     G8V 
 .             1001 X541000-0    Ba Lo Ni Po        002 --     F7V 
-.             1501 X140000-0    Ba De Lo Ni Po     012 --     F3V M6D 
-.             1601 X8D5000-0    Ba Fl Lo Ni        004 --     M1V M1D 
+.             1501 X140000-0    Ba De Lo Ni Po     012 --     F3V M6V
+.             1601 X8D5000-0    Ba Fl Lo Ni        004 --     M1V M1V
 .             1701 X755000-0    Ba Lo Ni           013 --     F1V 
 .             1801 XA9A000-0    Ba Lo Ni Wa        000 --     F9V 
-.             2001 X687000-0    Ba Lo Ni           004 --     F9V M1D M2D 
+.             2001 X687000-0    Ba Lo Ni           004 --     F9V M1V M2V
 .             2201 X352000-0    Ba Lo Ni Po        004 --     F0V 
-.             2601 X976000-0    Ba Lo Ni           017 --     F6V M4D 
+.             2601 X976000-0    Ba Lo Ni           017 --     F6V M4V
 .             3101 X7A7000-0    Ba Fl Lo Ni        021 --     M8V 
 .             0502 X783000-0    Ba Lo Ni           012 --     F7V 
 .             0702 X88A000-0    Ba Lo Ni Wa        004 --     G1V 
-.             1002 X564000-0    Ba Lo Ni           004 --     M8V M1D 
+.             1002 X564000-0    Ba Lo Ni           004 --     M1V M8V
 .             2002 X594000-0    Ba Lo Ni           010 --     F5V 
-.             2102 X69A000-0    Ba Lo Ni Wa        014 --     F4V M0D F2V 
-.             2602 X402000-0    Ba Ic Lo Ni Va     001 --     M5V M2D M6D 
+.             2102 X69A000-0    Ba Lo Ni Wa        014 --     F2V M0V F4V
+.             2602 X402000-0    Ba Ic Lo Ni Va     001 --     M2V M5V M6V
 .             2902 X9A5000-0    Ba Fl Lo Ni        013 --     M4V 
-.             0403 X759000-0    Ba Lo Ni           003 --     F6V M2D 
+.             0403 X759000-0    Ba Lo Ni           003 --     F6V M2V
 .             0703 X5A2000-0    Ba Fl Lo Ni        002 --     M4V 
 .             1503 X411000-0    Ba Ic Lo Ni        000 --     A2V 
 .             2103 X274000-0    Ba Lo Ni           004 --     K8V 
 .             2503 X421000-0    Ba Lo Ni Po        003 --     M4V 
-.             0604 X955000-0    Ba Lo Ni           015 --     F9V M4D 
-.             0804 X767000-0    Ba Lo Ni           013 --     F1V M1D 
+.             0604 X955000-0    Ba Lo Ni           015 --     F9V M4V
+.             0804 X767000-0    Ba Lo Ni           013 --     F1V M1V
 .             1004 X7A0000-0    Ba De Lo Ni        015 --     G0V 
 .             1504 X783000-0    Ba Lo Ni           002 --     F4V 
 .             1804 X656000-0    Ba Lo Ni           004 --     F1V 
 .             2004 X688000-0    Ba Lo Ni           000 --     F2V 
 .             2504 X9B4000-0    Ba Fl Lo Ni        004 --     M2V 
-.             0105 X7A7000-0    Ba Fl Lo Ni        003 --     M6V M8D 
+.             0105 X7A7000-0    Ba Fl Lo Ni        003 --     M6V M8V
 .             0205 X000000-0    As Ba Lo Ni        002 --     K9V 
-.             0505 X647000-0    Ba Lo Ni           033 --     F9V M3D 
-.             0705 X766000-0    Ba Lo Ni           021 --     F8V M5D 
+.             0505 X647000-0    Ba Lo Ni           033 --     F9V M3V
+.             0705 X766000-0    Ba Lo Ni           021 --     F8V M5V
 .             1905 X000000-0    As Ba Lo Ni        002 --     K5V 
 .             2005 X511000-0    Ba Ic Lo Ni        001 --     M3V 
-.             2305 X160000-0    Ba De Lo Ni        002 --     F3V M0D 
+.             2305 X160000-0    Ba De Lo Ni        002 --     F3V M0V
 .             2505 X000000-0    As Ba Lo Ni        000 --     M5V 
 .             2805 X565000-0    Ba Lo Ni           022 --     G2V 
-.             2905 X333000-0    Ba Lo Ni Po        005 --     M1V M6D 
-.             0106 X434000-0    Ba Lo Ni           014 --     M1II M0V 
-.             0306 X87A000-0    Ba Lo Ni Wa        034 --     F6V M8D 
-.             0406 X6A7000-0    Ba Fl Lo Ni        004 --     M2V M3V 
-.             0506 X539000-0    Ba Lo Ni           002 --     F4V M1V 
+.             2905 X333000-0    Ba Lo Ni Po        005 --     M1V M6V
+.             0106 X434000-0    Ba Lo Ni           014 --     M1II M0V
+.             0306 X87A000-0    Ba Lo Ni Wa        034 --     F6V M8V
+.             0406 X6A7000-0    Ba Fl Lo Ni        004 --     M2V M3V
+.             0506 X539000-0    Ba Lo Ni           002 --     F4V M1V
 .             0706 X875000-0    Ba Lo Ni           011 --     F2V 
 .             0906 X83A000-0    Ba Lo Ni Wa        004 --     M8V 
-.             1206 X528000-0    Ba Lo Ni           003 --     M0V M1D 
-.             1406 X546000-0    Ba Lo Ni           005 --     F4V M1D F3V M4D 
-.             1806 X668000-0    Ba Lo Ni           006 --     K6V M7D 
+.             1206 X528000-0    Ba Lo Ni           003 --     M0V M1V
+.             1406 X546000-0    Ba Lo Ni           005 --     F3V M1V F4V M4V
+.             1806 X668000-0    Ba Lo Ni           006 --     K6V M7V
 .             1906 X79A000-0    Ba Lo Ni Wa        014 --     K2V 
-.             2106 X353000-0    Ba Lo Ni Po        000 --     F5V M5D 
-.             2306 X774000-0    Ba Lo Ni           002 --     F9V M3D 
+.             2106 X353000-0    Ba Lo Ni Po        000 --     F5V M5V
+.             2306 X774000-0    Ba Lo Ni           002 --     F9V M3V
 .             2406 X62A000-0    Ba Lo Ni Wa        000 --     K2IV 
-.             3006 X533000-0    Ba Lo Ni Po        000 --     M8V M3D 
+.             3006 X533000-0    Ba Lo Ni Po        000 --     M3V M8V
 .             3106 X463000-0    Ba Lo Ni           030 --     F0V 
-.             0107 X140000-0    Ba De Lo Ni Po     005 --     F4V M3D 
-.             0207 X659000-0    Ba Lo Ni           002 --     M6V M4D 
+.             0107 X140000-0    Ba De Lo Ni Po     005 --     F4V M3V
+.             0207 X659000-0    Ba Lo Ni           002 --     M4V M6V
 .             0607 X533000-0    Ba Lo Ni Po        000 --     M4V 
 .             2907 X400000-0    Ba Lo Ni Va        004 --     M6V 
 .             0108 X000000-0    As Ba Lo Ni        001 --     M4V 
-.             0308 X669000-0    Ba Lo Ni           028 --     F2V F1V 
+.             0308 X669000-0    Ba Lo Ni           028 --     F1V F2V
 .             1208 XAD4000-0    Ba Fl Lo Ni        001 --     M8V 
 .             1708 X300000-0    Ba Lo Ni Va        010 --     F7V 
 .             1808 X545000-0    Ba Lo Ni           002 --     F6V 
 .             1908 X595000-0    Ba Lo Ni           003 --     M8V 
-.             2008 X310000-0    Ba Lo Ni           005 --     K8V M1D 
-.             2508 X526000-0    Ba Lo Ni           026 --     F2V M0D M8D 
-.             2608 X894000-0    Ba Lo Ni           016 --     F5V M3D 
+.             2008 X310000-0    Ba Lo Ni           005 --     K8V M1V
+.             2508 X526000-0    Ba Lo Ni           026 --     F2V M0V M8V
+.             2608 X894000-0    Ba Lo Ni           016 --     F5V M3V
 .             2808 X300000-0    Ba Lo Ni Va        023 --     F8V 
 .             3008 X337000-0    Ba Lo Ni           001 --     M4V 
 .             3108 X312000-0    Ba Ic Lo Ni        004 --     M4V 
-.             0109 X223000-0    Ba Lo Ni Po        002 --     M3V M1V 
+.             0109 X223000-0    Ba Lo Ni Po        002 --     M3V M1V
 .             0809 X447000-0    Ba Lo Ni           021 --     F6V 
 .             0909 X796000-0    Ba Lo Ni           010 --     F2V 
 .             1509 X88A000-0    Ba Lo Ni Wa        002 --     M8V 
 .             1609 X244000-0    Ba Lo Ni           010 --     F5V 
 .             2409 X899000-0    Ba Lo Ni           005 --     K2V 
 .             2609 X225000-0    Ba Lo Ni           003 --     F6V 
-.             3109 X200000-0    Ba Lo Ni Va        004 --     K9V M3D 
+.             3109 X200000-0    Ba Lo Ni Va        004 --     K9V M3V
 .             0210 X737000-0    Ba Lo Ni           001 --     F3V 
 .             0410 X300000-0    Ba Lo Ni Va        011 --     M4V 
-.             0510 X200000-0    Ba Lo Ni Va        014 --     G0V M2D 
-.             0610 X664000-0    Ba Lo Ni           006 --     F8V M3D 
+.             0510 X200000-0    Ba Lo Ni Va        014 --     G0V M2V
+.             0610 X664000-0    Ba Lo Ni           006 --     F8V M3V
 .             0810 X786000-0    Ba Lo Ni           003 --     F0V 
 .             1110 X949000-0    Ba Lo Ni           010 --     F7V 
 .             1310 X200000-0    Ba Lo Ni Va        011 --     G4V 
 .             1710 X767000-0    Ba Lo Ni           000 --     F3V 
-.             2610 X546000-0    Ba Lo Ni           024 --     F2V M5V 
-.             2710 X120000-0    Ba De Lo Ni Po     000 --     K8V M5D 
-.             0611 X478000-0    Ba Lo Ni           004 --     G4V M1D 
+.             2610 X546000-0    Ba Lo Ni           024 --     F2V M5V
+.             2710 X120000-0    Ba De Lo Ni Po     000 --     K8V M5V
+.             0611 X478000-0    Ba Lo Ni           004 --     G4V M1V
 .             0711 X596000-0    Ba Lo Ni           000 --     F8V 
 .             0811 X200000-0    Ba Lo Ni Va        002 --     M3V 
 .             0911 X9E1000-0    Ba Fl Lo Ni        010 --     F1IV 
 .             1211 X433000-0    Ba Lo Ni Po        002 --     F3V 
-.             1311 X352000-0    Ba Lo Ni Po        014 --     M6V M7D 
+.             1311 X352000-0    Ba Lo Ni Po        014 --     M6V M7V
 .             1511 X200000-0    Ba Lo Ni Va        002 --     G3V 
-.             1911 X373000-0    Ba Lo Ni           016 --     F3V M0D 
+.             1911 X373000-0    Ba Lo Ni           016 --     F3V M0V
 .             2011 X426000-0    Ba Lo Ni           002 --     G1V 
 .             2411 X755000-0    Ba Lo Ni           001 --     K4V 
 .             2611 X322000-0    Ba Lo Ni Po        003 --     K2III 
@@ -116,32 +116,32 @@ Veg Vergakh
 .             3111 X301000-0    Ba Ic Lo Ni Va     013 --     M8V 
 .             3211 X55A000-0    Ba Lo Ni Wa        000 --     F6V 
 .             0112 X233000-0    Ba Lo Ni Po        000 --     M5V 
-.             0312 X738000-0    Ba Lo Ni           003 --     M1V M6D 
-.             0412 X404000-0    Ba Ic Lo Ni Va     013 --     K1V M1D 
-.             0512 X494000-0    Ba Lo Ni           004 --     K2V M3D 
-.             0612 X685000-0    Ba Lo Ni           003 --     F2V M1D 
+.             0312 X738000-0    Ba Lo Ni           003 --     M1V M6V
+.             0412 X404000-0    Ba Ic Lo Ni Va     013 --     K1V M1V
+.             0512 X494000-0    Ba Lo Ni           004 --     K2V M3V
+.             0612 X685000-0    Ba Lo Ni           003 --     F2V M1V
 .             0812 X664000-0    Ba Lo Ni           003 --     K5V 
-.             1012 X7A4000-0    Ba Fl Lo Ni        018 --     M7V M6V G2V K6D 
-.             1312 X883000-0    Ba Lo Ni           012 --     F5V M1D 
-.             1412 X9B5000-0    Ba Fl Lo Ni        000 --     K7V M7D 
-.             1612 X300000-0    Ba Lo Ni Va        005 --     G7IV M6V 
-.             1712 X683000-0    Ba Lo Ni           003 --     F9V M6D 
-.             2512 X454000-0    Ba Lo Ni           015 --     G9V M6D 
+.             1012 X7A4000-0    Ba Fl Lo Ni        018 --     G2V M6V M7V K6V
+.             1312 X883000-0    Ba Lo Ni           012 --     F5V M1V
+.             1412 X9B5000-0    Ba Fl Lo Ni        000 --     K7V M7V
+.             1612 X300000-0    Ba Lo Ni Va        005 --     G7IV M6V
+.             1712 X683000-0    Ba Lo Ni           003 --     F9V M6V
+.             2512 X454000-0    Ba Lo Ni           015 --     G9V M6V
 .             3212 X661000-0    Ba Lo Ni           001 --     F9V 
-.             0313 X140000-0    Ba De Lo Ni Po     005 --     F0V M5D 
+.             0313 X140000-0    Ba De Lo Ni Po     005 --     F0V M5V
 .             0413 X443000-0    Ba Lo Ni Po        000 --     F3V 
-.             0713 X484000-0    Ba Lo Ni           018 --     F6V M5D F5V 
+.             0713 X484000-0    Ba Lo Ni           018 --     F5V M5V F6V
 .             1313 X585000-0    Ba Lo Ni           011 --     F9V 
-.             1513 X542000-0    Ba Lo Ni Po        001 --     F2V M0D 
+.             1513 X542000-0    Ba Lo Ni Po        001 --     F2V M0V
 .             1713 X575000-0    Ba Lo Ni           024 --     F8V 
-.             1913 X979000-0    Ba Lo Ni           012 --     F4V M0D 
-.             2013 X7B1000-0    Ba Fl Lo Ni        002 --     G9V M0D 
-.             2913 X485000-0    Ba Lo Ni           010 --     F4V M4D 
+.             1913 X979000-0    Ba Lo Ni           012 --     F4V M0V
+.             2013 X7B1000-0    Ba Fl Lo Ni        002 --     G9V M0V
+.             2913 X485000-0    Ba Lo Ni           010 --     F4V M4V
 .             0314 X210000-0    Ba Lo Ni           014 --     F8V 
 .             0514 X548000-0    Ba Lo Ni           013 --     F5V 
 .             1014 X000000-0    As Ba Lo Ni        000 --     A3V 
-.             1214 X838000-0    Ba Lo Ni           002 --     M2V M8D 
-.             1914 X110000-0    Ba Lo Ni           010 --     M1V M4D 
+.             1214 X838000-0    Ba Lo Ni           002 --     M2V M8V
+.             1914 X110000-0    Ba Lo Ni           010 --     M1V M4V
 .             2414 X325000-0    Ba Lo Ni           000 --     K9V 
 .             3114 X130000-0    Ba De Lo Ni Po     003 --     F9V 
 .             0515 X434000-0    Ba Lo Ni           002 --     G4V 
@@ -152,97 +152,97 @@ Veg Vergakh
 .             1515 X644000-0    Ba Lo Ni           003 --     F8V 
 .             2215 X668000-0    Ba Lo Ni           014 --     F8V 
 .             0216 X100000-0    Ba Lo Ni Va        003 --     M5V 
-.             0316 X66A000-0    Ba Lo Ni Wa        013 --     K1V M3D 
-.             0616 X400000-0    Ba Lo Ni Va        023 --     M1V M6D 
-.             0716 X321000-0    Ba Lo Ni Po        013 --     F9V M3D 
-.             1216 X456000-0    Ba Lo Ni           002 --     F5V M1D 
+.             0316 X66A000-0    Ba Lo Ni Wa        013 --     K1V M3V
+.             0616 X400000-0    Ba Lo Ni Va        023 --     M1V M6V
+.             0716 X321000-0    Ba Lo Ni Po        013 --     F9V M3V
+.             1216 X456000-0    Ba Lo Ni           002 --     F5V M1V
 .             1316 X513000-0    Ba Ic Lo Ni        002 --     F1V 
 .             1416 X547000-0    Ba Lo Ni           011 --     F9V 
 .             1616 X795000-0    Ba Lo Ni           012 --     F8V 
 .             1716 X763000-0    Ba Lo Ni           011 --     F9V 
-.             2616 X767000-0    Ba Lo Ni           003 --     F5V M0D 
-.             1217 X73A000-0    Ba Lo Ni Wa        025 --     M6V M7D 
-.             1817 X9B7000-0    Ba Fl Lo Ni        004 --     M8V M7D 
-.             1917 X420000-0    Ba De Lo Ni Po     003 --     F2V M5V 
-.             2517 X976000-0    Ba Lo Ni           002 --     M3V M8D 
+.             2616 X767000-0    Ba Lo Ni           003 --     F5V M0V
+.             1217 X73A000-0    Ba Lo Ni Wa        025 --     M6V M7V
+.             1817 X9B7000-0    Ba Fl Lo Ni        004 --     M7V M8V
+.             1917 X420000-0    Ba De Lo Ni Po     003 --     F2V M5V
+.             2517 X976000-0    Ba Lo Ni           002 --     M3V M8V
 .             3217 X000000-0    As Ba Lo Ni        002 --     M3V 
 .             0318 X674000-0    Ba Lo Ni           014 --     M1V 
 .             0418 X130000-0    Ba De Lo Ni Po     001 --     M1V 
-.             1118 X725000-0    Ba Lo Ni           001 --     M0V M6D 
+.             1118 X725000-0    Ba Lo Ni           001 --     M0V M6V
 .             1218 X273000-0    Ba Lo Ni           003 --     F0V 
 .             1518 X985000-0    Ba Lo Ni           003 --     F6V 
-.             1718 X302000-0    Ba Ic Lo Ni Va     012 --     F1V M4V 
+.             1718 X302000-0    Ba Ic Lo Ni Va     012 --     F1V M4V
 .             1818 X200000-0    Ba Lo Ni Va        003 --     A5V 
 .             2318 X510000-0    Ba Lo Ni           000 --     A1V 
-.             0619 X8A5000-0    Ba Fl Lo Ni        004 --     F9V M0D 
+.             0619 X8A5000-0    Ba Fl Lo Ni        004 --     F9V M0V
 .             0719 XA5A000-0    Ba Lo Ni Wa        011 --     F0V 
 .             0919 X528000-0    Ba Lo Ni           004 --     F9V 
 .             1219 X140000-0    Ba De Lo Ni Po     002 --     F1V 
-.             1319 X356000-0    Ba Lo Ni           024 --     M3V M0D 
-.             1419 X300000-0    Ba Lo Ni Va        025 --     M2V M1D 
+.             1319 X356000-0    Ba Lo Ni           024 --     M0V M3V
+.             1419 X300000-0    Ba Lo Ni Va        025 --     M1V M2V
 .             1519 X8A6000-0    Ba Fl Lo Ni        002 --     M0V 
 .             1719 X100000-0    Ba Lo Ni Va        014 --     K2V 
-.             2419 X456000-0    Ba Lo Ni           010 --     F7V M2D 
+.             2419 X456000-0    Ba Lo Ni           010 --     F7V M2V
 .             3119 X000000-0    As Ba Lo Ni        000 --     M7V 
-.             0520 X230000-0    Ba De Lo Ni Po     034 --     M4V M3V 
-.             0820 X210000-0    Ba Lo Ni           004 --     F3V M6D 
+.             0520 X230000-0    Ba De Lo Ni Po     034 --     M3V M4V
+.             0820 X210000-0    Ba Lo Ni           004 --     F3V M6V
 .             0920 X210000-0    Ba Lo Ni           014 --     M4V 
 .             1120 X330000-0    Ba De Lo Ni Po     003 --     M1V 
-.             1320 X555000-0    Ba Lo Ni           002 --     F5V M4D 
+.             1320 X555000-0    Ba Lo Ni           002 --     F5V M4V
 .             1420 X000000-0    As Ba Lo Ni        000 --     M5V 
 .             1820 X538000-0    Ba Lo Ni           024 --     G1V 
-.             2820 X454000-0    Ba Lo Ni           003 --     F7V M1D 
+.             2820 X454000-0    Ba Lo Ni           003 --     F7V M1V
 .             0521 X100000-0    Ba Lo Ni Va        003 --     F6V 
-.             0721 X988000-0    Ba Lo Ni           004 --     F4V M6D 
+.             0721 X988000-0    Ba Lo Ni           004 --     F4V M6V
 .             0921 X996000-0    Ba Lo Ni           002 --     G9V 
 .             1021 X100000-0    Ba Lo Ni Va        004 --     F3III 
-.             1321 X599000-0    Ba Lo Ni           003 --     G7V M2D 
+.             1321 X599000-0    Ba Lo Ni           003 --     G7V M2V
 .             1521 X413000-0    Ba Ic Lo Ni        002 --     M6V 
-.             1821 X130000-0    Ba De Lo Ni Po     006 --     G6IV M0D 
-.             2121 X474000-0    Ba Lo Ni           001 --     F8V M5D 
+.             1821 X130000-0    Ba De Lo Ni Po     006 --     G6IV M0V
+.             2121 X474000-0    Ba Lo Ni           001 --     F8V M5V
 .             2321 X567000-0    Ba Lo Ni           002 --     F8V 
 .             2521 X450000-0    Ba De Lo Ni Po     021 --     F4V 
-.             2721 X557000-0    Ba Lo Ni           005 --     F1V M8D 
+.             2721 X557000-0    Ba Lo Ni           005 --     F1V M8V
 .             0622 X447000-0    Ba Lo Ni           013 --     G7V 
 .             1322 X9A5000-0    Ba Fl Lo Ni        000 --     M8V 
 .             1722 X100000-0    Ba Lo Ni Va        003 --     F4D 
 .             2022 X140000-0    Ba De Lo Ni Po     013 --     G3V 
-.             3122 X637000-0    Ba Lo Ni           013 --     M4V M2D 
-.             0323 X85A000-0    Ba Lo Ni Wa        011 --     F1V M5D 
+.             3122 X637000-0    Ba Lo Ni           013 --     M4V
+.             0323 X85A000-0    Ba Lo Ni Wa        011 --     F1V M5V
 .             0423 X632000-0    Ba Lo Ni Po        002 --     M2V 
-.             0923 X676000-0    Ba Lo Ni           004 --     F0V M5D 
-.             1623 X200000-0    Ba Lo Ni Va        003 --     G1V M4D 
-.             1723 X000000-0    As Ba Lo Ni        015 --     M5V M6D 
-.             1823 X98A000-0    Ba Lo Ni Wa        001 --     F5V M8D 
+.             0923 X676000-0    Ba Lo Ni           004 --     F0V M5V
+.             1623 X200000-0    Ba Lo Ni Va        003 --     G1V M4V
+.             1723 X000000-0    As Ba Lo Ni        015 --     M5V M6V
+.             1823 X98A000-0    Ba Lo Ni Wa        001 --     F5V M8V
 .             2223 X580000-0    Ba De Lo Ni        022 --     F8V 
-.             2323 X854000-0    Ba Lo Ni           002 --     F1V M5D 
+.             2323 X854000-0    Ba Lo Ni           002 --     F1V M5V
 .             3223 X100000-0    Ba Lo Ni Va        002 --     M7V 
 .             0124 X664000-0    Ba Lo Ni           011 --     G2V 
 .             0724 X335000-0    Ba Lo Ni           000 --     M6III 
 .             0824 X100000-0    Ba Lo Ni Va        000 --     M5V 
-.             1324 X696000-0    Ba Lo Ni           023 --     F1V M3D 
+.             1324 X696000-0    Ba Lo Ni           023 --     F1V M3V
 .             1624 X545000-0    Ba Lo Ni           022 --     F0V 
 .             2024 X201000-0    Ba Ic Lo Ni Va     030 --     M7V 
-.             2124 X897000-0    Ba Lo Ni           012 --     F2V M5D 
-.             2224 X669000-0    Ba Lo Ni           016 --     F6V M0D 
+.             2124 X897000-0    Ba Lo Ni           012 --     F2V M5V
+.             2224 X669000-0    Ba Lo Ni           016 --     F6V M0V
 .             2624 X545000-0    Ba Lo Ni           013 --     F1V 
 .             2724 X786000-0    Ba Lo Ni           002 --     F6V 
 .             0225 X233000-0    Ba Lo Ni Po        004 --     K9V 
 .             0425 X548000-0    Ba Lo Ni           000 --     K0V 
-.             0525 X9B3000-0    Ba Fl Lo Ni        005 --     M2V M3D 
+.             0525 X9B3000-0    Ba Fl Lo Ni        005 --     M2V M3V
 .             0625 X364000-0    Ba Lo Ni           001 --     F8V 
 .             0825 X000000-0    As Ba Lo Ni        014 --     M2II 
-.             1525 X425000-0    Ba Lo Ni           001 --     K0V M6D 
-.             1725 X100000-0    Ba Lo Ni Va        003 --     A4V M8D 
-.             2025 X545000-0    Ba Lo Ni           018 --     F2V M8D G3V M6D 
+.             1525 X425000-0    Ba Lo Ni           001 --     K0V M6V
+.             1725 X100000-0    Ba Lo Ni Va        003 --     A4V M8V
+.             2025 X545000-0    Ba Lo Ni           018 --     F2V M8V G3V M6V
 .             2925 X788000-0    Ba Lo Ni           000 --     M1V 
 .             1026 X576000-0    Ba Lo Ni           000 --     F4V 
 .             1126 X8A5000-0    Ba Fl Lo Ni        001 --     M7V 
-.             2926 X452000-0    Ba Lo Ni Po        000 --     F6V M4D 
+.             2926 X452000-0    Ba Lo Ni Po        000 --     F6V M4V
 .             0127 X776000-0    Ba Lo Ni           010 --     G8V 
-.             0727 X672000-0    Ba Lo Ni           007 --     F4V M8D M7V 
-.             1427 X9A5000-0    Ba Fl Lo Ni        002 --     M5V M6D 
-.             0428 X110000-0    Ba Lo Ni           025 --     M1V M1D 
+.             0727 X672000-0    Ba Lo Ni           007 --     F4V M8V M7V
+.             1427 X9A5000-0    Ba Fl Lo Ni        002 --     M5V M6V
+.             0428 X110000-0    Ba Lo Ni           025 --     M1V M1V
 .             0728 X552000-0    Ba Lo Ni Po        001 --     F1V 
 .             1328 X89A000-0    Ba Lo Ni Wa        010 --     G9V 
 .             1528 X683000-0    Ba Lo Ni           001 --     K2V 
@@ -256,41 +256,41 @@ Veg Vergakh
 .             1129 X644000-0    Ba Lo Ni           000 --     F0V 
 .             1229 X373000-0    Ba Lo Ni           001 --     F1V 
 .             2929 X674000-0    Ba Lo Ni           013 --     F7V 
-.             0230 X242000-0    Ba Lo Ni Po        017 --     F2V M2D F5V 
+.             0230 X242000-0    Ba Lo Ni Po        017 --     F2V M2V F5V
 .             0330 X474000-0    Ba Lo Ni           002 --     F9V 
 .             0430 X000000-0    As Ba Lo Ni        011 --     M6V 
 .             0730 X502000-0    Ba Ic Lo Ni Va     002 --     M8V 
-.             0930 X453000-0    Ba Lo Ni Po        003 --     F9V M7D 
+.             0930 X453000-0    Ba Lo Ni Po        003 --     F9V M7V
 .             2130 X130000-0    Ba De Lo Ni Po     000 --     K1V 
-.             3030 X8A4000-0    Ba Fl Lo Ni        001 --     M3V M5D 
+.             3030 X8A4000-0    Ba Fl Lo Ni        001 --     M3V M5V
 .             0131 X351000-0    Ba Lo Ni Po        004 --     F3V 
 .             0231 X594000-0    Ba Lo Ni           010 --     F9V 
-.             0431 X668000-0    Ba Lo Ni           000 --     G9V M2D 
-.             0531 X303000-0    Ba Ic Lo Ni Va     003 --     K6V M1D 
-.             0731 X874000-0    Ba Lo Ni           015 --     F5V M0D 
+.             0431 X668000-0    Ba Lo Ni           000 --     G9V M2V
+.             0531 X303000-0    Ba Ic Lo Ni Va     003 --     K6V M1V
+.             0731 X874000-0    Ba Lo Ni           015 --     F5V M0V
 .             0931 X446000-0    Ba Lo Ni           004 --     F0V 
-.             1131 X859000-0    Ba Lo Ni           014 --     M6V M8D 
-.             1531 X470000-0    Ba De Lo Ni        003 --     F0V M7D 
-.             1731 X464000-0    Ba Lo Ni           013 --     F9V M3D 
+.             1131 X859000-0    Ba Lo Ni           014 --     M6V M8V
+.             1531 X470000-0    Ba De Lo Ni        003 --     F0V M7V
+.             1731 X464000-0    Ba Lo Ni           013 --     F9V M3V
 .             2231 X7A2000-0    Ba Fl Lo Ni        003 --     M0V 
 .             0332 X55A000-0    Ba Lo Ni Wa        004 --     F5V 
 .             0632 X477000-0    Ba Lo Ni           002 --     F9V 
 .             1232 X100000-0    Ba Lo Ni Va        002 --     M1V 
-.             1632 X467000-0    Ba Lo Ni           006 --     F5V M8D 
-.             2332 X555000-0    Ba Lo Ni           004 --     F0V M2D 
-.             2532 X410000-0    Ba Lo Ni           007 --     M7V M1D 
+.             1632 X467000-0    Ba Lo Ni           006 --     F5V M8V
+.             2332 X555000-0    Ba Lo Ni           004 --     F0V M2V
+.             2532 X410000-0    Ba Lo Ni           007 --     M1V M7V
 .             2932 X775000-0    Ba Lo Ni           011 --     F9V 
-.             3032 X353000-0    Ba Lo Ni Po        013 --     K2V M8D 
-Gerzoukhoez   0133 B658201-A  G Lo Ni              916 Va     F9V M0D 
+.             3032 X353000-0    Ba Lo Ni Po        013 --     K2V M8V
+Gerzoukhoez   0133 B658201-A  G Lo Ni              916 Va     F9V M0V
 .             0833 X257000-0    Ba Lo Ni           010 --     G8V 
-.             1133 X567000-0    Ba Lo Ni           004 --     F7V M1D 
+.             1133 X567000-0    Ba Lo Ni           004 --     F7V M1V
 .             1433 XAB3000-0    Ba Fl Lo Ni        001 --     M3V 
-.             1733 X679000-0    Ba Lo Ni           011 --     G7V M3D F4V 
-.             2833 X624000-0    Ba Lo Ni           000 --     M0V M2D 
-.             2933 X87A000-0    Ba Lo Ni Wa        006 --     G8V G8V M0D 
-.             3033 X678000-0    Ba Lo Ni           002 --     M8V M5D 
+.             1733 X679000-0    Ba Lo Ni           011 --     F4V M3V G7V
+.             2833 X624000-0    Ba Lo Ni           000 --     M0V M2V
+.             2933 X87A000-0    Ba Lo Ni Wa        006 --     G8V G8V M0V
+.             3033 X678000-0    Ba Lo Ni           002 --     M5V M8V
 Rudho         0234 C410643-5    Na Ni              401 Va     M8V 
-.             1234 X100000-0    Ba Lo Ni Va        003 --     M1V M7D 
+.             1234 X100000-0    Ba Lo Ni Va        003 --     M1V M7V
 .             1534 X322000-0    Ba Lo Ni Po        002 --     G2V 
 .             2334 X5A0000-0    Ba De Lo Ni        013 --     M8V 
 .             2434 X794000-0    Ba Lo Ni           001 --     F8V 
@@ -300,53 +300,53 @@ Sodhirr       0335 X451300-1  C Lo Ni Po           713 Va     F4V
 Gaenigoe      0435 C767234-2    Lo Ni              523 Va     F0V 
 .             1035 X789000-0    Ba Lo Ni           013 --     G9V 
 .             1335 X798000-0    Ba Lo Ni           024 --     G7V 
-.             1535 X303000-0    Ba Ic Lo Ni Va     004 --     G7V M6D 
-.             1935 X130000-0    Ba De Lo Ni Po     006 --     F6V M7D 
+.             1535 X303000-0    Ba Ic Lo Ni Va     004 --     G7V M6V
+.             1935 X130000-0    Ba De Lo Ni Po     006 --     F6V M7V
 .             2235 X130000-0    Ba De Lo Ni Po     000 --     M5III 
-.             2435 X68A000-0    Ba Lo Ni Wa        000 --     F1V M6D 
-.             2635 X225000-0    Ba Lo Ni           002 --     K3V K4D 
-.             2835 X431000-0    Ba Lo Ni Po        016 --     F5V M6D 
-.             3035 X200000-0    Ba Lo Ni Va        012 --     M3V M4D 
-.             1136 X000000-0    As Ba Lo Ni        006 --     G9IV K1D 
+.             2435 X68A000-0    Ba Lo Ni Wa        000 --     F1V M6V
+.             2635 X225000-0    Ba Lo Ni           002 --     K3V K4V
+.             2835 X431000-0    Ba Lo Ni Po        016 --     F5V M6V
+.             3035 X200000-0    Ba Lo Ni Va        012 --     M3V M4V
+.             1136 X000000-0    As Ba Lo Ni        006 --     G9IV K1V
 .             1836 X454000-0    Ba Lo Ni           004 --     K8V 
 .             2236 X557000-0    Ba Lo Ni           013 --     F9V 
-.             2636 X200000-0    Ba Lo Ni Va        001 --     M1V M7D 
+.             2636 X200000-0    Ba Lo Ni Va        001 --     M1V M7V
 .             2736 X886000-0    Ba Lo Ni           012 --     F0V 
 .             2836 X8A7000-0    Ba Fl Lo Ni        003 --     F2V 
 .             2936 X484000-0    Ba Lo Ni           000 --     F7V 
-Zoelungdath   0237 A9A55A8-7  G Fl Ni              905 Va     M2V M7D 
+Zoelungdath   0237 A9A55A8-7  G Fl Ni              905 Va     M2V M7V
 Gaegzill      0437 D8A7650-4    Fl Ni              504 Va     K8V 
 .             0737 X344000-0    Ba Lo Ni           023 --     F9V 
-.             0937 X444000-0    Ba Lo Ni           004 --     F5V M4D 
+.             0937 X444000-0    Ba Lo Ni           004 --     F5V M4V
 .             1237 X430000-0    Ba De Lo Ni Po     011 --     F0IV 
 .             1437 X449000-0    Ba Lo Ni           002 --     M4V 
 .             1637 X7B2000-0    Ba Fl Lo Ni        010 --     K6V 
 .             2037 X673000-0    Ba Lo Ni           000 --     K7V 
-.             2237 X554000-0    Ba Lo Ni           002 --     F5V M4D 
-.             2337 X642000-0    Ba Lo Ni Po        013 --     F8V M4D 
+.             2237 X554000-0    Ba Lo Ni           002 --     F5V M4V
+.             2337 X642000-0    Ba Lo Ni Po        013 --     F8V M4V
 .             3137 X556000-0    Ba Lo Ni           002 --     F2V 
 Tokoaesuen    0138 C340430-7  C De Ni Po           700 Va     F3V 
 Rarzksaes     0538 D200489-3    Ni Va              813 Va     M4V 
 Norirrgzikhs  0638 X610261-0  C Lo Ni              222 Va     M1III 
-.             0838 X000000-0    As Ba Lo Ni        008 --     G7V M6D M6V 
-.             0938 X160000-0    Ba De Lo Ni        002 --     F3V M0D 
+.             0838 X000000-0    As Ba Lo Ni        008 --     G7V M6V M6V
+.             0938 X160000-0    Ba De Lo Ni        002 --     F3V M0V
 .             1138 X7B6000-0    Ba Fl Lo Ni        000 --     K5V 
 .             1538 X444000-0    Ba Lo Ni           010 --     F9V 
-.             2138 X527000-0    Ba Lo Ni           017 --     M0V M0D F0V 
-Uengeng       2438 X360353-4  C De Lo Ni           403 Va     M1V M4D 
-Suedzodueks   0439 B200320-B  G Lo Ni Va           602 Va     M5V M0D 
-.             1539 X574000-0    Ba Lo Ni           017 --     F8V M1D 
+.             2138 X527000-0    Ba Lo Ni           017 --     F0V M0V M0V
+Uengeng       2438 X360353-4  C De Lo Ni           403 Va     M1V M4V
+Suedzodueks   0439 B200320-B  G Lo Ni Va           602 Va     M0V M5V
+.             1539 X574000-0    Ba Lo Ni           017 --     F8V M1V
 .             2139 X5A0000-0    Ba De Lo Ni        001 --     M2II 
 Dufakokhssok  3039 A68A753-B    Ri Wa              100 Va     F8V 
 Gvughuedi     3139 D87A662-7    Ni Wa              111 Va     F6V 
-Aksaengolagh  3239 C346333-4    Lo Ni              500 Va     F1V M6D 
+Aksaengolagh  3239 C346333-4    Lo Ni              500 Va     F1V M6V
 Koedhaenarr   0640 A587578-9  G Ag Ni              510 Va     F0V 
 Ghanusueth    1140 B564402-B  G Ni                 902 Va     F3V 
-.             1540 X75A000-0    Ba Lo Ni Wa        017 --     K7V M7D 
+.             1540 X75A000-0    Ba Lo Ni Wa        017 --     K7V M7V
 Sunakoks      1840 C130779-8  G De Na Po           902 Va     M1V 
-Dzudzir       2240 D343430-6    Ni Po              503 Va     F9V M7D 
+Dzudzir       2240 D343430-6    Ni Po              503 Va     F9V M7V
 Aelluerzzogh  2340 E634544-4  C Ni                 404 Va     M0V 
-Iloghir       2740 E200978-4    Hi Na Va           803 Va     F9V M3D 
-Nogzaeras     2940 C515000-7    Ba Ic Lo Ni        506 Va     M6V M3D 
+Iloghir       2740 E200978-4    Hi Na Va           803 Va     F9V M3V
+Nogzaeras     2940 C515000-7    Ba Ic Lo Ni        506 Va     M3V M6V
 Dhazoroekh    3140 C656740-3    Ag                 400 Va     M2V 
 Ghesurrg      3240 C896942-7    Hi In              100 Va     F8V 

--- a/res/Sectors/M1105/Zao Kfeng Ig Grilokh.tab
+++ b/res/Sectors/M1105/Zao Kfeng Ig Grilokh.tab
@@ -174,7 +174,7 @@ Zaok	L	3227	Sougaeekaeg	B787766-8	C	Ag Ri		901	VK	K5 V D						0
 Zaok	M	0137	Turadhadz	C8A3831-6		Fl		500	Va	F3 V						0
 Zaok	M	0139	Loure	D628577-4	C	Ni		301	Va	M7 V						0
 Zaok	M	0233	Gzoughia	C775777-4	K	Ag Pi Pz	A	424	VS	G1 V						0
-Zaok	M	0333	Khoezo	B575486-5	C	Ni		204	VS	G8 V M4 V F2 V						0
+Zaok	M	0333	Khoezo	B575486-5	C	Ni		204	VS	F2 V M4 V G8 V						0
 Zaok	M	0334	Soutsgvaek	E659798-7	C			500	VS	G2 V						0
 Zaok	M	0335	Gharroeth	B62768A-6	K	Ni		405	VS	F4 V D						0
 Zaok	M	0337	Agrerrgkueng	C685485-3		Ni		814	Va	F8 V D						0
@@ -183,7 +183,7 @@ Zaok	M	0532	Ghugzaaekars	C738432-9		Ni		702	VS	M8 V						0
 Zaok	M	0533	Gvarrgaz	C562878-7		Cp Ph Pz Ri	A	210	VS	F1 V						0
 Zaok	M	0540	Ralangzakor	C877876-5	K			403	Va	F7 V						0
 Zaok	M	0631	Agueksther	C7A4301-8	K	Fl Lo		604	VS	F9 V						0
-Zaok	M	0633	Raerrthadh	X4527AB-1	C	Fo Po	R	325	VS	M3 V M2 V F6 V D						0
+Zaok	M	0633	Raerrthadh	X4527AB-1	C	Fo Po	R	325	VS	F6 V M2 V M3 V D						0
 Zaok	M	0733	Ledzuegzo	C884233-5	K	Lo		512	VS	F8 V						0
 Zaok	M	0738	Gvugvaer	C400300-8		Lo Ni Va		400	Va	M4 II						0
 Zaok	M	0740	Zuerrknenkag	A120220-A	K	De Lo Ni Po		102	Va	M8 V						0

--- a/res/Sectors/M1105/Zortakh.sec
+++ b/res/Sectors/M1105/Zortakh.sec
@@ -10,19 +10,19 @@ Zortakh
 #----------   ---- ---------  - --------------- -  --- -- --- -
 .             0501 X887000-0    Ba Lo Ni           003 --     G2V 
 .             0701 X485000-0    Ba Lo Ni           000 --     F3V 
-.             1101 X344000-0    Ba Lo Ni           003 --     M0V M3D 
+.             1101 X344000-0    Ba Lo Ni           003 --     M0V M3V
 .             1301 X000000-0    As Ba Lo Ni        000 --     M2V 
-.             1501 X423000-0    Ba Lo Ni Po        017 --     K0V M1D 
+.             1501 X423000-0    Ba Lo Ni Po        017 --     K0V M1V
 .             1701 X312000-0    Ba Ic Lo Ni        001 --     F5V 
 .             2001 X201000-0    Ba Ic Lo Ni Va     002 --     M3V 
 .             2501 X313000-0    Ba Ic Lo Ni        004 --     M6V 
-.             0402 X774000-0    Ba Lo Ni           012 --     G4V M5D 
+.             0402 X774000-0    Ba Lo Ni           012 --     G4V M5V
 .             0702 X859000-0    Ba Lo Ni           014 --     K8V 
 .             2302 X575000-0    Ba Lo Ni           000 --     F4V 
-.             2602 X987000-0    Ba Lo Ni           006 --     F2V M2D 
+.             2602 X987000-0    Ba Lo Ni           006 --     F2V M2V
 .             2702 X525000-0    Ba Lo Ni           002 --     A0V 
-.             2902 X227000-0    Ba Lo Ni           007 --     M8V F8V 
-.             0103 X7C5000-0    Ba Fl Lo Ni        024 --     A0V M5D 
+.             2902 X227000-0    Ba Lo Ni           007 --     F8V M8V
+.             0103 X7C5000-0    Ba Fl Lo Ni        024 --     A0V M5V
 .             0303 X645000-0    Ba Lo Ni           000 --     F2V 
 .             0503 X231000-0    Ba Lo Ni Po        012 --     F4IV 
 .             0703 X677000-0    Ba Lo Ni           023 --     F5V 
@@ -30,48 +30,48 @@ Zortakh
 .             1403 X5A2000-0    Ba Fl Lo Ni        022 --     M6V 
 .             1503 XA69000-0    Ba Lo Ni           012 --     F4V 
 .             1803 X223000-0    Ba Lo Ni Po        005 --     M1V 
-.             1903 X746000-0    Ba Lo Ni           001 --     F9V M8D 
+.             1903 X746000-0    Ba Lo Ni           001 --     F9V M8V
 .             2103 X9A5000-0    Ba Fl Lo Ni        020 --     M8II 
-.             3003 X627000-0    Ba Lo Ni           004 --     M2V M3V 
+.             3003 X627000-0    Ba Lo Ni           004 --     M2V M3V
 .             3203 X637000-0    Ba Lo Ni           012 --     M2V 
 .             0104 X491000-0    Ba Lo Ni           001 --     F8V 
 .             0204 X99A000-0    Ba Lo Ni Wa        000 --     F1V 
 .             0304 X6A3000-0    Ba Fl Lo Ni        004 --     M4V 
-.             0404 X220000-0    Ba De Lo Ni Po     002 --     M6V M0V 
-.             0704 X79A000-0    Ba Lo Ni Wa        000 --     F2V M7D 
-.             0804 X140000-0    Ba De Lo Ni Po     018 --     F6V M5D 
+.             0404 X220000-0    Ba De Lo Ni Po     002 --     M0V M6V
+.             0704 X79A000-0    Ba Lo Ni Wa        000 --     F2V M7V
+.             0804 X140000-0    Ba De Lo Ni Po     018 --     F6V M5V
 .             1004 X230000-0    Ba De Lo Ni Po     005 --     G5V 
 .             1104 X262000-0    Ba Lo Ni           005 --     M7V 
 .             1404 X894000-0    Ba Lo Ni           020 --     F2V 
 .             1504 X548000-0    Ba Lo Ni           012 --     G8V 
 .             1904 X558000-0    Ba Lo Ni           013 --     F2V 
-.             2104 X232000-0    Ba Lo Ni Po        005 --     M5V M6D 
+.             2104 X232000-0    Ba Lo Ni Po        005 --     M5V M6V
 .             0205 X873000-0    Ba Lo Ni           004 --     F8V 
-.             0705 X96A000-0    Ba Lo Ni Wa        004 --     F5V M7D 
+.             0705 X96A000-0    Ba Lo Ni Wa        004 --     F5V M7V
 .             1605 X000000-0    As Ba Lo Ni        003 --     K5V 
-.             2305 X411000-0    Ba Ic Lo Ni        020 --     M5V 
+.             2305 X411000-0    Ba Ic Lo Ni        020 --     M5V
 .             3205 X457000-0    Ba Lo Ni           010 --     F5V 
-.             0306 X469000-0    Ba Lo Ni           003 --     F5V M7D 
-.             0406 X88A000-0    Ba Lo Ni Wa        013 --     F8V M4D 
+.             0306 X469000-0    Ba Lo Ni           003 --     F5V M7V
+.             0406 X88A000-0    Ba Lo Ni Wa        013 --     F8V M4V
 .             0906 X210000-0    Ba Lo Ni           003 --     M2V 
-.             1006 X677000-0    Ba Lo Ni           005 --     K7V M1D 
+.             1006 X677000-0    Ba Lo Ni           005 --     K7V M1V
 .             1706 X988000-0    Ba Lo Ni           010 --     F2V 
 .             1806 X400000-0    Ba Lo Ni Va        003 --     M2V 
 .             1906 X969000-0    Ba Lo Ni           003 --     F2V 
 .             2106 X622000-0    Ba Lo Ni Po        001 --     A5V 
 .             2606 X755000-0    Ba Lo Ni           001 --     F8V 
-.             2806 X688000-0    Ba Lo Ni           003 --     F2V M4V 
+.             2806 X688000-0    Ba Lo Ni           003 --     F2V M4V
 .             3006 X452000-0    Ba Lo Ni Po        023 --     F0V 
 .             0107 X758000-0    Ba Lo Ni           001 --     F2V 
-.             0807 X996000-0    Ba Lo Ni           005 --     F8V M8D 
+.             0807 X996000-0    Ba Lo Ni           005 --     F8V M8V
 .             0907 X756000-0    Ba Lo Ni           015 --     F6V 
-.             1307 X578000-0    Ba Lo Ni           002 --     F0V M5D 
+.             1307 X578000-0    Ba Lo Ni           002 --     F0V M5V
 .             2407 X130000-0    Ba De Lo Ni Po     003 --     M7V 
 .             2507 X83A000-0    Ba Lo Ni Wa        003 --     M8V 
-.             0408 X423000-0    Ba Lo Ni Po        017 --     F1IV M8V M8V 
-.             1208 X423000-0    Ba Lo Ni Po        004 --     K7V M6D 
+.             0408 X423000-0    Ba Lo Ni Po        017 --     F1IV M8V M8V
+.             1208 X423000-0    Ba Lo Ni Po        004 --     K7V M6V
 .             1708 X667000-0    Ba Lo Ni           003 --     K6V 
-.             1808 X8A6000-0    Ba Fl Lo Ni        013 --     M4V M3V 
+.             1808 X8A6000-0    Ba Fl Lo Ni        013 --     M3V M4V
 .             1908 X575000-0    Ba Lo Ni           020 --     F2V 
 .             2808 X574000-0    Ba Lo Ni           014 --     F3V 
 .             3208 X6A0000-0    Ba De Lo Ni        023 --     F4V 
@@ -82,167 +82,167 @@ Zortakh
 .             1209 X67A000-0    Ba Lo Ni Wa        004 --     F6V 
 .             1309 X224000-0    Ba Lo Ni           010 --     M5V 
 .             1909 X240000-0    Ba De Lo Ni Po     010 --     F2V 
-.             2509 X996000-0    Ba Lo Ni           002 --     F1V M2D 
+.             2509 X996000-0    Ba Lo Ni           002 --     F1V M2V
 .             3109 X201000-0    Ba Ic Lo Ni Va     000 --     M3V 
 .             3209 XAD2000-0    Ba Fl Lo Ni        000 --     F1III 
 .             0310 X583000-0    Ba Lo Ni           000 --     F7V 
 .             0610 X100000-0    Ba Lo Ni Va        000 --     M1III 
-.             2410 X8B9000-0    Ba Fl Lo Ni        015 --     G1V M4D 
+.             2410 X8B9000-0    Ba Fl Lo Ni        015 --     G1V M4V
 .             2610 X637000-0    Ba Lo Ni           013 --     M1V 
-.             0111 X848000-0    Ba Lo Ni           001 --     F0V M4D M5D 
-.             0411 XAB9000-0    Ba Fl Lo Ni        002 --     M3V M7D 
+.             0111 X848000-0    Ba Lo Ni           001 --     F0V M4V M5V
+.             0411 XAB9000-0    Ba Fl Lo Ni        002 --     M3V M7V
 .             1211 X120000-0    Ba De Lo Ni Po     004 --     G9V M8V 
-.             1511 X536000-0    Ba Lo Ni           002 --     K5V M3D 
-.             1711 X563000-0    Ba Lo Ni           005 --     F1V M1D 
+.             1511 X536000-0    Ba Lo Ni           002 --     K5V M3V
+.             1711 X563000-0    Ba Lo Ni           005 --     F1V M1V
 .             0112 X867000-0    Ba Lo Ni           004 --     F2V 
-.             0412 X441000-0    Ba Lo Ni Po        004 --     F1V M4D 
-.             0912 X221000-0    Ba Lo Ni Po        022 --     M8V M4D 
-.             1012 X677000-0    Ba Lo Ni           003 --     G3V M8D 
+.             0412 X441000-0    Ba Lo Ni Po        004 --     F1V M4V
+.             0912 X221000-0    Ba Lo Ni Po        022 --     M4V M8V
+.             1012 X677000-0    Ba Lo Ni           003 --     G3V M8V
 .             1212 X110000-0    Ba Lo Ni           013 --     M5V 
-.             1412 X675000-0    Ba Lo Ni           016 --     F0V M4D 
+.             1412 X675000-0    Ba Lo Ni           016 --     F0V M4V
 .             1712 X476000-0    Ba Lo Ni           005 --     K7V M8V 
-.             2012 X657000-0    Ba Lo Ni           002 --     F1V M5D 
+.             2012 X657000-0    Ba Lo Ni           002 --     F1V M5V
 .             2412 X300000-0    Ba Lo Ni Va        003 --     M7V 
-.             2512 X333000-0    Ba Lo Ni Po        015 --     K5V M5D 
-.             2812 X300000-0    Ba Lo Ni Va        005 --     M6V M0D 
+.             2512 X333000-0    Ba Lo Ni Po        015 --     K5V M5V
+.             2812 X300000-0    Ba Lo Ni Va        005 --     M0V M6V
 .             3112 X5A2000-0    Ba Fl Lo Ni        011 --     M3V 
 .             1013 X556000-0    Ba Lo Ni           000 --     F0V 
 .             1313 X150000-0    Ba De Lo Ni Po     012 --     F8V 
-.             1513 X130000-0    Ba De Lo Ni Po     014 --     F5III G1D 
+.             1513 X130000-0    Ba De Lo Ni Po     014 --     F5III G1V
 .             1613 X564000-0    Ba Lo Ni           011 --     F3V 
-.             1813 X454000-0    Ba Lo Ni           014 --     F1V M1D 
+.             1813 X454000-0    Ba Lo Ni           014 --     F1V M1V
 .             2413 XAB6000-0    Ba Fl Lo Ni        002 --     M7V 
-.             3013 X774000-0    Ba Lo Ni           000 --     K3V M0D 
-.             3213 X210000-0    Ba Lo Ni           015 --     F5V M3D 
+.             3013 X774000-0    Ba Lo Ni           000 --     K3V M0V
+.             3213 X210000-0    Ba Lo Ni           015 --     F5V M3V
 .             0414 X356000-0    Ba Lo Ni           002 --     F1V 
 .             0614 X745000-0    Ba Lo Ni           004 --     F5V 
-.             0914 X422000-0    Ba Lo Ni Po        003 --     M5V M8D 
-.             1314 X897000-0    Ba Lo Ni           020 --     F0V M6D 
-.             1414 X610000-0    Ba Lo Ni           006 --     K8V M8D 
-.             1514 X7A1000-0    Ba Fl Lo Ni        010 --     M3V M6D 
+.             0914 X422000-0    Ba Lo Ni Po        003 --     M5V M8V
+.             1314 X897000-0    Ba Lo Ni           020 --     F0V M6V
+.             1414 X610000-0    Ba Lo Ni           006 --     K8V M8V
+.             1514 X7A1000-0    Ba Fl Lo Ni        010 --     M3V M6V
 .             1814 X200000-0    Ba Lo Ni Va        000 --     F8V 
 .             1914 X555000-0    Ba Lo Ni           002 --     F9V 
 .             2114 X835000-0    Ba Lo Ni           002 --     K8V 
 .             2214 X523000-0    Ba Lo Ni Po        002 --     M5V 
-.             2514 X681000-0    Ba Lo Ni           004 --     F6V M6D 
+.             2514 X681000-0    Ba Lo Ni           004 --     F6V M6V
 .             2714 X230000-0    Ba De Lo Ni Po     001 --     F4V 
-.             0315 X665000-0    Ba Lo Ni           001 --     F1V M4D 
+.             0315 X665000-0    Ba Lo Ni           001 --     F1V M4V
 .             0415 X578000-0    Ba Lo Ni           003 --     F9V 
-.             0615 X678000-0    Ba Lo Ni           003 --     F3V M8D 
-.             0915 X475000-0    Ba Lo Ni           015 --     F3V M2D 
-.             1715 X514000-0    Ba Ic Lo Ni        002 --     F1V M3D 
+.             0615 X678000-0    Ba Lo Ni           003 --     F3V M8V
+.             0915 X475000-0    Ba Lo Ni           015 --     F3V M2V
+.             1715 X514000-0    Ba Ic Lo Ni        002 --     F1V M3V
 .             2015 X233000-0    Ba Lo Ni Po        024 --     G6V 
 .             2315 X544000-0    Ba Lo Ni           011 --     F6V 
-.             2415 X592000-0    Ba Lo Ni           006 --     F4V M0D 
+.             2415 X592000-0    Ba Lo Ni           006 --     F4V M0V
 .             2515 X110000-0    Ba Lo Ni           001 --     K3V 
-.             2715 X444000-0    Ba Lo Ni           004 --     K3V M5D 
-.             3115 X8A4000-0    Ba Fl Lo Ni        015 --     M1V M8D 
-.             0116 X85A000-0    Ba Lo Ni Wa        002 --     F1V M3D 
-.             0516 X758000-0    Ba Lo Ni           000 --     F9V M1D 
+.             2715 X444000-0    Ba Lo Ni           004 --     K3V M5V
+.             3115 X8A4000-0    Ba Fl Lo Ni        015 --     M1V M8V
+.             0116 X85A000-0    Ba Lo Ni Wa        002 --     F1V M3V
+.             0516 X758000-0    Ba Lo Ni           000 --     F9V M1V
 .             0716 X241000-0    Ba Lo Ni Po        003 --     K2V 
-.             1016 X787000-0    Ba Lo Ni           003 --     F0V M2D 
-.             1116 X552000-0    Ba Lo Ni Po        014 --     F7V M4D 
+.             1016 X787000-0    Ba Lo Ni           003 --     F0V M2V
+.             1116 X552000-0    Ba Lo Ni Po        014 --     F7V M4V
 .             1316 X400000-0    Ba Lo Ni Va        002 --     M0V 
 .             1616 X405000-0    Ba Ic Lo Ni Va     003 --     G4V 
 .             1716 X964000-0    Ba Lo Ni           024 --     F1V 
 .             1816 X99A000-0    Ba Lo Ni Wa        021 --     M5V 
 .             1916 X5A3000-0    Ba Fl Lo Ni        003 --     M6V 
-.             2116 X352000-0    Ba Lo Ni Po        016 --     F5V M8D 
+.             2116 X352000-0    Ba Lo Ni Po        016 --     F5V M8V
 .             3016 X200000-0    Ba Lo Ni Va        012 --     M7V 
 .             0117 X200000-0    Ba Lo Ni Va        003 --     M7V 
 .             0417 X89A000-0    Ba Lo Ni Wa        001 --     F6V 
-.             0817 X8C5000-0    Ba Fl Lo Ni        000 --     M8V M5D 
+.             0817 X8C5000-0    Ba Fl Lo Ni        000 --     M5V M8V
 .             1017 X221000-0    Ba Lo Ni Po        003 --     M3V 
-.             1317 X000000-0    As Ba Lo Ni        000 --     F9V M2D 
-.             1417 X642000-0    Ba Lo Ni Po        014 --     F1V M0D 
-.             1617 X100000-0    Ba Lo Ni Va        015 --     M5V M7D 
+.             1317 X000000-0    As Ba Lo Ni        000 --     F9V M2V
+.             1417 X642000-0    Ba Lo Ni Po        014 --     F1V M0V
+.             1617 X100000-0    Ba Lo Ni Va        015 --     M5V M7V
 .             1817 X510000-0    Ba Lo Ni           000 --     F8V 
 .             2017 X586000-0    Ba Lo Ni           000 --     M6V 
-.             0418 X8D6000-0    Ba Fl Lo Ni        002 --     M6II M0V 
+.             0418 X8D6000-0    Ba Fl Lo Ni        002 --     M6II M0V
 .             0518 X743000-0    Ba Lo Ni Po        002 --     F4V 
 .             0818 X400000-0    Ba Lo Ni Va        002 --     F9V 
 .             0918 X475000-0    Ba Lo Ni           011 --     K4V 
-.             1018 X978000-0    Ba Lo Ni           003 --     F0V M4D 
+.             1018 X978000-0    Ba Lo Ni           003 --     F0V M4V
 .             1118 X120000-0    Ba De Lo Ni Po     003 --     M8V 
 .             1418 X200000-0    Ba Lo Ni Va        004 --     G8V 
-.             1518 X311000-0    Ba Ic Lo Ni        002 --     M2V M2V 
-.             1718 X779000-0    Ba Lo Ni           004 --     F0V M7D 
+.             1518 X311000-0    Ba Ic Lo Ni        002 --     M2V M2V
+.             1718 X779000-0    Ba Lo Ni           004 --     F0V M7V
 .             1818 X65A000-0    Ba Lo Ni Wa        000 --     F4V 
 .             2518 X100000-0    Ba Lo Ni Va        015 --     G9V 
 .             2718 X865000-0    Ba Lo Ni           001 --     F5V 
 .             2818 X797000-0    Ba Lo Ni           000 --     F1V 
-.             3118 X7B0000-0    Ba De Lo Ni        034 --     M4V M1D 
+.             3118 X7B0000-0    Ba De Lo Ni        034 --     M1V M4V
 .             0719 X616000-0    Ba Ic Lo Ni        012 --     K4V 
 .             1019 X563000-0    Ba Lo Ni           003 --     F9V 
-.             2019 X325000-0    Ba Lo Ni           015 --     M3V M1D 
+.             2019 X325000-0    Ba Lo Ni           015 --     M1V M3V
 .             2119 X475000-0    Ba Lo Ni           012 --     F0V 
-.             2619 X764000-0    Ba Lo Ni           011 --     F7V M2D 
+.             2619 X764000-0    Ba Lo Ni           011 --     F7V M2V
 .             0120 X635000-0    Ba Lo Ni           012 --     M7V 
 .             0320 X110000-0    Ba Lo Ni           003 --     M0V 
-.             2320 X667000-0    Ba Lo Ni           024 --     F1V M0D M6D 
-.             2420 X756000-0    Ba Lo Ni           003 --     F9V M2D 
-.             2520 X7B4000-0    Ba Fl Lo Ni        023 --     M7V M0V 
-.             2820 X735000-0    Ba Lo Ni           000 --     F6V M1D 
+.             2320 X667000-0    Ba Lo Ni           024 --     F1V M0V M6V
+.             2420 X756000-0    Ba Lo Ni           003 --     F9V M2V
+.             2520 X7B4000-0    Ba Fl Lo Ni        023 --     M0V M7V
+.             2820 X735000-0    Ba Lo Ni           000 --     F6V M1V
 .             3020 X220000-0    Ba De Lo Ni Po     013 --     K7V 
 .             3120 X63A000-0    Ba Lo Ni Wa        001 --     M2V 
 .             0421 X120000-0    Ba De Lo Ni Po     003 --     M8V 
 .             0621 X362000-0    Ba Lo Ni           002 --     F2V 
 .             1121 X401000-0    Ba Ic Lo Ni Va     004 --     M1V 
 .             1221 X233000-0    Ba Lo Ni Po        001 --     F0V 
-.             1721 X585000-0    Ba Lo Ni           001 --     F9V M6D 
+.             1721 X585000-0    Ba Lo Ni           001 --     F9V M6V
 .             2221 X8A9000-0    Ba Fl Lo Ni        004 --     F6V 
 .             2421 X334000-0    Ba Lo Ni           003 --     M2V M5V 
 .             2721 X120000-0    Ba De Lo Ni Po     010 --     M1V 
-.             3121 X335000-0    Ba Lo Ni           001 --     F0V M7V 
+.             3121 X335000-0    Ba Lo Ni           001 --     F0V M7V
 .             0222 X8B3000-0    Ba Fl Lo Ni        003 --     M7V 
 .             0522 X110000-0    Ba Lo Ni           000 --     M5V 
-.             1322 X210000-0    Ba Lo Ni           003 --     M5V M8D 
-.             1422 X678000-0    Ba Lo Ni           014 --     K2V M0D M1V M6D 
-.             1622 X629000-0    Ba Lo Ni           004 --     M3V M5D 
+.             1322 X210000-0    Ba Lo Ni           003 --     M5V M8V
+.             1422 X678000-0    Ba Lo Ni           014 --     K2V M0V M1V M6V
+.             1622 X629000-0    Ba Lo Ni           004 --     M3V M5V
 .             1922 X568000-0    Ba Lo Ni           004 --     G3V 
 .             2222 X692000-0    Ba Lo Ni           000 --     F9V 
-.             2722 X110000-0    Ba Lo Ni           016 --     F6V M4D 
+.             2722 X110000-0    Ba Lo Ni           016 --     F6V M4V
 .             0723 X584000-0    Ba Lo Ni           003 --     F5V 
 .             1023 X233000-0    Ba Lo Ni Po        013 --     M1V 
-.             1323 X363000-0    Ba Lo Ni           012 --     K4V M3D 
-.             1423 X8C7000-0    Ba Fl Lo Ni        006 --     M6V M3D 
+.             1323 X363000-0    Ba Lo Ni           012 --     K4V M3V
+.             1423 X8C7000-0    Ba Fl Lo Ni        006 --     M3V M6V
 .             1723 X736000-0    Ba Lo Ni           002 --     M3V 
 .             2023 X333000-0    Ba Lo Ni Po        004 --     K5V 
-.             2723 X768000-0    Ba Lo Ni           014 --     G5V M3D 
-.             2823 X473000-0    Ba Lo Ni           005 --     F3V M8D 
+.             2723 X768000-0    Ba Lo Ni           014 --     G5V M3V
+.             2823 X473000-0    Ba Lo Ni           005 --     F3V M8V
 .             3023 X88A000-0    Ba Lo Ni Wa        023 --     F6V 
-.             0524 X100000-0    Ba Lo Ni Va        001 --     M0V M1D 
-.             0824 X657000-0    Ba Lo Ni           002 --     F1V M8D 
-.             1024 X426000-0    Ba Lo Ni           004 --     M6V M0D 
+.             0524 X100000-0    Ba Lo Ni Va        001 --     M0V M1V
+.             0824 X657000-0    Ba Lo Ni           002 --     F1V M8V
+.             1024 X426000-0    Ba Lo Ni           004 --     M0V M6V
 .             1324 X657000-0    Ba Lo Ni           023 --     F3V 
 .             1724 X410000-0    Ba Lo Ni           004 --     G3IV 
-.             2124 X99A000-0    Ba Lo Ni Wa        003 --     M5V M7D 
-.             2224 X598000-0    Ba Lo Ni           004 --     K3V M1D 
-.             2324 X537000-0    Ba Lo Ni           014 --     M0V M7D 
+.             2124 X99A000-0    Ba Lo Ni Wa        003 --     M5V M7V
+.             2224 X598000-0    Ba Lo Ni           004 --     K3V M1V
+.             2324 X537000-0    Ba Lo Ni           014 --     M0V M7V
 .             2424 X610000-0    Ba Lo Ni           012 --     M5III 
 .             3224 X758000-0    Ba Lo Ni           024 --     F1V 
 .             0225 X100000-0    Ba Lo Ni Va        003 --     F6V 
 .             0825 X628000-0    Ba Lo Ni           003 --     M7V 
 .             1025 X786000-0    Ba Lo Ni           000 --     F9V 
-.             1425 X477000-0    Ba Lo Ni           001 --     F9V M4D 
+.             1425 X477000-0    Ba Lo Ni           001 --     F9V M4V
 .             1725 X8A7000-0    Ba Fl Lo Ni        000 --     M3V 
 .             1825 X787000-0    Ba Lo Ni           012 --     F2V 
 .             1925 X455000-0    Ba Lo Ni           002 --     F3V 
 .             2125 X859000-0    Ba Lo Ni           003 --     F2V 
-.             2525 X235000-0    Ba Lo Ni           006 --     M6V M7D 
-.             2625 X130000-0    Ba De Lo Ni Po     002 --     M4V M3V 
+.             2525 X235000-0    Ba Lo Ni           006 --     M6V M7V
+.             2625 X130000-0    Ba De Lo Ni Po     002 --     M3V M4V
 .             2725 X100000-0    Ba Lo Ni Va        000 --     M2V 
 .             3025 X947000-0    Ba Lo Ni           004 --     F1V 
 .             3125 X7A2000-0    Ba Fl Lo Ni        000 --     K9V 
-.             3225 X201000-0    Ba Ic Lo Ni Va     000 --     F1V M8D 
-.             0126 X696000-0    Ba Lo Ni           000 --     F6V M6D 
+.             3225 X201000-0    Ba Ic Lo Ni Va     000 --     F1V M8V
+.             0126 X696000-0    Ba Lo Ni           000 --     F6V M6V
 .             0626 X544000-0    Ba Lo Ni           001 --     F8V 
 .             0726 X110000-0    Ba Lo Ni           010 --     M6V 
 .             1326 X200000-0    Ba Lo Ni Va        010 --     G5V 
 .             1826 X000000-0    As Ba Lo Ni        003 --     K6V 
 .             2826 X676000-0    Ba Lo Ni           003 --     F6V 
 .             2926 X662000-0    Ba Lo Ni           004 --     K0V 
-.             0127 X569000-0    Ba Lo Ni           013 --     F7V M6D 
+.             0127 X569000-0    Ba Lo Ni           013 --     F7V M6V
 .             0427 X000000-0    As Ba Lo Ni        001 --     G9V 
 .             0827 X435000-0    Ba Lo Ni           003 --     F2V 
 .             1327 X000000-0    As Ba Lo Ni        013 --     G7V 
@@ -253,26 +253,26 @@ Zortakh
 .             2327 X110000-0    Ba Lo Ni           005 --     G5V 
 .             2427 X89A000-0    Ba Lo Ni Wa        000 --     F4V 
 .             3127 X201000-0    Ba Ic Lo Ni Va     002 --     A7V 
-.             0128 X8C3000-0    Ba Fl Lo Ni        018 --     G5V M4D 
+.             0128 X8C3000-0    Ba Fl Lo Ni        018 --     G5V M4V
 .             0228 X474000-0    Ba Lo Ni           014 --     F2V 
-.             0528 X9B4000-0    Ba Fl Lo Ni        012 --     M3V M2D 
+.             0528 X9B4000-0    Ba Fl Lo Ni        012 --     M2V M3V
 .             0628 X459000-0    Ba Lo Ni           003 --     F8V 
-.             1228 X522000-0    Ba Lo Ni Po        030 --     M6V M5D 
+.             1228 X522000-0    Ba Lo Ni Po        030 --     M5V M6V
 .             1528 X261000-0    Ba Lo Ni           003 --     F3V 
-.             2128 X655000-0    Ba Lo Ni           004 --     M6V M0D 
-.             2328 X749000-0    Ba Lo Ni           013 --     G2V M2D 
+.             2128 X655000-0    Ba Lo Ni           004 --     M0V M6V
+.             2328 X749000-0    Ba Lo Ni           013 --     G2V M2V
 .             2528 X586000-0    Ba Lo Ni           022 --     F0V 
 .             2828 X413000-0    Ba Ic Lo Ni        000 --     K0V 
-.             2928 X755000-0    Ba Lo Ni           023 --     F3V M8D 
+.             2928 X755000-0    Ba Lo Ni           023 --     F3V M8V
 .             0229 X488000-0    Ba Lo Ni           013 --     F5V 
 .             0529 X877000-0    Ba Lo Ni           014 --     F0V 
 .             0629 X130000-0    Ba De Lo Ni Po     000 --     M3III M3V 
 .             1029 X420000-0    Ba De Lo Ni Po     001 --     M3V 
 .             1229 X372000-0    Ba Lo Ni           002 --     F5V 
-.             1429 X110000-0    Ba Lo Ni           002 --     G5V M7V 
-.             1929 X8B3000-0    Ba Fl Lo Ni        002 --     M0V M5D 
-.             2029 X655000-0    Ba Lo Ni           013 --     F9V M2D 
-.             2429 X591000-0    Ba Lo Ni           037 --     K3V M7D 
+.             1429 X110000-0    Ba Lo Ni           002 --     G5V M7V
+.             1929 X8B3000-0    Ba Fl Lo Ni        002 --     M0V M5V
+.             2029 X655000-0    Ba Lo Ni           013 --     F9V M2V
+.             2429 X591000-0    Ba Lo Ni           037 --     K3V M7V
 .             2729 X426000-0    Ba Lo Ni           000 --     F3V 
 .             2829 X696000-0    Ba Lo Ni           002 --     F3V 
 .             3029 X242000-0    Ba Lo Ni Po        001 --     F7V 
@@ -281,82 +281,82 @@ Zortakh
 .             1430 X000000-0    As Ba Lo Ni        013 --     F4V 
 .             1830 X525000-0    Ba Lo Ni           021 --     G6III 
 .             2030 X584000-0    Ba Lo Ni           001 --     F1V 
-.             2730 X130000-0    Ba De Lo Ni Po     000 --     F8V M0D 
+.             2730 X130000-0    Ba De Lo Ni Po     000 --     F8V M0V
 .             3030 X000000-0    As Ba Lo Ni        003 --     F0V M6V 
 .             3230 X559000-0    Ba Lo Ni           003 --     F2V 
 .             0131 X6B2000-0    Ba Fl Lo Ni        001 --     F5V 
 .             1131 X77A000-0    Ba Lo Ni Wa        004 --     K2V 
-.             1531 X200000-0    Ba Lo Ni Va        003 --     M7V M5D 
+.             1531 X200000-0    Ba Lo Ni Va        003 --     M5V M7V
 .             1931 X400000-0    Ba Lo Ni Va        004 --     K1V 
 .             2031 XA89000-0    Ba Lo Ni           002 --     F5V 
-.             0332 X99A000-0    Ba Lo Ni Wa        005 --     F9V M7D 
-.             0532 X998000-0    Ba Lo Ni           005 --     F1V M2D M7D 
+.             0332 X99A000-0    Ba Lo Ni Wa        005 --     F9V M7V
+.             0532 X998000-0    Ba Lo Ni           005 --     F1V M2V M7V
 .             0732 X773000-0    Ba Lo Ni           022 --     F1V 
-.             0932 X400000-0    Ba Lo Ni Va        017 --     K5V M7D 
+.             0932 X400000-0    Ba Lo Ni Va        017 --     K5V M7V
 .             1132 X635000-0    Ba Lo Ni           012 --     A9V 
 .             1332 X74A000-0    Ba Lo Ni Wa        024 --     G6V 
 .             1732 X896000-0    Ba Lo Ni           012 --     F0V 
 .             2332 X300000-0    Ba Lo Ni Va        004 --     F4V 
 .             2632 X574000-0    Ba Lo Ni           001 --     F1V 
 .             2732 X423000-0    Ba Lo Ni Po        002 --     M7V 
-.             3132 X474000-0    Ba Lo Ni           005 --     G4V M8D 
+.             3132 X474000-0    Ba Lo Ni           005 --     G4V M8V
 .             0933 X888000-0    Ba Lo Ni           024 --     F4V 
-.             2333 X428000-0    Ba Lo Ni           000 --     F3V M6D 
-.             2433 X510000-0    Ba Lo Ni           010 --     M1V M6D 
+.             2333 X428000-0    Ba Lo Ni           000 --     F3V M6V
+.             2433 X510000-0    Ba Lo Ni           010 --     M1V M6V
 .             3133 X889000-0    Ba Lo Ni           000 --     F0V 
-.             0134 X311000-0    Ba Ic Lo Ni        023 --     M7V M8D 
-.             0334 X424000-0    Ba Lo Ni           001 --     G1V M6D 
+.             0134 X311000-0    Ba Ic Lo Ni        023 --     M7V M8V
+.             0334 X424000-0    Ba Lo Ni           001 --     G1V M6V
 .             0434 X402000-0    Ba Ic Lo Ni Va     002 --     M5V 
-.             1034 X655000-0    Ba Lo Ni           040 --     F2V F0V M0D 
+.             1034 X655000-0    Ba Lo Ni           040 --     F0V F2V M0V
 .             1434 X692000-0    Ba Lo Ni           024 --     K9V 
 .             1534 X333000-0    Ba Lo Ni Po        002 --     M7V 
 .             1934 X86A000-0    Ba Lo Ni Wa        004 --     F2V 
-.             2334 X100000-0    Ba Lo Ni Va        001 --     M0V M6D 
+.             2334 X100000-0    Ba Lo Ni Va        001 --     M0V M6V
 .             2434 X310000-0    Ba Lo Ni           013 --     A6III 
-.             2534 X789000-0    Ba Lo Ni           004 --     F2V M3D 
-.             3034 X464000-0    Ba Lo Ni           023 --     G1V F4V 
+.             2534 X789000-0    Ba Lo Ni           004 --     F2V M3V
+.             3034 X464000-0    Ba Lo Ni           023 --     F4V G1V
 .             0735 X8C3000-0    Ba Fl Lo Ni        003 --     K9V 
-.             1635 X330000-0    Ba De Lo Ni Po     017 --     K7V M0D 
-.             2135 X340000-0    Ba De Lo Ni Po     006 --     G7V M5D 
+.             1635 X330000-0    Ba De Lo Ni Po     017 --     K7V M0V
+.             2135 X340000-0    Ba De Lo Ni Po     006 --     G7V M5V
 .             2235 X734000-0    Ba Lo Ni           023 --     G7V 
-.             2335 X896000-0    Ba Lo Ni           030 --     F7V M0D 
-.             2635 X000000-0    As Ba Lo Ni        015 --     K7V M7D M3D 
-.             2735 X310000-0    Ba Lo Ni           004 --     K9V F0V 
-.             2835 X400000-0    Ba Lo Ni Va        023 --     M0V M3D 
-.             3235 X554000-0    Ba Lo Ni           006 --     F5V M3D 
+.             2335 X896000-0    Ba Lo Ni           030 --     F7V M0V
+.             2635 X000000-0    As Ba Lo Ni        015 --     K7V M7V M3V
+.             2735 X310000-0    Ba Lo Ni           004 --     F0V K9V
+.             2835 X400000-0    Ba Lo Ni Va        023 --     M0V M3V
+.             3235 X554000-0    Ba Lo Ni           006 --     F5V M3V
 .             0336 X637000-0    Ba Lo Ni           014 --     G0V 
 .             1436 X403000-0    Ba Ic Lo Ni Va     002 --     F6V 
 .             1736 X587000-0    Ba Lo Ni           003 --     F6V 
 .             1836 X505000-0    Ba Ic Lo Ni Va     021 --     M4V 
 .             2336 X63A000-0    Ba Lo Ni Wa        000 --     M0V 
-.             2736 X9A3000-0    Ba Fl Lo Ni        013 --     M1V M2D 
+.             2736 X9A3000-0    Ba Fl Lo Ni        013 --     M1V M2V
 .             2936 X99A000-0    Ba Lo Ni Wa        000 --     F2V 
-.             3236 X450000-0    Ba De Lo Ni Po     003 --     F9V M0D 
+.             3236 X450000-0    Ba De Lo Ni Po     003 --     F9V M0V
 .             0437 X448000-0    Ba Lo Ni           003 --     F9V 
-.             0937 X95A000-0    Ba Lo Ni Wa        001 --     K3V M3D 
+.             0937 X95A000-0    Ba Lo Ni Wa        001 --     K3V M3V
 .             1437 X6B0000-0    Ba De Lo Ni        003 --     K9V 
-.             1837 X6A0000-0    Ba De Lo Ni        004 --     K3V M1D 
-.             2037 X510000-0    Ba Lo Ni           002 --     K1V M5V 
+.             1837 X6A0000-0    Ba De Lo Ni        004 --     K3V M1V
+.             2037 X510000-0    Ba Lo Ni           002 --     K1V M5V
 .             2437 X543000-0    Ba Lo Ni Po        000 --     M2V 
 .             2837 X535000-0    Ba Lo Ni           022 --     K6V 
 .             0338 X432000-0    Ba Lo Ni Po        001 --     M4V 
-.             0738 X698000-0    Ba Lo Ni           015 --     F6V M1D 
-.             1138 X100000-0    Ba Lo Ni Va        005 --     M2II M6V 
-.             1438 X000000-0    As Ba Lo Ni        003 --     M7V M5D 
-.             1738 X797000-0    Ba Lo Ni           002 --     M4V M3D 
-.             2138 X9A4000-0    Ba Fl Lo Ni        002 --     M1V M8D 
-.             2238 X655000-0    Ba Lo Ni           010 --     G4V M5D 
+.             0738 X698000-0    Ba Lo Ni           015 --     F6V M1V
+.             1138 X100000-0    Ba Lo Ni Va        005 --     M2II M6V
+.             1438 X000000-0    As Ba Lo Ni        003 --     M5V M7V
+.             1738 X797000-0    Ba Lo Ni           002 --     M3V M4V
+.             2138 X9A4000-0    Ba Fl Lo Ni        002 --     M1V M8V
+.             2238 X655000-0    Ba Lo Ni           010 --     G4V M5V
 .             2338 X9B5000-0    Ba Fl Lo Ni        000 --     F3V 
 .             2738 X210000-0    Ba Lo Ni           013 --     M4V 
 .             2938 X563000-0    Ba Lo Ni           003 --     F8V 
 .             0439 X160000-0    Ba De Lo Ni        014 --     F2V 
-.             0639 X739000-0    Ba Lo Ni           004 --     M2V M7D 
+.             0639 X739000-0    Ba Lo Ni           004 --     M2V M7V
 .             0739 X482000-0    Ba Lo Ni           020 --     F1V 
 .             1439 X989000-0    Ba Lo Ni           010 --     M3V 
 .             1739 X767000-0    Ba Lo Ni           004 --     F7V 
-.             1939 X535000-0    Ba Lo Ni           014 --     K6V M7D 
-.             2239 X200000-0    Ba Lo Ni Va        012 --     G8V M5D 
-.             2939 X435000-0    Ba Lo Ni           016 --     K9V M7D 
+.             1939 X535000-0    Ba Lo Ni           014 --     K6V M7V
+.             2239 X200000-0    Ba Lo Ni Va        012 --     G8V M5V
+.             2939 X435000-0    Ba Lo Ni           016 --     K9V M7V
 .             3239 X777000-0    Ba Lo Ni           004 --     F2V 
 .             0540 X594000-0    Ba Lo Ni           004 --     F7V 
-.             1940 X521000-0    Ba Lo Ni Po        014 --     M1V M3D 
+.             1940 X521000-0    Ba Lo Ni Po        014 --     M1V M3V


### PR DESCRIPTION
@inexorabletash asked me to, when submitting bulk sector-data fixen, break up said fixen PRs into different classes of sectors, so here goes with squaring up the stellar data in Undeveloped Sectors.
I'm not making any deliberate attempt to canonicalise star sizes as per T5.10 Book 3 p 28.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is _swapped_ into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).