### PR TITLE
Fix stellar data in Undeveloped Sectors , round 2

### DIFF
--- a/res/Sectors/M1105/Knaeleng.sec
+++ b/res/Sectors/M1105/Knaeleng.sec
@@ -16,29 +16,29 @@ Knaeleng
 #--------1---------2---------3---------4---------5---------6---
 #PlanetName   Loc. UPP Code   B   Notes         Z  PBG Al LRX *
 #----------   ---- ---------  - --------------- -  --- -- --- -
-Dikhoghai     0101 C327778-6                       713 Va     M6V M8D
-Ksouegzoe     0301 C747685-2    Ag Ni              514 Va     F0V M8D
-Uegvounu      0701 B464554-8  G Ag Ni              604 Va     F9V M2D
-Taekhi        0801 C444100-7  C Lo Ni              512 Va     K5V M7D
+Dikhoghai     0101 C327778-6                       713 Va     M6V M8V
+Ksouegzoe     0301 C747685-2    Ag Ni              514 Va     F0V M8V
+Uegvounu      0701 B464554-8  G Ag Ni              604 Va     F9V M2V
+Taekhi        0801 C444100-7  C Lo Ni              512 Va     K5V M7V
 Nakhusar      1401 C100363-6  G Lo Ni Va           303 Va     M2V
 Dhakegzan     1501 C448563-9    Ag Ni              601 Va     F5V
 Agzanrae      1601 C8A2623-9    Fl Ni              303 Va     F5II
-Gnaoo         2401 B97A451-D    Ni Wa              910 Va     F2V M0D
-Osuetsadh     1302 C75367B-7  C Ag Ni Po           504 Va     G9V M7D
-Likholaengo   1502 C766575-3  C Ag Ni              612 Va     G9V M8D
+Gnaoo         2401 B97A451-D    Ni Wa              910 Va     F2V M0V
+Osuetsadh     1302 C75367B-7  C Ag Ni Po           504 Va     G9V M7V
+Likholaengo   1502 C766575-3  C Ag Ni              612 Va     G9V M8V
 Feighthaerr   2302 C410976-B    Hi Na              700 Va     F3V
 Knuzae        2502 C255446-6    Ni                 901 Va     F8V
-Doukaedhal    2602 C43487B-8                       704 Va     F2V M1D
-Asgvughz      0103 C200875-5  C Na Va              703 Va     F2D
+Doukaedhal    2602 C43487B-8                       704 Va     F2V M1V
+Asgvughz      0103 C200875-5  C Na Va              703 Va     F2V
 Sulueng       0203 C778579-6    Ag Ni              411 Va     G8V
 Llakha        0503 B7C2556-B    Fl Ni              202 Va     M2V
-Iklorrghvoul  0603 E341250-5    Lo Ni Po           704 Va     K2V M7D
+Iklorrghvoul  0603 E341250-5    Lo Ni Po           704 Va     K2V M7V
 Oegor         0703 B6767B8-6  G Ag                 400 Va     F4V
-Aedhueuen     1203 C231301-8  C Lo Ni Po           200 Va     M6V M5D
+Aedhueuen     1203 C231301-8  C Lo Ni Po           200 Va     M6V M5V
 Dadhusedz     1603 C7A3575-6  G Fl Ni              513 Va     G4V
 Kuenaz        2003 E6A2463-2  C Fl Ni              302 Va     M2V
 Naon          2703 C9D65A5-8  G Fl Ni              603 Va     F8V
-Zora          0104 B404A78-C  G Hi Ic Va           512 Va     G1D M6D
+Zora          0104 B404A78-C  G Hi Ic Va           512 Va     G1D M6V
 Saegakhau     0504 DAB8422-7  C Fl Ni              303 Va     M0V
 Khughaenuel   0704 B480574-8    De Ni              403 Va     G1V
 Gzaeghzaa     0804 B6735AE-8    Ag Ni              110 Va     F9V
@@ -46,71 +46,71 @@ Dharrgidza    0904 C330522-5    De Ni Po           242 Va     F1V M8D F8V M3V
 Thokul        1104 C221103-6  G Lo Ni Po           202 Va     M5V
 Vaoe          2204 C785366-6  C Lo Ni              404 Va     F0V
 Orrag         2404 C400100-9    Lo Ni Va           102 Va     M3V
-Laeirrgaks    0605 B261952-A  C Hi In              113 Va     F0V M3D
-Aesakhurrg    1505 E8C357A-8  C Fl Ni              614 Va     M4V M8D
+Laeirrgaks    0605 B261952-A  C Hi In              113 Va     F0V M3V
+Aesakhurrg    1505 E8C357A-8  C Fl Ni              614 Va     M4V M8V
 Llekho        1605 C34457C-6  C Ag Ni              703 Va     M4V
 Kougzarz      1705 C340A75-B  C De Hi In Po        916 Va     F6V M7V
-Nazae         1905 C879351-8    Lo Ni              500 Va     F1V M3D
-Touodzouue    2005 C473567-7    Ag Ni              203 Va     F7V M0D
+Nazae         1905 C879351-8    Lo Ni              500 Va     F1V M3V
+Touodzouue    2005 C473567-7    Ag Ni              203 Va     F7V M0V
 Khuearrzong   2305 C343467-8  H Ni Po              102 Va     M2V
 Zaedhoeodzi   2705 B200586-8    Ni Va              623 Va     K5V
 Gughoou       0606 C3228CB-8  C Na Po              810 Va     F3V
-Iraegknaen    0706 D576866-4                       515 Va     F7V M0D
+Iraegknaen    0706 D576866-4                       515 Va     F7V M0V
 Ladha         1306 C20055A-B    Ni Va              605 Va     K7V
 Igasorr       1606 C310567-8    Ni                 500 Va     K9V
-Faaoukhan     1706 C8C6976-8  C Fl Hi In           800 Va     F4V M7D
-Aenan         1906 C9D48B9-3    Fl                 524 Va     G6V M2D F4V M8D
+Faaoukhan     1706 C8C6976-8  C Fl Hi In           800 Va     F4V M7V
+Aenan         1906 C9D48B9-3    Fl                 524 Va     G6V M2D F4V M8V
 Avoeoekhs     2306 C659774-2                       700 Va     F1V
 Kakifoe       2406 C5A0899-8    De                 901 Va     F6V
-Aenggnaeng    2606 C763626-3    Ag Ni              706 Va     F9V M1D
+Aenggnaeng    2606 C763626-3    Ag Ni              706 Va     F9V M1V
 Saetsueno     2806 B8A9687-9    Fl Ni              212 Va     M2V
-Arrghiks      0307 E516313-1    Ic Lo Ni           210 Va     M5V M5D
+Arrghiks      0307 E516313-1    Ic Lo Ni           210 Va     M5V M5V
 Daeedhknaek   0707 C979121-7    Lo Ni              701 Va     F4V
-Oldusasghirz  0807 C120743-6    De Na Po           626 Va     M8V M5D
+Oldusasghirz  0807 C120743-6    De Na Po           626 Va     M8V M5V
 Ghaeko        0907 D210876-7  C Na                 213 Va     F4V
-Suo           1207 C510635-9  C Na Ni              606 Va     M5V M4D
-Gangkhueng    1707 C562465-6  G Ni                 122 Va     F4V M5D
-Ksoulla       2607 D441555-6    Ni Po              617 Va     G5V M8D
+Suo           1207 C510635-9  C Na Ni              606 Va     M5V M4V
+Gangkhueng    1707 C562465-6  G Ni                 122 Va     F4V M5V
+Ksoulla       2607 D441555-6    Ni Po              617 Va     G5V M8V
 Zoraung       2707 C896432-9    Ni                 600 Va     M3V
 Thoae         0608 C130977-B  G De Hi In Na Po     921 Va     F4V
 Aedo          0808 A6A0679-7  G De Ni              400 Va     M7V
 Ueghzang      0908 C251866-2    Po                 210 Va     F3V
-Zathaesisagh  1308 C462576-3  G Ni                 901 Va     F1V M3D
+Zathaesisagh  1308 C462576-3  G Ni                 901 Va     F1V M3V
 Zezanuen      1408 B7A0144-7  G De Lo Ni           723 Va     F3V
-Fothoadu      2108 B64869C-8  G Ag Ni              402 Va     F3V M0D
+Fothoadu      2108 B64869C-8  G Ag Ni              402 Va     F3V M0V
 Aefoerraerr   2308 C735779-9                       113 Va     M3V
 Egvagh        2508 C510222-5  G Lo Ni              601 Va     K5V
 Duegingoeudh  0109 A586630-6  G Ag Ni              312 Va     F2V
-Thatsae       0809 CA9A654-4    Ni Wa              605 Va     F8V M4D
-Kerozodzaks   1009 E10056B-7    Ni Va              101 Va     F7V M5D
+Thatsae       0809 CA9A654-4    Ni Wa              605 Va     F8V M4V
+Kerozodzaks   1009 E10056B-7    Ni Va              101 Va     F7V M5V
 Agzfouthnous  1309 B678467-7  G Ni                 110 Va     F8V
 Nguekogzgorr  1709 B594534-5  G Ag Ni              613 Va     F3V
 Zouavae       2109 C580466-6    De Ni              802 Va     F0V
 Dzoghonuedz   2409 D559754-2                       801 Va     F7V
-Sueouz        3009 X629A9A-4  C Hi In              203 Va     F9V M0D
+Sueouz        3009 X629A9A-4  C Hi In              203 Va     F9V M0V
 Thogzasaegha  0210 C343698-6    Ag Ni Po           100 Va     F7V
 Dzizenranoen  1110 B441886-6    Po                 324 Va     G8V
 Kukaegzuerz   1210 B576776-4    Ag                 402 Va     F6V
 Fisutsogh     1310 D120200-6  G De Lo Ni Po        200 Va     G9V
-Foeourrgh     1910 E464410-3  C Ni                 632 Va     F6V M6D
+Foeourrgh     1910 E464410-3  C Ni                 632 Va     F6V M6V
 Lligalaks     2110 C437400-6  C Ni                 303 Va     G3V
 Rrodhogoe     2210 B100644-7  G Na Ni Va           503 Va     M0III M3V
-Zagezoeng     2610 C300878-5  C Na Va              702 Va     F0D M4D
-Tireen        2910 X484XXX-X    An {Rosette}       XXX Va     F2V M4D
+Zagezoeng     2610 C300878-5  C Na Va              702 Va     F0D M4V
+Tireen        2910 X484XXX-X    An {Rosette}       XXX Va     F2V M4V
 Fovorruenuks  3210 C755502-A    Ag Ni              922 VA     F7V
-Anesdokon     0111 C100231-9  G Lo Ni Va           702 Va     M2V M7V M0D
+Anesdokon     0111 C100231-9  G Lo Ni Va           702 Va     M2V M7V M0V
 Dzoghaen      0311 B334583-A  G Ni                 311 Va     A9IV K9V
-Faefazoo      0911 B320743-A    De Na Po           502 Va     F8V M5D
+Faefazoo      0911 B320743-A    De Na Po           502 Va     F8V M5V
 Khueug        1511 C447563-6  C Ag Ni              620 VK     F8V
-Llaezoug      1711 A979536-7  G Ni                 307 Va     F8V M5D
-Thaeoes       3111 D15069B-5  C De Ni Po           436 VA     F6V M7D
+Llaezoug      1711 A979536-7  G Ni                 307 Va     F8V M5V
+Thaeoes       3111 D15069B-5  C De Ni Po           436 VA     F6V M7V
 Goulakonkar   3211 CA86975-5  C Hi In              504 VA     M7V
-Oudae         0212 X387622-0  C Ag Ni              203 Va     M1V M2D
+Oudae         0212 X387622-0  C Ag Ni              203 Va     M1V M2V
 Zoaaeng       0312 C898620-6    Ag Ni              900 Va     F5V
 Kaegoulon     0512 A200479-B    Ni Va              103 VK     M3V
 Oou           1512 C797344-6    Lo Ni              711 VK     F6V
 Knuengolats   2012 C240502-9    De Ni Po           410 Va     F7V
-Gaevaeenae    2112 E543645-2    Ag Ni Po           303 Va     K9V M5D
+Gaevaeenae    2112 E543645-2    Ag Ni Po           303 Va     K9V M5V
 Dhovorraa     2212 A63647A-A  G Ni                 522 Va     M7V K8V
 Aenkouz       2612 A310A78-E    Hi Na              400 Va     M3V
 Uenkhosfel    2812 B687510-9  C Ag Ni              900 VA     F4V
@@ -121,76 +121,76 @@ Ghoga         1413 D323776-4    Na Po              822 VK     M8V
 Idzoedhe      1513 C87A873-7    Wa                 402 VK     M0V
 Gzoingaeg     2213 D998731-1    Ag                 304 Va     K4V
 Kagesonaegh   2413 B452677-8  G Ni Po              803 Va     G8V
-Aeaknou       2813 B367444-A    Ni                 304 VA     F1V M2D
-Asoerou       3113 D455976-4    Hi In              304 VA     F0V M5D
+Aeaknou       2813 B367444-A    Ni                 304 VA     F1V M2V
+Asoerou       3113 D455976-4    Hi In              304 VA     F0V M5V
 Kaokasaer     0514 B687640-8  G Ag Ni Ri           904 VK     F1V
-Diodoe        0614 C52316B-6    Lo Ni Po           200 VK     M7V M8D
+Diodoe        0614 C52316B-6    Lo Ni Po           200 VK     M7V M8V
 Fuzou         1014 C611698-9  G Ic Na Ni           223 VK     M8V
 Dhoeeksvoen   1214 C401840-9    Ic Na Va           605 VK     F7V
 Ollkaen       1314 E437674-7  C Ni                 111 VK     F5IV
 Zougaerrghig  1514 C255977-9  C Hi In              604 VK     G5V
-Aksueui       1714 C100320-6    Lo Ni Va           510 Va     M2V M2D
+Aksueui       1714 C100320-6    Lo Ni Va           510 Va     M2V M2V
 Daeaendorz    1914 C000323-8    As Lo Ni           905 Va     F8V M2V
-Ruerra        2014 C744568-5  C Ag Ni              216 Va     F7V M2D
-Suniaen       2714 X424444-2  C Ni                 913 VA     K7V M0D
+Ruerra        2014 C744568-5  C Ag Ni              216 Va     F7V M2V
+Suniaen       2714 X424444-2  C Ni                 913 VA     K7V M0V
 Aghaeraedz    2914 D8C4445-8    Fl Ni              702 VA     F3V
-Vogvoeael     3114 D778722-3    Ag                 602 VA     F9V M0D
+Vogvoeael     3114 D778722-3    Ag                 602 VA     F9V M0V
 Karruez       0115 D423464-5    Ni Po              315 VK     G9V
 Vaksun        0515 D110642-7    Na Ni              202 VK     M3V
-Oedzang       0715 C8C2330-8  C Fl Lo Ni           302 VK     M0V M7D
+Oedzang       0715 C8C2330-8  C Fl Lo Ni           302 VK     M0V M7V
 Knaekhoo      1415 A565566-8    Ag Ni              503 VK     F3V
 Luennakkaks   1515 B511442-7  C Ic Ni              418 VK     F2III M4D F3V
 Dhakakueou    1915 X100410-0    Ni Va              200 Va     M5V
-Ngoeognaefue  2315 C410551-5  G Ni                 515 Va     G3V M0D
+Ngoeognaefue  2315 C410551-5  G Ni                 515 Va     G3V M0V
 Ksutssugh     2815 D657300-3    Lo Ni              900 VA     F5V
 Dzouthague    3215 C676134-2    Lo Ni              202 VA     F6V
-Tava          0116 E768878-3  C                    702 VK     F9V M6D
+Tava          0116 E768878-3  C                    702 VK     F9V M6V
 Aefuez        0416 C64A87A-8  H Wa                 803 VK     F5V
 Aethun        0616 E468669-0    Ag Ni Ri           900 VK     F1V
 Dhekaeaegoe   1016 C300100-8  C Lo Ni Va           601 VK     G5V
-Thasoeuegi    1116 C657895-3                       615 VK     F7V M1D
+Thasoeuegi    1116 C657895-3                       615 VK     F7V M1V
 Tarrung       1316 B888874-7                       303 VK     F2V
 Lighzoetsous  1416 C5A3978-9    Fl Hi In           502 VK     F4V
-Suluz         2216 E67A213-7  C Lo Ni Wa           602 Va     K3V M5D
+Suluz         2216 E67A213-7  C Lo Ni Wa           602 Va     K3V M5V
 Gakoungengaz  2416 A303554-A    Ic Ni Va           406 VA     M4V M1V
 Gvekse        2616 B677564-B  C Ag Ni              605 VA     F7V
 Naeaellku     2816 A8A2776-9    Fl                 103 VA     K5V
-Naksang       3016 C777215-4  H Lo Ni              507 VA     K6V M3D
+Naksang       3016 C777215-4  H Lo Ni              507 VA     K6V M3V
 Vuvadhuek     0117 AAC4544-C    Fl Ni              800 VK     K4V
 Gugvues       0417 E8C6978-3  C Fl Hi In           900 VK     F2V
 Olavi         0717 C260737-4  G De                 810 VK     F2V
 Tsaedukho     0917 C454643-5  G Ag Ni              900 VK     F9V
-Zueruzag      1317 C353250-5  C Lo Ni Po           902 VK     F6V M6D
+Zueruzag      1317 C353250-5  C Lo Ni Po           902 VK     F6V M6V
 Fungour       2117 C97A310-8  C Lo Ni Wa           803 Va     F4V
 Zaekakue      2417 C32487A-8  G                    224 VA     F4V
 Ksaga         2517 C6538BB-2  C Po                 800 VA     F5V
-Ghogvuon      2717 E488543-6  C Ag Ni              804 VA     G5V M4D
+Ghogvuon      2717 E488543-6  C Ag Ni              804 VA     G5V M4V
 Adeoesudhgug  3117 C753558-8    Ag Ni Po           211 VA     F3V
-Kave          3217 A839210-E    Lo Ni              402 VA     M5V M3D
+Kave          3217 A839210-E    Lo Ni              402 VA     M5V M3V
 Ivaegvagz     0218 B76287A-5                       904 VK     G1V
 Ksoosuegh     0318 C67557B-2  G Ag Ni              500 VK     F2V
 Gnua          0918 B6A0310-6    De Lo Ni           202 VK     M6V
 Alang         1018 B334976-7    Hi In              412 VK     F3V
-Aenga         2018 B676468-B    Ni                 603 Va     F3V M6D
+Aenga         2018 B676468-B    Ni                 603 Va     F3V M6V
 Ksenoe        3018 D442598-3    Ni Po              904 VA     F3V
 Dhoerr        3118 C9BA668-7    Fl Ni Wa           802 VA     K1III M7V
-Tsekuegang    0319 D550574-3  G De Ni Po           515 VK     K0V M2D
-Dodhfueth     0419 B252255-7  G Lo Ni Po           127 VK     G6V M8D
-Knuekes       0819 B110543-B  G Ni                 726 VK     K8V M0D
+Tsekuegang    0319 D550574-3  G De Ni Po           515 VK     K0V M2V
+Dodhfueth     0419 B252255-7  G Lo Ni Po           127 VK     G6V M8V
+Knuekes       0819 B110543-B  G Ni                 726 VK     K8V M0V
 Gvurrilvul    1019 B546310-7  G Lo Ni              421 VK     K8V
 Aesaenuell    1119 B7B4575-9    Fl Ni              300 VK     K0V
-Rrosoezzoedh  1619 C64A97B-8  G Hi In Wa           904 Va     M1V M3D
+Rrosoezzoedh  1619 C64A97B-8  G Hi In Wa           904 Va     M1V M3V
 Oungakh       2419 C779420-7  G Ni                 904 VA     K1V
 Izoegzoghz    2819 B468255-B    Lo Ni              111 VA     F7V
 Zegzidh       3019 C433778-9    Na Po              603 VA     K5V
 Ekno          3219 C673443-9  G Ni                 610 VA     F5V
 Vokoroentson  0620 A326558-B    Ni                 710 VK     F3V
 Tukedhzoerz   0720 X7C269D-1  C Fl Ni              212 VK     M1V
-Aroeoeur      1020 X749689-0  C Ni                 301 VK     F1V M3D
-Thaethunokh   1220 E98A368-7  C Lo Ni Wa           703 VK     F8V M7D
-Khokhdzagzon  1520 C445788-7  G Ag                 515 Va     F5V M5D
-Nufue         1620 E673423-4    Ni                 501 Va     G9V M3D
-Kozagho       2220 C6B4420-5    Fl Ni              602 VA     M6V M1D
+Aroeoeur      1020 X749689-0  C Ni                 301 VK     F1V M3V
+Thaethunokh   1220 E98A368-7  C Lo Ni Wa           703 VK     F8V M7V
+Khokhdzagzon  1520 C445788-7  G Ag                 515 Va     F5V M5V
+Nufue         1620 E673423-4    Ni                 501 Va     G9V M3V
+Kozagho       2220 C6B4420-5    Fl Ni              602 VA     M6V M1V
 Aeghikhsghes  2620 D384875-4                       814 VA     F8V
 Luzgolgan     2920 C7599BD-8  G Hi In              204 VA     F3V
 Aesing        3220 C448489-5  G Ni                 604 VA     G5V
@@ -198,27 +198,27 @@ Voeorsaerr    0121 B876404-9  C Ni                 202 VK     F2V
 Ullaorz       0421 A4246A6-A  G Ni                 800 VK     F6V
 Khaeuek       1221 B9B7353-A    Fl Lo Ni           723 VK     F8V
 Vugnodhos     1521 C352220-6    Lo Ni Po           120 Va     F4V
-Kuksezsong    1621 B8A078B-9    De                 902 Va     M3V M1D
+Kuksezsong    1621 B8A078B-9    De                 902 Va     M3V M1V
 Aerungokh     1921 E667778-3    Ag                 403 VA     G4V
-Ghaezoa       2421 C575123-2    Lo Ni              123 VA     F3V M0D
-Ghasa         2721 C785242-6    Lo Ni              615 VA     F0V M2D
-Naefirran     2921 B442002-7    Lo Ni Po           502 VA     F4V M7D
+Ghaezoa       2421 C575123-2    Lo Ni              123 VA     F3V M0V
+Ghasa         2721 C785242-6    Lo Ni              615 VA     F0V M2V
+Naefirran     2921 B442002-7    Lo Ni Po           502 VA     F4V M7V
 Katsuk        3021 C000653-B    As Na Ni           113 VA     F5V
-Zalghikanfag  3121 C686463-4  C Ni                 812 VA     M0V M5D
+Zalghikanfag  3121 C686463-4  C Ni                 812 VA     M0V M5V
 Lluenangaeng  3221 A120323-A  G De Lo Ni Po        414 VA     M3V M3V
 Garounuek     0922 C557555-6    Ag Ni              902 VK     F4V
 Knengorrg     1022 C8C0237-4    De Lo Ni           105 VK     M2V
 Ksokou        1722 B455534-7    Ag Ni              801 VA     F8V
 Lluru         1922 E54367B-3  C Ag Ni Po           800 VA     F0V
-Udhedoe       2122 C66467A-5    Ag Ni              812 VA     K0V M0D
-Knoeougarrg   2522 X237311-0  C Lo Ni              703 VA     K9V M3D
+Udhedoe       2122 C66467A-5    Ag Ni              812 VA     K0V M0V
+Knoeougarrg   2522 X237311-0  C Lo Ni              703 VA     K9V M3V
 Zaenotsae     2722 C330679-6  C De Na Ni Po        300 VA     M7V
 Tsadzazoz     2922 B410462-9  G Ni                 102 VA     M5V
-Kungoegzaeg   3022 C8887AC-4  C Ag                 901 VA     K3V M8D
-Eoenguekoer   0423 C446788-6  C Ag                 216 VK     G9V M4D
+Kungoegzaeg   3022 C8887AC-4  C Ag                 901 VA     K3V M8V
+Eoenguekoer   0423 C446788-6  C Ag                 216 VK     G9V M4V
 Zokoknerr     0723 C544379-2  C Lo Ni              600 VK     F5V
-Zinoea        0823 D300236-4  C Lo Ni Va           912 VK     G1V M8D
-Taegharoulo   0923 C575369-9    Lo Ni              412 VK     F5V M4D
+Zinoea        0823 D300236-4  C Lo Ni Va           912 VK     G1V M8V
+Taegharoulo   0923 C575369-9    Lo Ni              412 VK     F5V M4V
 Gaeaeksdhael  1223 C210100-A  G Lo Ni              902 VK     A7II
 Gaenkuth      1723 CAF4263-3    Fl Lo Ni           515 VA     F8V
 Sarrueg       1823 C327778-6                       900 VA     A6V
@@ -229,160 +229,160 @@ Dhizathgnull  2823 B765973-8  G Hi In              103 VA     K1V
 Ogzae         3123 C1207BF-7    De Na Po           702 VA     M6V
 Vounon        0324 B510551-8  G Ni                 902 VK     M3V
 Tsuegnaeang   0424 EAAA747-7  C Fl Wa              116 VK     F6V M2V
-Taafu         0524 B657543-6  G Ag Ni              803 VK     F8V M2D
+Taafu         0524 B657543-6  G Ag Ni              803 VK     F8V M2V
 Thueakue      0724 C887445-6  C Ni                 902 VK     M8V
-Rruvodzu      0824 C99A861-7  G Wa                 432 VK     M6V M6D
-Aezonneng     0924 AA8A674-A  G Ni Wa              423 VK     M1V M4D
+Rruvodzu      0824 C99A861-7  G Wa                 432 VK     M6V M6V
+Aezonneng     0924 AA8A674-A  G Ni Wa              423 VK     M1V M4V
 Kourarrgarr   1624 B548777-5  C Ag                 403 Va     M6V
 Gvodza        2124 B130100-B  G De Lo Ni Po        804 VA     M4V
-Guarraerr     2324 C748AAC-9    Hi In              500 VA     F6V M0D
+Guarraerr     2324 C748AAC-9    Hi In              500 VA     F6V M0V
 Athag         2424 B256265-A    Lo Ni              202 VA     F0V
 Gokokhllukug  2824 A538410-B    Ni                 700 VA     K0V
 Dugsasae      2924 C53259D-8  C Ni Po              314 VA     G3V
 Uksits        3024 D694240-6  C Lo Ni              804 VA     M2V
 Gurruzaengan  0225 C866120-2    Lo Ni              613 VK     K4V
-Khaezaikue    0325 C224447-A  C Ni                 806 VK     M8V M6D
+Khaezaikue    0325 C224447-A  C Ni                 806 VK     M8V M6V
 Rrouuekhs     0525 C2117CF-4    Ic Na              523 VK     K8III
-Oegturr       0825 C653579-5    Ag Ni Po           805 VK     M6V M1D
+Oegturr       0825 C653579-5    Ag Ni Po           805 VK     M6V M1V
 Llaeksaezal   1525 E200500-6  C Ni Va              701 Va     M8V
-Nuetaoknen    1625 A68A200-D  G Lo Ni Wa           401 Va     F5V M0D
+Nuetaoknen    1625 A68A200-D  G Lo Ni Wa           401 Va     F5V M0V
 Dzaezele      1725 C484200-9  G Lo Ni              600 Va     M1V
 Rruezakhsaz   1825 B575576-B    Ag Ni              920 Va     F1V
 Louthurrg     2325 CAB6202-8  H Fl Lo Ni           500 VA     M8V M6V
-Knaedzae      3025 B648535-4    Ag Ni              215 VA     F0V M2D
-Kouzalogh     3125 C648668-2  C Ag Ni              902 VA     M4V M8D
-Dikhsaers     0126 C586677-6  G Ag Ni              927 VK     F8V K2V M5D
-Asrrolang     0226 D000554-B  C As Ni              602 VK     F2V M1D
+Knaedzae      3025 B648535-4    Ag Ni              215 VA     F0V M2V
+Kouzalogh     3125 C648668-2  C Ag Ni              902 VA     M4V M8V
+Dikhsaers     0126 C586677-6  G Ag Ni              927 VK     F8V K2V M5V
+Asrrolang     0226 D000554-B  C As Ni              602 VK     F2V M1V
 Vangaeksksal  0426 C538678-5    Ni                 718 VK     M1V M3V
 Dzaekang      0826 C895778-3  G Ag                 401 VK     F5V
 Leaefazae     0926 E768462-6    Ni                 903 VK     K8V
 Dhuksalaeng   1126 C555333-5  G Lo Ni              614 VK     F5V
-Uthaethu      1426 C462973-7  C Hi In              421 Va     F3V M5D
-Arruedzae     1526 C521343-8    Lo Ni Po           122 Va     A7V M0D
+Uthaethu      1426 C462973-7  C Hi In              421 Va     F3V M5V
+Arruedzae     1526 C521343-8    Lo Ni Po           122 Va     A7V M0V
 Aeluenaeth    2126 E729640-5    Ni                 814 Va     K2V M8V
 Gozo          3026 D526740-5  C                    311 VA     F7V
 Kseksukoae    0727 A413300-A    Ic Lo Ni           103 VK     G8V
-Aenukoun      1627 D582877-2                       725 Va     F9V M1D
+Aenukoun      1627 D582877-2                       725 Va     F9V M1V
 Oerdzikh      1727 C699778-8  G                    702 Va     M5V
-Saenknanuerr  1827 C373555-9    Ag Ni              814 Va     F4V M8D
+Saenknanuerr  1827 C373555-9    Ag Ni              814 Va     F4V M8V
 Vuthengang    2527 C76A244-5    Lo Ni Wa           713 Ve     F1V
 Safofaevue    0628 C646310-7  G Lo Ni              703 VK     K3V
-Dhudzzugh     0728 C554121-7    Lo Ni              536 VK     K3V M1D
-Kazudou       0928 C473464-A    Ni                 614 VK     F3V M2D F3V M0D M5D
+Dhudzzugh     0728 C554121-7    Lo Ni              536 VK     K3V M1V
+Kazudou       0928 C473464-A    Ni                 614 VK     F3V M2D F3V M0D M5V
 Soukogthae    1228 C100302-9  C Lo Ni Va           703 Va     M7V
-Daengvagh     1328 C466979-B    Hi In              815 Va     F9V M7D
+Daengvagh     1328 C466979-B    Hi In              815 Va     F9V M7V
 Kuellingez    2528 E484534-6  C Ag Ni              505 Ve     K9V
-Oedhthueghz   3028 CAC8642-2  C Fl Ni              501 Ve     M7V M5D
+Oedhthueghz   3028 CAC8642-2  C Fl Ni              501 Ve     M7V M5V
 Gzizue        3128 A595530-D  G Ag Ni              224 Ve     K2V
-Ghezesurrgh   0129 B231500-C  C Ni Po              903 Ve     M2V M8D
-Zoevanaegats  0229 B6A3523-7  C Fl Ni              406 Ve     F2V M7D M8D
+Ghezesurrgh   0129 B231500-C  C Ni Po              903 Ve     M2V M8V
+Zoevanaegats  0229 B6A3523-7  C Fl Ni              406 Ve     F2V M7D M8V
 Zozaeue       1129 D654341-6  C Lo Ni              905 Va     K9V
 Fonveg        2129 A452332-A    Lo Ni Po           900 Ve     F8V
 Kadzue        2329 C234436-7    Ni                 702 Ve     M2V
-Ksoghzozaz    2529 D9B3567-6    Fl Ni              311 Ve     M3V M8D
+Ksoghzozaz    2529 D9B3567-6    Fl Ni              311 Ve     M3V M8V
 Egefae        2629 C200235-A    Lo Ni Va           820 Ve     M6V
 Nudzaeda      3029 C236401-A  C Ni                 602 Ve     M6V M1V
-Gaktsolig     3129 C120999-B    De Hi In Na Po     315 Ve     G9V M2D
-Llaknurroen   0730 E455648-3  C Ag Ni              503 Ve     F0V M2D
+Gaktsolig     3129 C120999-B    De Hi In Na Po     315 Ve     G9V M2V
+Llaknurroen   0730 E455648-3  C Ag Ni              503 Ve     F0V M2V
 Sazesuerrgh   1530 C504505-8  G Ic Ni Va           823 Ve     K6V
 Koeghthoez    1830 C410000-8    Ba Lo Ni           700 Ve     M6III
 Ksogllokhan   2330 C342443-5    Ni Po              112 Ve     F7V
 Sorruelkakh   3030 C436743-A                       804 Ve     M2V M2V
 Kovaekang     3130 X967456-0  C Ni                 112 Ve     F6V
-Ungvuekong    0931 B372334-7  C Lo Ni              904 Ve     K9V M4D
+Ungvuekong    0931 B372334-7  C Lo Ni              904 Ve     K9V M4V
 Katsasdhedh   1231 E737863-4  C                    311 Ve     F3V
-Rradhoutu     1331 D325120-7  C Lo Ni              302 Ve     F0V M7D
+Rradhoutu     1331 D325120-7  C Lo Ni              302 Ve     F0V M7V
 Tharralogarr  1631 D686320-4  C Lo Ni              307 Ve     F8V F9V
 Oakkaeng      1831 C210002-4  G Lo Ni              601 Ve     F2V
-Degvog        2031 B592263-5  C Lo Ni              704 Ve     F0V M3D
-Thuezaaruel   2231 C694772-4  C Ag                 403 Ve     F0V M0D
-Luskaersull   2331 E8B2100-8  C Fl Lo Ni           902 Ve     M2V M5D
-Auvuotsaeue   2931 C779677-6  G Ni                 123 Ve     F2V M6D
+Degvog        2031 B592263-5  C Lo Ni              704 Ve     F0V M3V
+Thuezaaruel   2231 C694772-4  C Ag                 403 Ve     F0V M0V
+Luskaersull   2331 E8B2100-8  C Fl Lo Ni           902 Ve     M2V M5V
+Auvuotsaeue   2931 C779677-6  G Ni                 123 Ve     F2V M6V
 Knuekhoe      0232 C63738C-6  G Lo Ni              602 Ve     F2III K3V
-Kuevioenueng  0332 C345457-6  C Ni                 124 Ve     F0V M2D
+Kuevioenueng  0332 C345457-6  C Ni                 124 Ve     F0V M2V
 Osknuengaegz  0832 C610000-7  G Ba Lo Ni           204 Ve     K0V
 Ugnogvas      1032 E645457-5    Ni                 100 Ve     F6V
-Aorae         1332 B000326-D  G As Lo Ni           911 Ve     G9V M4D
+Aorae         1332 B000326-D  G As Lo Ni           911 Ve     G9V M4V
 Dzaaeza       1532 E69787A-0                       114 Ve     M1V
-Uaegzo        2432 C64A778-6    Wa                 315 Ve     G3V M3D
-Fueksour      2732 C400A77-C  G Hi Na Va           702 Ve     M1V M2D
-Agzaeghz      3232 C493696-5    Ag Ni              731 Va     F6V M4D
+Uaegzo        2432 C64A778-6    Wa                 315 Ve     G3V M3V
+Fueksour      2732 C400A77-C  G Hi Na Va           702 Ve     M1V M2V
+Agzaeghz      3232 C493696-5    Ag Ni              731 Va     F6V M4V
 Ongazaksa     0133 B674323-5  C Lo Ni              704 Ve     G1V
-Thengoukhugh  0333 D538A78-9  G Hi In              800 Ve     F4V M1D
+Thengoukhugh  0333 D538A78-9  G Hi In              800 Ve     F4V M1V
 Isaezogoun    0533 C7B7400-7  H Fl Ni              102 Ve     M5V
-Gnungdzoue    1033 C78786A-1  C Ri                 203 Ve     F7V M0D
-Keadzu        1333 C653456-A  C Ni Po              600 Ve     F5V M4D
-Oerresuz      1533 C427766-9  H                    222 Ve     F8V M6D
-Kaelanorok    1933 X475414-3  C Ni                 305 Ve     F8V M4D
-Foeinonuek    2233 E78948A-2  C Ni                 703 Ve     F5V M4D
+Gnungdzoue    1033 C78786A-1  C Ri                 203 Ve     F7V M0V
+Keadzu        1333 C653456-A  C Ni Po              600 Ve     F5V M4V
+Oerresuz      1533 C427766-9  H                    222 Ve     F8V M6V
+Kaelanorok    1933 X475414-3  C Ni                 305 Ve     F8V M4V
+Foeinonuek    2233 E78948A-2  C Ni                 703 Ve     F5V M4V
 Aethrigin     2433 D643468-2  H Ni Po              501 Ve     K7V
-Arrllorrgaae  2933 C757164-7    Lo Ni              405 Va     F9V M3D
+Arrllorrgaae  2933 C757164-7    Lo Ni              405 Va     F9V M3V
 Lloesozu      0734 C678569-4  G Ag Ni              604 Ve     G4V
-Zongakdhaerr  1734 C8A0332-A  C De Lo Ni           503 Ve     G4V M0D
+Zongakdhaerr  1734 C8A0332-A  C De Lo Ni           503 Ve     G4V M0V
 Kfadhazonodh  1934 A453343-8  G Lo Ni Po           400 Ve     G9V
-Vaaezoenirrg  2334 A53486B-7                       301 Ve     F1V M5D
-Foevirzaz     2434 C5496BE-5    Ni                 400 Ve     F5V M8D
+Vaaezoenirrg  2334 A53486B-7                       301 Ve     F1V M5V
+Foevirzaz     2434 C5496BE-5    Ni                 400 Ve     F5V M8V
 Dzueroune     0235 C530352-9    De Lo Ni Po        400 Ve     K0V
-Ouvogorruz    0535 B443547-9  C Ag Ni Po           914 Ve     K6V M6D
-Suerrarrall   0735 C85A79E-5  C Wa                 403 Ve     F3V M7D
-Guedogue      0835 C8D0976-7  G De Hi In           820 Ve     F8V M5D
+Ouvogorruz    0535 B443547-9  C Ag Ni Po           914 Ve     K6V M6V
+Suerrarrall   0735 C85A79E-5  C Wa                 403 Ve     F3V M7V
+Guedogue      0835 C8D0976-7  G De Hi In           820 Ve     F8V M5V
 Uekhsoroz     1035 C5236A7-2  G Na Ni Po           802 Ve     M0V
 Ogeghzoedz    1635 C777101-6  G Lo Ni              214 Ve     F7V
-Teknuezoe     1735 A560977-8    De Hi In           303 Ve     F2V M5D
+Teknuezoe     1735 A560977-8    De Hi In           303 Ve     F2V M5V
 Rrasakeksal   1935 B412568-6    Ic Ni              204 Ve     M6III
 Ghaeoezzaegh  2235 B575443-6    Ni                 600 Ve     F6V
 Teuesonuekhs  2435 B230630-8    De Na Ni Po        100 Ve     K2V
 Llaoe         2535 C746451-A    Ni                 224 Ve     G9V
-Vougza        2735 C100669-7    Na Ni Va           704 Va     F9V M6D
+Vougza        2735 C100669-7    Na Ni Va           704 Va     F9V M6V
 Ngatae        2935 D443879-5    Po                 321 Va     F7V
-Soae          3235 CA9A540-8    Ni Wa              804 Va     G0V M2D
-Dzaeva        0236 A220511-F  G De Ni Po           104 Ve     M0V M4D
+Soae          3235 CA9A540-8    Ni Wa              804 Va     G0V M2V
+Dzaeva        0236 A220511-F  G De Ni Po           104 Ve     M0V M4V
 Khuengzanigz  0336 B844246-9  G Lo Ni              800 Ve     F3V
 Faesouk       0536 B559641-5  G Ni                 603 Ve     G0V
 Aekekue       0636 A200872-D  G Na Va              123 Ve     F9V
-Rrangaesgza   0736 B100588-C    Ni Va              204 Ve     M8V M6D
+Rrangaesgza   0736 B100588-C    Ni Va              204 Ve     M8V M6V
 Aezo          0836 C5757CA-4    Ag                 300 Ve     F9V
 Faekaaae      1036 E866977-8    Hi In              318 Ve     G1V M2D F0V
-Dzongaerr     1236 C7B2132-7  G Fl Lo Ni           144 Ve     M4V M4D
+Dzongaerr     1236 C7B2132-7  G Fl Lo Ni           144 Ve     M4V M4V
 Ghua          1836 X667000-0    Ba Lo Ni           014 Ve     G0V
 Raersoghanuz  2236 E463110-8  C Lo Ni              612 Ve     F1V
 Vuegho        2436 C585578-3    Ag Ni              404 Ve     G5V
 Ngarrkosouvi  2836 C769677-7  C Ni                 200 Va     F6V
 Outaeoulue    2936 C100876-6  C Na Va              300 Va     F9V
 Knogan        3136 C331A78-7  C Hi In Na Po        702 Va     G0V
-Thaenadz      0437 A52667A-A    Ni                 217 Ve     G9V M3D
+Thaenadz      0437 A52667A-A    Ni                 217 Ve     G9V M3V
 Gogho         1137 C333679-7    Na Ni Po           922 Ve     F1IV
 Raezuvaevi    2137 C539867-4  G                    211 Ve     G0V
 Zonoeufogh    2337 C442677-7    Ni Po              413 Ve     G4V
-Fuegaearrgh   2937 E8899AA-8  C Hi In              904 Va     K9V M0D
-Kfueek        3237 C8B6778-3  C Fl                 603 Va     M3V M3D
+Fuegaearrgh   2937 E8899AA-8  C Hi In              904 Va     K9V M0V
+Kfueek        3237 C8B6778-3  C Fl                 603 Va     M3V M3V
 Zuesuksueks   0838 D382312-5    Lo Ni              522 Ve     F9V
 Khongonur     1438 E364875-4  C                    602 Ve     K9V
-Thaousrror    1538 E8C5630-1    Fl Ni              800 Ve     M1V M2D
+Thaousrror    1538 E8C5630-1    Fl Ni              800 Ve     M1V M2V
 Ursngakaekh   2138 C201420-9    Ic Ni Va           200 Ve     G6III
 Gzueovu       2338 C789512-6  G Ni                 501 Ve     F9V
 Aegzanorsak   2938 D486675-3    Ag Ni              205 Va     G9V
 Ouen          3238 C425121-4    Lo Ni              803 Va     M3V
 Ekador        0239 B687777-6  G Ag                 403 Ve     F0V
-Dosaedzung    0339 E66499D-5  C Hi In              425 Ve     K1V M1D
+Dosaedzung    0339 E66499D-5  C Hi In              425 Ve     K1V M1V
 Zaghaedhaeng  0539 E867647-3  C Ag Ni Ri           302 Ve     F5V
-Kaakhagz      0639 C693865-3                       512 Ve     K0V M7D
+Kaakhagz      0639 C693865-3                       512 Ve     K0V M7V
 Vakakiza      0739 C422532-8    Ni Po              523 Ve     G7V
 Fourzorr      1039 A427A9C-E  G Hi In              102 Ve     F9V
 Fuekhoufo     1439 D43678A-4                       114 Ve     M6V
-Koungegaeae   1639 A646545-C  G Ag Ni              102 Ve     F4V M5D
-Suekuuedz     1939 C340699-6  G De Ni Po           322 Ve     F7V M0D
-Dhodzueras    2039 C337A78-B    Hi In              802 Ve     G1V M2D
-Knovaero      3039 C420510-B  G De Ni Po           701 Va     K3V M0D
-Vaeourraekh   3139 B458579-9    Ag Ni              402 Va     M7V M7D
+Koungegaeae   1639 A646545-C  G Ag Ni              102 Ve     F4V M5V
+Suekuuedz     1939 C340699-6  G De Ni Po           322 Ve     F7V M0V
+Dhodzueras    2039 C337A78-B    Hi In              802 Ve     G1V M2V
+Knovaero      3039 C420510-B  G De Ni Po           701 Va     K3V M0V
+Vaeourraekh   3139 B458579-9    Ag Ni              402 Va     M7V M7V
 Llunankerz    0240 B261487-A    Ni                 102 Ve     F5V
 Arrggan       0340 E671742-2                       305 Ve     F8V
 Koufakhoog    0740 C22049B-B  G De Ni Po           430 Ve     M1V
 Zotuon        1440 E12057A-9    De Ni Po           902 Ve     M6V M7V
-Gnodhou       2040 C59A862-5    Wa                 801 Ve     M4V M3D
-Kueangaenvo   2240 E0009CC-9  C As Hi Na           304 Ve     F0D
-Goguekurrgh   2440 E50179A-5    Ic Na Va           907 Ve     M1V M1D
+Gnodhou       2040 C59A862-5    Wa                 801 Ve     M4V M3V
+Kueangaenvo   2240 E0009CC-9  C As Hi Na           304 Ve     F0V
+Goguekurrgh   2440 E50179A-5    Ic Na Va           907 Ve     M1V M1V
 Ghoeoer       2540 C679536-6    Ni                 210 Ve     F4V
 Dukfoellar    2940 C354430-5    Ni                 401 Va     K7V
 Untuen        3040 C433854-7    Na Po              614 Va     F3V
-Arrgnoenues   3140 C768698-8    Ag Ni Ri           925 Va     F3V M1D M3D
+Arrgnoenues   3140 C768698-8    Ag Ni Ri           925 Va     F3V M1D M3V

--- a/res/Sectors/M1105/Knoellighz.txt
+++ b/res/Sectors/M1105/Knoellighz.txt
@@ -34,9 +34,9 @@ Hex  Name                 UWP       Remarks                                     
 0309 Fitsekr              B342442-8 He Ni Po                                             { -1 } (931+1) [4339]       -   U 204 13 ZhSh M3 V
 0310 Klefriaaatsidl       B355333-C Lo                                                   { 1 }  (A21-4) [148C]       -   - 304  8 ZhSh F8 V D
 0314 Ila                  B7A4669-8 Fl Ni                                                { -1 } (755+4) [355B]       -   - 303 10 ZhSh M2 V D
-0318 Idrrrzrovryazh       D326774-7 Pi                                                   { -2 } (465-1) [6539]       -   - 905 11 ZhSh M6 V K5 V
-0319 Ipzhdievrebl         C543664-8 Ni Po O:Knoe-0520                                    { -2 } (751+5) [545B]       -   - 101 13 ZhSh M6 V K5 V
-0320 Odlinche             D221679-8 Na Ni Po                                             { -3 } (751+0) [8346]       -   - 101 10 ZhSh M6 V K5 V
+0318 Idrrrzrovryazh       D326774-7 Pi                                                   { -2 } (465-1) [6539]       -   - 905 11 ZhSh K5 V M6 V
+0319 Ipzhdievrebl         C543664-8 Ni Po O:Knoe-0520                                    { -2 } (751+5) [545B]       -   - 101 13 ZhSh K5 V M6 V
+0320 Odlinche             D221679-8 Na Ni Po                                             { -3 } (751+0) [8346]       -   - 101 10 ZhSh K5 V M6 V
 0321 Zhiblchins           A323553-D Ni Po Cp                                             { 1 }  (F45+2) [365E]       -   - 603 10 ZhSh M5 V
 0322 Prtabrket            D3204A9-A De He Ni Po                                          { -1 } (934+3) [8395]       -   U 101 10 ZhSh M5 V
 0324 Chavlzhdoblshet      B526765-8 Pi                                                   { 0 }  (866+3) [576C]       -   - 503  9 ZhSh F8 V D
@@ -94,7 +94,7 @@ Hex  Name                 UWP       Remarks                                     
 0637 Asal                 B5A0500-D He Ni                                                { 1 }  (A47+1) [563D]       C   - 312 10 NaVa M0 V
 0639 Thaerarrg            C6A0331-6 He Lo                                                { -2 } (B21-1) [5154]       -   - 502 13 NaVa M6 II K2 V
 0705 Ghingtholkoengaedh   C4126BC-A Ic Na Ni Co Pz                                       { 0 }  (D56+0) [3656]       -   A 104 15 NaVa M0 V D
-0707 Kaezthuerserrgh      D410545-7 Ni                                                   { -3 } (740+3) [1267]       K   - 300  8 NaVa M8 V M6 V D
+0707 Kaezthuerserrgh      D410545-7 Ni                                                   { -3 } (740+3) [1267]       K   - 300  8 NaVa M6 V M8 V D
 0710 Iezhdebdleflsha      A260301-E De Lo Cp                                             { 2 }  (921+0) [358F]       KM  - 802  8 ZhSh F5 V D
 0711 Tliaklo              B221675-C Na Ni Po                                             { 1 }  (A55+0) [678B]       -   - 802  9 ZhSh M4 V
 0712 Epfintsplrz          D310534-6 Ni                                                   { -3 } (842+2) [5251]       -   - 101  7 ZhSh M4 V
@@ -157,10 +157,10 @@ Hex  Name                 UWP       Remarks                                     
 1110 Dhughre              C240165-6 De Lo Po O:Knoe-1109                                 { -2 } (701-3) [1188]       C   - 111  9 NaVa F6 V
 1114 Aenguezae            B140664-8 De Ni Po O:Knoe-1212                                 { -1 } (C53+2) [553C]       -   - 203 14 NaVa F2 V D
 1119 Vanthoskaedhokhsig   C451267-6 Lo Po O:Knoe-1020                                    { -2 } (811+0) [5195]       -   - 304 11 NaVa F9 V D
-1123 Aegverrgfakh         C564103-5 Lo                                                   { -2 } (601+2) [2173]       -   - 204 13 NaVa M7 V D K2 V
+1123 Aegverrgfakh         C564103-5 Lo                                                   { -2 } (601+2) [2173]       -   - 204 13 NaVa K2 V D M7 V
 1127 Thueknorrurr         B679000-A Di                                                   { 1 }  (B03-1) [0000]       K   - 315 16 VAsP F9 V D
 1128 Ukhunllorr           D237854-6 Ph                                                   { -2 } (476+1) [766B]       K   - 101  8 VAsP F9 V D
-1131 Tsouu                D98A463-5 Ni Wa                                                { -3 } (833+5) [4181]       C   - 102  8 VInL K5 V F7 V D
+1131 Tsouu                D98A463-5 Ni Wa                                                { -3 } (833+5) [4181]       C   - 102  8 VInL F7 V K5 V D
 1134 Tuellaerrghog        C5A0588-4 He Ni                                                { -2 } (742+0) [2334]       -   - 803 10 NaVa F9 V D
 1137 Orrgto               A475253-D Lo                                                   { 1 }  (911-2) [337D]       -   - 101 10 VInL F9 V D
 1138 Duelunogoerrzuez     B000A79-B As Hi In Na Va C:Knoe-1036 Cp Cx                     { 4 }  (99C+1) [BE6A]       -   - 602 13 VInL G5 V D
@@ -346,7 +346,7 @@ Hex  Name                 UWP       Remarks                                     
 2233 Ksaellaez            C553102-5 Lo Po                                                { -2 } (501+1) [21A2]       C   - 312  8 NaVa F5 V D
 2237 Uosa                 D544976-8 Hi In                                                { 0 }  (A8B+1) [B945]       C   - 116 16 VAsP F6 V D
 2240 Uknonueng            X78A576-1 Ni Pr Wa                                             { -3 } (B43-4) [7254]       C   - 808  8 VAsP K6 V D
-2301 Oknaeg               B40547B-B Ic Ni Va Co                                          { 1 }  (D34-2) [353E]       C   - 503 16 NaVa M3 V M1 V
+2301 Oknaeg               B40547B-B Ic Ni Va Co                                          { 1 }  (D34-2) [353E]       C   - 503 16 NaVa M1 V M3 V
 2302 Gaeksan              A577000-0 Ba C:Knoe-2201                                       { -1 } (900-5) [0000]       K   - 801  9 NaVa F9 V
 2303 Aergghdza            D767859-4 Ga Pa Ph Ri                                          { -1 } (676+1) [9784]       -   - 000  9 NaVa F9 V
 2304 Ekhsgvo              C9B0401-C He Ni                                                { 0 }  (935-5) [143D]       -   - 101  8 NaVa F9 V
@@ -381,7 +381,7 @@ Hex  Name                 UWP       Remarks                                     
 2510 Negarrghoeoegong     A558454-B Ni Pa Cp                                             { 1 }  (C33-4) [351E]       K   - 104 12 VDeG F0 V
 2513 Vafozouthallkfuks    E586474-7 Ni Pa                                                { -3 } (230+4) [3199]       C   - 300  4 VDeG F8 V
 2517 Adhaeoe              A7C7237-C Fl Lo Cp                                             { 1 }  (911+0) [333D]       K   - 202 12 VDeG G6 V D
-2518 Ghukno               E000685-3 As Na Ni Va                                          { -3 } (352-2) [3333]       C   - 500 13 VDeG M4 V M7 III
+2518 Ghukno               E000685-3 As Na Ni Va                                          { -3 } (352-2) [3333]       C   - 500 13 VDeG M7 III M4 V
 2519 Unaluks              C98A540-9 Ni Pr Wa                                             { -1 } (B41+0) [445C]       C   - 922  7 VDeG G3 V
 2520 Oall                 D869587-3 Ni Pr                                                { -3 } (943-2) [A256]       -   - 101 12 VDeG G3 V
 2521 Atokhlloeg           A323333-C Lo Po                                                { 1 }  (721-1) [545H]       K   - 202 11 VDeG M2 V
@@ -391,7 +391,7 @@ Hex  Name                 UWP       Remarks                                     
 2602 Sueodhoeng           C53559B-9 Ni                                                   { -1 } (444+0) [543B]       -   - 200  8 NaVa M4 II
 2605 Gzaeogvaksksueks     A52489A-6 Ph Pi                                                { 0 }  (474+1) [9851]       K   - 303 13 VDeG F3 V D
 2606 Zuloth               C595343-6 Lo Tp                                                { -2 } (921+2) [1118]       -   - 101 11 VDeG F3 V D
-2607 Oudhurlongkou        E000205-5 As Lo Va                                             { -3 } (A11-3) [1171]       C   - 705 11 VDeG M6 V M3 V
+2607 Oudhurlongkou        E000205-5 As Lo Va                                             { -3 } (A11-3) [1171]       C   - 705 11 VDeG M3 V M6 V
 2610 Nogvullfaghzaellvang C35489A-2 Pa Ph                                                { -1 } (B74-2) [D751]       K   - 901 12 VDeG F2 V
 2611 Rurzsik              B998310-B Lo Tp                                                { 1 }  (621+1) [143D]       -   - 000 12 VDeG F2 V
 2613 Oukughoell           E342200-5 He Lo Po                                             { -3 } (911-3) [4134]       -   - 206 12 VDeG K0 V D
@@ -403,7 +403,7 @@ Hex  Name                 UWP       Remarks                                     
 2623 Raggzarrgh           C210573-9 Ni                                                   { -1 } (A42-1) [7458]       K   - 102 12 VDeG M3 V
 2624 Goevozuou            B85A356-9 Lo Wa                                                { 0 }  (C21+4) [431C]       K   - 302 12 VDeG G1 V D
 2625 Oeghdon              E330501-7 De Ni Po                                             { -3 } (940-1) [5249]       -   - 101  9 VDeG G1 V D
-2626 Dugzkoegzoen         C30036B-5 Lo Va                                                { -2 } (621-5) [2151]       -   - 303  8 VDeG M6 V K6 V
+2626 Dugzkoegzoen         C30036B-5 Lo Va                                                { -2 } (621-5) [2151]       -   - 303  8 VDeG K6 V M6 V
 2628 Toghdzoerzuedh       C303000-B Ic Va Co Di                                          { 0 }  (907+0) [0000]       -   - 904 14 VDeG K8 V M7 V D D
 2630 Idzagudzuegaets      A611400-A Ic Ni Co                                             { 1 }  (E35+2) [656B]       -   - 903 12 NaVa F0 IV M5 V
 2638 Nullkfaetskhuen      A546376-A Lo Cp                                                { 1 }  (B21+0) [1489]       -   - 203 14 NaVa F0 V

--- a/res/Sectors/M1105/Ksinanirz.sec
+++ b/res/Sectors/M1105/Ksinanirz.sec
@@ -14,115 +14,115 @@ Ksinanirz
 #----------   ---- ---------  - --------------- -  --- -- --- -
 .             0501 X778000-0    Ba Lo Ni           014 --     F5V 
 .             0701 X596000-0    Ba Lo Ni           023 --     F1V 
-.             0901 X452000-0    Ba Lo Ni Po        012 --     F5V M6D 
+.             0901 X452000-0    Ba Lo Ni Po        012 --     F5V M6V
 .             1101 X262000-0    Ba Lo Ni           003 --     F0V 
-Oukegaeguerr  1501 E695468-1    Ni                 213 Va     F3V M3D 
-Tsadzguez     1601 A754105-9  G Lo Ni              823 Va     F8V M6D 
-Tsuetsnozug   1701 B231778-8  C Na Po              400 Va     M2V K8D 
+Oukegaeguerr  1501 E695468-1    Ni                 213 Va     F3V M3V
+Tsadzguez     1601 A754105-9  G Lo Ni              823 Va     F8V M6V
+Tsuetsnozug   1701 B231778-8  C Na Po              400 Va     M2V K8V
 Enguksuerrug  2001 C223134-9    Lo Ni Po           803 Va     K5V 
-Rughoe        2201 B374777-5  G Ag                 705 Va     F3V M6D 
+Rughoe        2201 B374777-5  G Ag                 705 Va     F3V M6V
 Konourogh     2301 B532363-A  G Lo Ni Po           810 Va     M8V 
 Utsighz       2401 C313487-A    Ic Ni              614 Va     A1IV 
 Oeurorz       2501 B76A626-C    Ni Wa              202 Va     F2V 
 Oknagoe       2801 AAD9566-F    Fl Ni              410 Va     K4IV 
 Zaetsarrg     3001 C767358-4  C Lo Ni              223 Va     K7V 
 .             0102 X534000-0    Ba Lo Ni           002 --     M5V 
-Gnuuekfedz    0602 D200878-4    Na Va              414 Va     F8D 
+Gnuuekfedz    0602 D200878-4    Na Va              414 Va     F8V
 .             1102 X78A000-0    Ba Lo Ni Wa        002 --     G5V 
 Llarthoelal   2002 A47367B-A  G Ag Ni              312 Va     M6V 
-Vouvou        2302 E2009CA-5  C Hi Na Va           904 Va     F6D M7D 
+Vouvou        2302 E2009CA-5  C Hi Na Va           904 Va     F6D M7V
 Uerragaefae   2402 C56497C-5    Hi In              304 Va     F4V 
-Tueaeue       2902 C514434-4  G Ic Ni              441 Va     M5V M7D 
-Dhangaeks     3002 A878974-B  G Hi In              506 Va     M1V M1D 
+Tueaeue       2902 C514434-4  G Ic Ni              441 Va     M5V M7V
+Dhangaeks     3002 A878974-B  G Hi In              506 Va     M1V M1V
 Tsoeluegz     3202 C8A1744-7    Fl                 822 Va     M1V 
 Tsagvuerr     0803 D250874-4  C De Po              310 VP     F2V 
 Khazvanekh    1503 D000579-8  C As Ni              605 Va     F0II 
 Daeghado      1603 B536988-9    Hi In              100 Va     F2V 
 Irtaek        1703 A9B4310-A    Fl Lo Ni           203 Va     M3II 
 Thouirru      1803 C474675-5    Ag Ni              303 Va     F1V 
-Tsaghzksuell  3203 C899458-7  C Ni                 405 Va     F5V M0D 
-Vothookh      0404 D633676-4    Na Ni Po           107 Va     K2V M5D 
-Thaoedhaekhs  0504 B9B8649-A  H Fl Ni              802 Va     M1V M5D M0D 
+Tsaghzksuell  3203 C899458-7  C Ni                 405 Va     F5V M0V
+Vothookh      0404 D633676-4    Na Ni Po           107 Va     K2V M5V
+Thaoedhaekhs  0504 B9B8649-A  H Fl Ni              802 Va     M1V M5D M0V
 Gagvaekerr    0804 E686878-3  C                    805 VP     F5V 
-Dougha        0904 A545203-8  G Lo Ni              505 VP     F6V M8D 
-Saaghun       1004 E788773-2    Ag                 922 VP     F3V M5D 
+Dougha        0904 A545203-8  G Lo Ni              505 VP     F6V M8V
+Saaghun       1004 E788773-2    Ag                 922 VP     F3V M5V
 Gungharsoell  1104 B577897-7  G                    904 VP     G1V 
 Kaedonoks     1204 D575543-6  C Ag Ni              601 VP     F1V 
-Ruerrgueng    1304 B380331-9  G De Lo Ni           720 VP     F5V M6D 
+Ruerrgueng    1304 B380331-9  G De Lo Ni           720 VP     F5V M6V
 Vaghzigan     1604 C422776-A    Na Po              313 Va     K9V 
 Aekoensoez    1704 E54726A-5    Lo Ni              300 Va     G7V 
-Dugzaesi      2204 C636666-4  C Ni                 705 Va     M3V M4D 
-Eraezors      2404 B866765-8    Ag Ri              504 Va     F9V M8D 
+Dugzaesi      2204 C636666-4  C Ni                 705 Va     M3V M4V
+Eraezors      2404 B866765-8    Ag Ri              504 Va     F9V M8V
 Uezaekaren    2604 C445305-9    Lo Ni              213 Va     F1V 
 Ghouga        2704 X989778-1  C                    705 Va     F3V 
-Rruzathantek  2804 C739266-9    Lo Ni              707 Va     K0V M1D M0D 
-.             0105 X363000-0    Ba Lo Ni           011 --     F2V M7D 
+Rruzathantek  2804 C739266-9    Lo Ni              707 Va     K0V M1D M0V
+.             0105 X363000-0    Ba Lo Ni           011 --     F2V M7V
 Suerrouroe    0905 C966879-1                       500 VP     F1V 
-Kekoeghuegh   1005 D886001-5    Lo Ni              202 VP     F4V M3D F5V M6D 
-Ghokhogva     1805 E100000-9  C Ba Lo Ni Va        723 Va     M5V M4D 
-Surrarrgh     1905 C43297A-C    Hi In Na Po        407 Va     G2V M3D F5V M2D 
+Kekoeghuegh   1005 D886001-5    Lo Ni              202 VP     F4V M3D F5V M6V
+Ghokhogva     1805 E100000-9  C Ba Lo Ni Va        723 Va     M5V M4V
+Surrarrgh     1905 C43297A-C    Hi In Na Po        407 Va     G2V M3D F5V M2V
 Gvanaerran    2005 B100323-9  G Lo Ni Va           303 Va     G2V 
 Ksounaz       2205 E200442-4    Ni Va              804 Va     G7V 
 Okharuz       2505 B436855-8                       704 Va     F9V 
 .             0106 X231000-0    Ba Lo Ni Po        001 --     M7V 
 Onuarra       0506 D220100-A    De Lo Ni Po        513 VR     M7V 
-Guegvarrgh    0606 C78599A-A  C Hi In              801 VR     F5V M7D 
-Nuerouvaekh   0706 B54667B-4    Ag Ni              923 VR     F9V M4D 
+Guegvarrgh    0606 C78599A-A  C Hi In              801 VR     F5V M7V
+Nuerouvaekh   0706 B54667B-4    Ag Ni              923 VR     F9V M4V
 Gaoedho       1106 C765865-8    Ri                 404 VP     F2V 
 Etazuek       1306 A130766-8    De Na Po           514 VP     M6V 
-Aedzaue       1406 D377A7A-A    Hi In              203 VP     K5V M7D 
-Tsoeghours    1506 B301565-9    Ic Ni Va           103 VP     A0D 
-Aeghaedhi     1806 C76A212-9    Lo Ni Wa           804 Va     F9V M5D 
+Aedzaue       1406 D377A7A-A    Hi In              203 VP     K5V M7V
+Tsoeghours    1506 B301565-9    Ic Ni Va           103 VP     A0V
+Aeghaedhi     1806 C76A212-9    Lo Ni Wa           804 Va     F9V M5V
 Khuuo         1906 C97677A-4    Ag                 502 Va     K1V 
-Zoenaedhtsus  2206 D400876-2    Na Va              500 Va     G1D M6D 
+Zoenaedhtsus  2206 D400876-2    Na Va              500 Va     G1D M6V
 Oksa          2506 A501226-9  G Ic Lo Ni Va        615 Va     G8V 
-Fioilug       0307 C78A664-3    Ni Ri Wa           206 Va     F5V M8D 
-Uraegou       0707 B655357-9  G Lo Ni              605 VR     F1V M2D 
+Fioilug       0307 C78A664-3    Ni Ri Wa           206 Va     F5V M8V
+Uraegou       0707 B655357-9  G Lo Ni              605 VR     F1V M2V
 Kengllunar    0807 A230662-A  G De Na Ni Po        402 VR     K2V 
 Koerukhukh    0907 C345466-6  G Ni                 510 VR     F0V 
 Rraekhus      1007 B325899-8                       712 VR     K4V 
 Aegzeoe       1307 E100244-A    Lo Ni Va           411 VP     M5III K4V 
-Gnughenangi   1707 B1607B7-9  G De                 303 Va     K6V M0D 
-Lengikakh     2007 E220435-7    De Ni Po           100 Va     M6V M1V M8D 
+Gnughenangi   1707 B1607B7-9  G De                 303 Va     K6V M0V
+Lengikakh     2007 E220435-7    De Ni Po           100 Va     M6V M1V M8V
 Khoenugzaghz  3207 C9C5000-9    Ba Fl Lo Ni        801 Va     G7V 
 Khaello       0208 B672677-7    Ni                 215 Va     G6V 
 Nourrghfourz  0808 E333400-8  C Ni Po              914 VR     M4V 
 Forraroekou   0908 A629500-E  G Ni                 700 VR     K2V 
 Aellonorrgh   1308 D873454-6  G Ni                 602 VP     F8V 
 Ularr         1408 A355578-B  G Ag Ni              502 VP     F0V 
-Rrozuetsae    1508 B681874-8                       834 VP     F0V M6D 
+Rrozuetsae    1508 B681874-8                       834 VP     F0V M6V
 Tsatha        1608 D352697-2  G Ni Po              500 VP     F2V 
-Ksigtsodho    1808 B639676-7    Ni                 502 Va     M5V G6D 
-Dulloue       2108 E400102-5  C Lo Ni Va           732 Va     M0V M2D 
-Kaeuerzgueg   0109 C433666-4  C Na Ni Po           707 Va     M8V M2D 
-Enouvarro     0209 C484652-7    Ag Ni Ri           604 Va     F9V M1D 
+Ksigtsodho    1808 B639676-7    Ni                 502 Va     M5V G6V
+Dulloue       2108 E400102-5  C Lo Ni Va           732 Va     M0V M2V
+Kaeuerzgueg   0109 C433666-4  C Na Ni Po           707 Va     M8V M2V
+Enouvarro     0209 C484652-7    Ag Ni Ri           604 Va     F9V M1V
 Ouaklloluen   0609 B658201-A  G Lo Ni              303 VR     K5V 
 Tuetangalou   0709 C66197C-3    Hi In              901 VR     F4V 
-Ouellanourz   0809 C585777-3  C Ag                 228 VR     M1V F3V M6D 
+Ouellanourz   0809 C585777-3  C Ag                 228 VR     M1V F3V M6V
 Arruezaegh    1209 B345588-5  C Ag Ni              404 VP     F7V 
 Gueovou       1309 E310533-4    Ni                 324 VP     F6V 
-Ksueghale     1509 C634325-5    Lo Ni              616 VP     K2V F3V M1D 
+Ksueghale     1509 C634325-5    Lo Ni              616 VP     K2V F3V M1V
 Ghagugharr    1609 B665574-6  C Ag Ni              800 VP     F8V 
-Ungugudz      1809 C9C48AB-3    Fl                 223 Va     F3V M6D 
-Rerukh        2009 X632243-1  C Lo Ni Po           103 Va     F8V M3D 
+Ungugudz      1809 C9C48AB-3    Fl                 223 Va     F3V M6V
+Rerukh        2009 X632243-1  C Lo Ni Po           103 Va     F8V M3V
 Zuedala       2209 E120400-A  C De Ni Po           110 Va     K9V 
 Edunllak      2609 C100A74-A  C Hi Na Va           803 Va     F2V 
 Vesueksaon    0210 C427776-9                       203 Va     M4V 
 Gzouno        0310 B000768-A  C As Na              903 Va     M6V 
-Rroiroers     0410 A687789-A  G Ag                 103 Va     F3V M1D 
+Rroiroers     0410 A687789-A  G Ag                 103 Va     F3V M1V
 Goeollaz      0910 CA9A977-9  G Hi In Wa           404 Va     F2V 
-Aenarou       1010 E210452-9    Ni                 701 Va     M8V M1D 
-Dzaerakhsaeg  0111 B310657-7  C Na Ni              301 Va     M4V M0D 
+Aenarou       1010 E210452-9    Ni                 701 Va     M8V M1V
+Dzaerakhsaeg  0111 B310657-7  C Na Ni              301 Va     M4V M0V
 Kfuegvakue    0211 A482500-B    Ni                 500 Va     G6V 
-Ngadzughz     0311 D443A7C-4  H Hi In Po           735 Va     M6V M6D 
+Ngadzughz     0311 D443A7C-4  H Hi In Po           735 Va     M6V M6V
 Roukharr      0511 D63AAA8-7    Hi In Wa           100 Va     F8V 
-Uagve         0811 E452457-7  C Ni Po              803 Va     F0V M6D 
+Uagve         0811 E452457-7  C Ni Po              803 Va     F0V M6V
 Ouerorr       0911 A350145-B  G De Lo Ni Po        810 Va     F3V 
 Aekfuezarr    1511 B946310-8    Lo Ni              322 VP     F4V 
 Thueaeuae     1611 C200435-9    Ni Va              300 VP     M8V 
 Daza          1911 B130253-8    De Lo Ni Po        712 Va     K1IV 
 Zotusael      2111 C673433-7  G Ni                 305 Va     F9V 
-Vuesagouvull  0112 D463553-4  G Ag Ni              825 Va     K5V M7D 
+Vuesagouvull  0112 D463553-4  G Ag Ni              825 Va     K5V M7V
 Oruerraez     0612 D6388AD-5                       413 Va     F2V 
 Gueksogok     0912 C100362-6  G Lo Ni Va           722 Va     M4V 
 Voughoegheng  1112 X000654-3  C As Na Ni           603 Va     G6V M6V 
@@ -131,87 +131,87 @@ Sueghzengar   1612 BAA6563-B    Fl Ni              605 VP     K9V
 Gvaegigan     1812 C332343-5    Lo Ni Po           302 VP     M5V 
 Kueghaetue    0613 B444146-8    Lo Ni              502 Va     M0V 
 Toungougun    1113 E659675-5  C Ni                 712 Va     K5V 
-Gadhknoungar  1413 C356202-4  C Lo Ni              802 VP     F0V M4D 
+Gadhknoungar  1413 C356202-4  C Lo Ni              802 VP     F0V M4V
 Nengnueghz    1513 C366674-6  G Ag Ni              413 VP     F7V 
 Kurrunguer    1713 B200247-7    Lo Ni Va           701 VP     M4V 
-Goeakson      0514 C643100-A  G Lo Ni Po           203 Va     F9V M3D 
+Goeakson      0514 C643100-A  G Lo Ni Po           203 Va     F9V M3V
 Orsgirsfagz   0714 B365344-9  G Lo Ni              611 Va     F5V 
 Zanue         0914 D529300-4    Lo Ni              305 Va     G2V M7V K7V 
-Kaethoukue    1514 C898301-5    Lo Ni              523 VP     F9V M2D 
+Kaethoukue    1514 C898301-5    Lo Ni              523 VP     F9V M2V
 Ondokhs       2914 C538000-5    Ba Lo Ni           203 Va     G4V 
 Okuvoe        0115 E8A269D-7    Fl Ni              802 Va     K0V 
-Voenaetsoour  1415 C889479-6  G Ni                 205 Va     F7V M3D 
+Voenaetsoour  1415 C889479-6  G Ni                 205 Va     F7V M3V
 Saeksaez      1715 B856356-6    Lo Ni              200 Va     F1V 
 Gueghikang    2915 C452532-6  G Ni Po              913 Va     F4V 
 Sughue        0116 B559552-B    Ni                 803 Va     K4V 
-Rrozanrroeng  0316 C225200-7    Lo Ni              401 Va     M1V M2D 
+Rrozanrroeng  0316 C225200-7    Lo Ni              401 Va     M1V M2V
 Uesatsagzon   0716 X543644-0  C Ag Ni Po           124 Va     F0V 
 Raekhirr      0916 E97A597-6    Ni Wa              513 Va     F2V 
 Ruganill      1316 C221AC8-A  G Hi In Na Po        305 Va     G2V F9V 
 Ogoedha       1516 C799456-7  C Ni                 713 Va     G4V 
-Dzorrgun      2416 X855884-0  C                    402 Va     F9V M2D 
+Dzorrgun      2416 X855884-0  C                    402 Va     F9V M2V
 Doe           2716 C899666-8    Ni                 600 Va     F3V 
 Razuka        2816 C8C8532-9  C Fl Ni              903 Va     F0V 
 Dagzvoen      0617 B537746-6  G                    203 Va     M5V 
-Roeagha       1517 E79A987-5    Hi In Wa           912 Va     F3V M7D 
+Roeagha       1517 E79A987-5    Hi In Wa           912 Va     F3V M7V
 Rafuegvuerro  1917 C535144-6  G Lo Ni              902 Va     M3V 
-Ivakhsoes     2517 E9E1778-5  C Fl                 105 Va     M3V M5D 
-Ngaradhur     2617 B68A222-A    Lo Ni Wa           813 Va     F8V M5D 
-Naeaou        2717 A51275A-7    Ic Na              802 Va     M3V M2D 
+Ivakhsoes     2517 E9E1778-5  C Fl                 105 Va     M3V M5V
+Ngaradhur     2617 B68A222-A    Lo Ni Wa           813 Va     F8V M5V
+Naeaou        2717 A51275A-7    Ic Na              802 Va     M3V M2V
 Rralludh      3217 E85A6B7-4  C Ni Wa              602 Va     F5V 
 Ruezerrfugar  0118 C000553-9  G As Ni              302 Va     M2V 
-Sighangarorr  0218 C669555-7    Ni                 204 Va     F9V M8D 
-Ugogvudz      0518 D575646-4    Ag Ni              215 Va     F7V M2D 
-Akhguetsoerr  1018 B675455-8    Ni                 604 Va     F9V M0D 
-Rrulkhalrun   2818 DA9A201-A    Lo Ni Wa           702 Va     F9V M2D 
+Sighangarorr  0218 C669555-7    Ni                 204 Va     F9V M8V
+Ugogvudz      0518 D575646-4    Ag Ni              215 Va     F7V M2V
+Akhguetsoerr  1018 B675455-8    Ni                 604 Va     F9V M0V
+Rrulkhalrun   2818 DA9A201-A    Lo Ni Wa           702 Va     F9V M2V
 Ughkuesdorr   0219 A46487A-6                       605 Va     K1V 
 Nazaelzol     0319 X321657-1  C Na Ni Po           800 Va     F2IV K3V 
 Soesuenoeng   0519 C647478-6    Ni                 803 Va     F6V 
 Ksauelloeae   1319 C475875-5                       302 Va     G0V 
 Relluezgaeng  1519 E4236A9-5    Na Ni Po           106 Va     F4IV K5V 
 Uknarron      1719 D659321-3  G Lo Ni              214 Va     G4V 
-Dhoerou       2219 C787776-3    Ag                 911 Va     F5V M6D 
-Aenarsveghz   2519 C6B2876-7  C Fl                 210 Va     F2V M8D 
-Knougzaeue    0220 B464301-9    Lo Ni              426 Va     F8V M6D 
+Dhoerou       2219 C787776-3    Ag                 911 Va     F5V M6V
+Aenarsveghz   2519 C6B2876-7  C Fl                 210 Va     F2V M8V
+Knougzaeue    0220 B464301-9    Lo Ni              426 Va     F8V M6V
 Azoegzoen     0320 B221201-A  H Lo Ni Po           503 Va     G9V 
 Gvoghang      0820 B57657A-6  G Ag Ni              800 Va     F1V 
-Soeuo         0920 B534564-8    Ni                 400 Va     A1V M0D 
+Soeuo         0920 B534564-8    Ni                 400 Va     A1V M0V
 Aerugvekh     1120 C64A578-9  G Ni Wa              703 Va     K5V 
 Gnaezrra      1520 E523598-3  C Ni Po              204 Va     K5V 
-Igarangan     0121 D000979-7    As Hi Na           802 Va     F5V M3D 
+Igarangan     0121 D000979-7    As Hi Na           802 Va     F5V M3V
 Ghuetstoge    0321 B999132-5  G Lo Ni              700 Va     M4V 
 Tsukhdhoeu    1021 C577300-5  G Lo Ni              412 Va     F3V 
-Thoudzanang   1121 C300644-6    Na Ni Va           103 Va     A5V M4D 
-Guedzagh      1321 E222561-2  C Ni Po              811 Va     F3V M7D 
-Soeugi        1421 C762214-4    Lo Ni              300 Va     G1V M2D 
+Thoudzanang   1121 C300644-6    Na Ni Va           103 Va     A5V M4V
+Guedzagh      1321 E222561-2  C Ni Po              811 Va     F3V M7V
+Soeugi        1421 C762214-4    Lo Ni              300 Va     G1V M2V
 Sunzorkhasou  1721 B676878-A  G                    603 Va     G2V 
-Khazoekhskha  2321 C653420-9    Ni Po              704 Va     F7V M2D 
+Khazoekhskha  2321 C653420-9    Ni Po              704 Va     F7V M2V
 Aerakhsaghz   2621 C767869-4  G Ri                 333 Va     F7V 
-Udakhag       3021 B100857-C  G Na Va              905 Va     M6D M2D 
+Udakhag       3021 B100857-C  G Na Va              905 Va     M6D M2V
 Roksue        0122 E435443-7    Ni                 900 Va     M8V 
-Tanuedhue     0322 B778100-8  G Lo Ni              905 Va     F3V M7D 
+Tanuedhue     0322 B778100-8  G Lo Ni              905 Va     F3V M7V
 Azzongekh     0422 A210558-D    Ni                 902 Va     F4V 
 Fuguerr       1022 B635435-A    Ni                 914 Va     K7V 
 Sakhsakhkuel  1322 A7A197B-C  G Fl Hi In           912 Va     K0V 
 Raguezag      3122 AAD3427-A    Fl Ni              610 Va     M7V 
 Ueoegvaghung  0223 C736002-8    Lo Ni              600 Va     F0V 
 Uegvaegni     0423 B360664-6    De Ni Ri           304 Va     F9V 
-Dhuerrosegh   1623 B533889-7  G Na Po              704 Va     M0V M2D 
+Dhuerrosegh   1623 B533889-7  G Na Po              704 Va     M0V M2V
 Gvueksoudzu   0124 A100548-D  G Ni Va              412 Va     G7III M0V 
 Tsagnoe       0524 C326674-4    Ni                 614 Va     F8V M3D F4V 
-Goevaturr     0724 A444562-9  G Ag Ni              226 Va     F4V M8D 
+Goevaturr     0724 A444562-9  G Ag Ni              226 Va     F4V M8V
 Garuegsaring  0824 C5A6300-B  G Fl Lo Ni           102 Va     M5V M5V 
 Zaengaening   1024 C694300-7    Lo Ni              600 Va     G4V 
-Gvosousuerr   1924 C728553-8    Ni                 513 Va     M5V M6D M5D 
+Gvosousuerr   1924 C728553-8    Ni                 513 Va     M5V M6D M5V
 Vakhuegh      0125 E200255-4    Lo Ni Va           400 Va     K1V 
 Ataetu        0225 B200100-D  G Lo Ni Va           701 Va     M5V 
-Doveka        0525 C201564-9    Ic Ni Va           622 Va     M5V M1D 
+Doveka        0525 C201564-9    Ic Ni Va           622 Va     M5V M1V
 Vuedhavug     1025 B543534-5    Ag Ni Po           912 Va     F3V 
-Rassoughzao   1125 C694300-7    Lo Ni              812 Va     F1V M8D 
-Konokh        1325 C77657C-4    Ag Ni              511 Va     F2V M2D 
+Rassoughzao   1125 C694300-7    Lo Ni              812 Va     F1V M8V
+Konokh        1325 C77657C-4    Ag Ni              511 Va     F2V M2V
 Alaethera     1525 B8C7574-9  G Fl Ni              501 Va     G1V M2V 
 Ukanguekagh   1625 B84A578-B    Ni Wa              712 Va     F5V 
-Rirsthuers    2025 CAA6454-7    Fl Ni              813 Va     F1V M1D 
+Rirsthuers    2025 CAA6454-7    Fl Ni              813 Va     F1V M1V
 Ugsuezou      2625 E476130-4    Lo Ni              411 Va     K7V 
 Tharkung      3225 A585579-9    Ag Ni              320 Va     M7V 
 Eeouts        0426 A78966A-8    Ni Ri              900 Va     F1V 
@@ -221,11 +221,11 @@ Ghueaae       1126 D674699-1    Ag Ni              923 Va     F3V
 Liuae         1326 X5A3453-0  C Fl Ni              501 Va     K5V 
 Aelluegknugh  1726 C729325-7  C Lo Ni              413 Va     M4V 
 Kaedzanzourr  1826 B234577-7    Ni                 400 Va     M5V 
-Thathegz      2826 C585876-1  C                    705 Va     F5V M2D 
-Otsonvikhs    3226 C854423-5  G Ni                 223 Va     F2V M1D 
-Daeguea       0127 C436635-3  C Ni                 214 Va     F3V M3D 
-Ghuergnogzu   0227 C402488-7    Ic Ni Va           325 Va     F1V M2D 
-Zerraksuk     0427 C202A77-A  G Hi Ic Na Va        213 Va     F9D 
+Thathegz      2826 C585876-1  C                    705 Va     F5V M2V
+Otsonvikhs    3226 C854423-5  G Ni                 223 Va     F2V M1V
+Daeguea       0127 C436635-3  C Ni                 214 Va     F3V M3V
+Ghuergnogzu   0227 C402488-7    Ic Ni Va           325 Va     F1V M2V
+Zerraksuk     0427 C202A77-A  G Hi Ic Na Va        213 Va     F9V
 Gvueradue     0527 E99A123-6  C Lo Ni Wa           300 Va     G6V 
 Kughkuengokh  0727 B8A9875-A  G Fl                 500 Va     F2V 
 Uenguea       1027 C100223-8  C Lo Ni Va           904 Va     M6V 
@@ -234,56 +234,56 @@ Thaegvongouk  1727 A464523-8    Ag Ni              110 Va     F1V
 Lluzaengvoe   2727 C232675-3    Na Ni Po           500 Va     M0III 
 Kasakhe       0928 E86469B-3    Ag Ni Ri           602 Va     G7V 
 Breo          1428 C644688-7  M Ag Ni              910 Ve     F4V 
-Gelal         1528 B341578-A    Ni Po              203 Ve     G4V M2D 
+Gelal         1528 B341578-A    Ni Po              203 Ve     G4V M2V
 Tashe         1628 B667225-7  B Lo Ni              324 Ve     F6V 
 Ogaerou       2628 E646879-4  C                    901 Va     M7V 
 Saguerrukh    0329 B5A0444-8    De Ni              302 Va     F2V 
 Thaethouvu    0829 C577957-5    Hi In              414 Va     G7V 
 Ousou         2829 C100455-B  G Ni Va              904 Va     G5V 
-Thokfakeng    2929 C62446A-8  C Ni                 702 Va     M0V M0D 
+Thokfakeng    2929 C62446A-8  C Ni                 702 Va     M0V M0V
 Aeoengghuk    0130 E66A443-2  C Ni Wa              512 Va     F9V 
 Kheduzksuzuk  0330 C528641-9    Ni                 301 Va     K0V 
 Thuguegousa   0430 XA78422-0  C Ni                 302 Va     F0V 
 Ksaekhaae     0730 C525203-6  G Lo Ni              402 Va     M4V 
 Aaedzouz      0830 C647513-7    Ag Ni              720 Va     F6V M5V 
 Yehigeton     1530 E53369C-4    Na Ni Po           504 Ve     K5V M0V 
-Seseto        2030 E789452-7    Ni                 916 Ve     M7V M0D 
+Seseto        2030 E789452-7    Ni                 916 Ve     M7V M0V
 Locae         2430 C654988-8  S Hi In              800 Ve     F9V 
 Kuesatsu      0231 A427368-B  G Lo Ni              811 Va     M3III M7V 
 Lugviae       0531 C465775-7    Ag                 810 Va     F1V 
 Tuedukhsaghz  0631 C63587B-5                       603 Va     F4V 
 Rarueksuen    0731 C469145-5  C Lo Ni              401 Va     F9V 
 Geoedue       0831 X13049B-6    De Ni Po           503 Va     F9II K7V 
-Vuoutha       0931 A000887-9  G As Na              214 Va     F1D 
+Vuoutha       0931 A000887-9  G As Na              214 Va     F1V
 Zoelkhazats   0132 A429415-B    Ni                 101 Va     M7V 
 Gasaesuenue   0532 D7557A9-6  G Ag                 603 Va     F2V 
-Toengedzgugh  0632 C300898-4  C Na Va              403 Va     F8D 
-Koeghookh     0732 B733000-A    Ba Lo Ni Po        823 Va     G8V M6D 
+Toengedzgugh  0632 C300898-4  C Na Va              403 Va     F8V
+Koeghookh     0732 B733000-A    Ba Lo Ni Po        823 Va     G8V M6V
 Ngoegroghan   0832 B352566-8    Ni Po              803 Va     F3V 
-Idpo          1232 C565ADD-8    Hi In              717 Ve     F8V M6D 
+Idpo          1232 C565ADD-8    Hi In              717 Ve     F8V M6V
 Ithian        1432 B548300-9  M Lo Ni              902 Ve     K9V 
 Esdesthi      1632 B263142-B  A Lo Ni              624 Ve     F8V 
-Emufen        1932 XA8A8BA-3    Wa              R  803 Ve     F5V M0D 
-Ullonzong     0133 B212203-E    Ic Lo Ni           904 Va     K2V M5D 
+Emufen        1932 XA8A8BA-3    Wa              R  803 Ve     F5V M0V
+Ullonzong     0133 B212203-E    Ic Lo Ni           904 Va     K2V M5V
 Nazaeng       0233 C626876-9  C                    500 Va     F9V 
 Zourzaegae    0333 C483876-3                       504 Va     G5V 
 Saangoungaeg  0533 D426378-3    Lo Ni              401 Va     M5V 
 Ransaenuedz   0733 B7A6554-B    Fl Ni              201 Va     F2II 
 Eghuengerrgh  0933 DAB8453-7  C Fl Ni              214 Va     F6II 
-Zatsueleghz   1033 B748696-6    Ag Ni              102 Va     K8V M8D 
-Tharirseand   1933 C754556-6  S Ag Ni              213 Ve     F2V M4D 
+Zatsueleghz   1033 B748696-6    Ag Ni              102 Va     K8V M8V
+Tharirseand   1933 C754556-6  S Ag Ni              213 Ve     F2V M4V
 Gzuegae       3233 A35467C-A  G Ag Ni              520 Va     F0V 
 Legzourrges   0434 A796662-9  G Ag Ni              400 Va     M8V 
 Kears         0734 E200376-9    Lo Ni Va           706 Va     M7II M0V 
-Iwi           1234 C110432-7  M Ni                 707 Ve     M2V M4D 
-Froire        1534 C695673-5  M Ag Ni              501 Ve     F0V M2D 
+Iwi           1234 C110432-7  M Ni                 707 Ve     M2V M4V
+Froire        1534 C695673-5  M Ag Ni              501 Ve     F0V M2V
 Ingthan       2334 C210304-B    Lo Ni              200 Ve     A0V 
-Oursonoag     0135 B334556-B    Ni                 902 Va     M1V M1D 
+Oursonoag     0135 B334556-B    Ni                 902 Va     M1V M1V
 Kugzoeghzaek  0435 C313335-5  G Ic Lo Ni           300 Va     K7V 
 Sagvoeoegh    0535 C646773-5    Ag                 102 Va     M1V 
 Zoungtadae    0935 D649673-5  C Ni                 403 Va     F6V 
-Zugue         1035 C687974-5  H Hi In              900 Va     F2V M6D 
-Sise          1235 C848001-7  S Lo Ni              707 Ve     K3V M8D 
+Zugue         1035 C687974-5  H Hi In              900 Va     F2V M6V
+Sise          1235 C848001-7  S Lo Ni              707 Ve     K3V M8V
 Foorsaa       2235 C546421-8    Ni                 302 Ve     M8V 
 Hasam         2435 C000210-8    As Lo Ni           722 Ve     F9III 
 Ienbet        2535 E656677-1    Ag Ni              620 Ve     F3V 
@@ -299,7 +299,7 @@ Gvueukhgzoe   0237 B500777-7    Na Va              201 Va     G4V M2V
 Sekhurour     0337 C470654-5    De Ni              200 Va     F6V 
 Ueonugzaeng   0537 B9C8778-A    Fl                 900 Va     M2V M1V 
 Ungugzaezogh  0837 A837145-B  G Lo Ni              700 Va     M0V 
-Atsoerghourz  0937 E67A350-6    Lo Ni Wa           800 Va     F8V M0D 
+Atsoerghourz  0937 E67A350-6    Lo Ni Wa           800 Va     F8V M0V
 Okaegvong     1037 C785666-3    Ag Ni Ri           700 Va     F6V 
 Ese           1437 C575000-8  S Ba Lo Ni           700 Ve     F1V 
 Langed        1837 CAA6234-7  S Fl Lo Ni           300 Ve     M2V M5V 
@@ -307,40 +307,40 @@ Yomeceth      2137 E4536AA-3    Ag Ni Po           100 Ve     F0V
 Whothelle     2237 C411610-A  S Ic Na Ni           603 Ve     M8V M0V 
 Yolinga       2937 B6A286A-7    Fl                 813 Ve     F8V 
 Rilalnughz    0538 B566651-A  G Ag Ni Ri           601 Va     M5V 
-Ueoudhdoeth   0638 C411431-8  G Ic Ni              135 Va     A3V M0D 
-Aksrrue       0738 C644889-2                       104 Va     F8V M3D 
+Ueoudhdoeth   0638 C411431-8  G Ic Ni              135 Va     A3V M0V
+Aksrrue       0738 C644889-2                       104 Va     F8V M3V
 Ourrruaks     1038 B4136A8-A  G Ic Na Ni           104 Va     G2V 
-Iha           1338 C9E3788-5    Fl                 114 Ve     M0V M6D 
-Widbaen       1538 E97A278-9    Lo Ni Wa           500 Ve     K2V M4D 
-Codithishe    1938 B989630-7  S Ni                 102 Ve     F7V M7D M1D 
+Iha           1338 C9E3788-5    Fl                 114 Ve     M0V M6V
+Widbaen       1538 E97A278-9    Lo Ni Wa           500 Ve     K2V M4V
+Codithishe    1938 B989630-7  S Ni                 102 Ve     F7V M7D M1V
 Hellewanse    2138 A587ABE-G  S Hi In              104 Ve     F0V 
 Ecet          2338 C789120-6  M Lo Ni              700 Ve     F2V 
 Tofeo         2438 C559352-7    Lo Ni              703 Ve     F8V 
-Suelllouvoe   3238 C203520-7  G Ic Ni Va           704 Va     G7V M5D 
-Tsaenzuellog  0139 E000878-7  C As Na              514 Va     F1D 
-Sutaavun      0239 C87A698-5    Ni Wa              303 Va     F6V M3D 
+Suelllouvoe   3238 C203520-7  G Ic Ni Va           704 Va     G7V M5V
+Tsaenzuellog  0139 E000878-7  C As Na              514 Va     F1V
+Sutaavun      0239 C87A698-5    Ni Wa              303 Va     F6V M3V
 Ikerrgorrg    0639 D336145-5    Lo Ni              113 Va     F9V 
-Aungknae      0739 E254974-3  C Hi In              603 Va     F2V M1D 
+Aungknae      0739 E254974-3  C Hi In              603 Va     F2V M1V
 Kaksueghen    1039 C536A77-D  G Hi In              502 Va     F9V 
-Dhollorourr   1139 C669779-2  G                    726 Va     G7V M3D 
-Cewerdi       1439 D66A510-9    Ni Wa              232 Ve     F6V M3D 
-Shitouck      1739 E78379C-2    Ag Ri              100 Ve     K9V M3D 
+Dhollorourr   1139 C669779-2  G                    726 Va     G7V M3V
+Cewerdi       1439 D66A510-9    Ni Wa              232 Ve     F6V M3V
+Shitouck      1739 E78379C-2    Ag Ri              100 Ve     K9V M3V
 Adide         2039 A530454-D    De Ni Po           503 Ve     G4V 
-Feemef        2139 BA5A77A-A    Wa                 823 Ve     M0V M2D 
-Bothad        2339 X548455-2    Ni              R  813 Ve     G4V M2D 
-Rueaguks      3139 C778798-7    Ag                 613 Va     F0V M7D 
+Feemef        2139 BA5A77A-A    Wa                 823 Ve     M0V M2V
+Bothad        2339 X548455-2    Ni              R  813 Ve     G4V M2V
+Rueaguks      3139 C778798-7    Ag                 613 Va     F0V M7V
 Agastour      0240 C75A677-A  G Ni Wa              322 Va     F1V 
-Aknoutsagh    0340 X677686-0  C Ag Ni              615 Va     F6V M7D 
+Aknoutsagh    0340 X677686-0  C Ag Ni              615 Va     F6V M7V
 Ksaega        0440 C679636-5  G Ni                 504 Va     F5V 
 Foekoe        0540 E5377AB-2  C                    301 Va     A2V 
 Tsurougvae    0640 D6377BE-5                       403 Va     M6V 
-Sughankoung   0740 C100578-7    Ni Va              701 Va     M7V M4D 
-Kanangall     0940 B77A003-A  G Lo Ni Wa           703 Va     G3V M8D M0D 
-Cauw          1240 E696516-4    Ag Ni              603 Ve     F7V M5D 
+Sughankoung   0740 C100578-7    Ni Va              701 Va     M7V M4V
+Kanangall     0940 B77A003-A  G Lo Ni Wa           703 Va     G3V M8D M0V
+Cauw          1240 E696516-4    Ag Ni              603 Ve     F7V M5V
 Keors         1340 X546632-0    Ag Ni           R  213 Ve     F4V 
 Houriwwep     1540 B227731-8  B                    504 Ve     G6V 
 Obayon        1840 E300658-8    Na Ni Va           602 Ve     G9V 
 Lainte        2040 C324145-A    Lo Ni              722 Ve     F5V 
-Etheet        2440 C79A652-9  M Ni Wa              314 Ve     F1V M3D 
+Etheet        2440 C79A652-9  M Ni Wa              314 Ve     F1V M3V
 Tefie         2740 C140688-9  M De Ni Po           504 Ve     F1V 
-Bina          3040 B11077A-9    Na                 300 Ve     M0V M8D 
+Bina          3040 B11077A-9    Na                 300 Ve     M0V M8V

--- a/res/Sectors/M1105/Listanaya.sec
+++ b/res/Sectors/M1105/Listanaya.sec
@@ -23,25 +23,25 @@ Listanaya
 .             1202 X100000-0    Ba Lo Ni Va        024 --     A7V 
 .             1702 X235000-0    Ba Lo Ni           002 --     A5V 
 .             1902 X120000-0    Ba De Lo Ni Po     004 --     F1IV M4V 
-.             3002 X844000-0    Ba Lo Ni           024 --     K1V M6D 
+.             3002 X844000-0    Ba Lo Ni           024 --     K1V M6V
 .             3102 X312000-0    Ba Ic Lo Ni        003 --     K8V M0V 
 .             0303 X557000-0    Ba Lo Ni           022 --     M0V 
 .             0703 X537000-0    Ba Lo Ni           000 --     M2V M3V 
 .             1003 X234000-0    Ba Lo Ni           000 --     M5V 
 .             1303 X677000-0    Ba Lo Ni           002 --     F0V 
 .             1803 X100000-0    Ba Lo Ni Va        001 --     M1V 
-.             2403 X87A000-0    Ba Lo Ni Wa        024 --     F9V M8D 
+.             2403 X87A000-0    Ba Lo Ni Wa        024 --     F9V M8V
 .             0704 X554000-0    Ba Lo Ni           011 --     K6V 
-.             0904 X696000-0    Ba Lo Ni           004 --     G3V M0D 
+.             0904 X696000-0    Ba Lo Ni           004 --     G3V M0V
 .             1504 X88A000-0    Ba Lo Ni Wa        002 --     F2V 
-.             1604 X461000-0    Ba Lo Ni           005 --     F8V M4D 
-.             2004 X88A000-0    Ba Lo Ni Wa        002 --     F2V M5D 
+.             1604 X461000-0    Ba Lo Ni           005 --     F8V M4V
+.             2004 X88A000-0    Ba Lo Ni Wa        002 --     F2V M5V
 .             2104 X9A9000-0    Ba Fl Lo Ni        003 --     M8V 
 .             2904 X385000-0    Ba Lo Ni           002 --     F3V 
-.             3204 X120000-0    Ba De Lo Ni Po     003 --     M2V M6D 
-.             0305 X542000-0    Ba Lo Ni Po        004 --     F6V M7D 
-.             0805 X765000-0    Ba Lo Ni           004 --     F8V M2D 
-.             2105 X878000-0    Ba Lo Ni           010 --     F2V M4D 
+.             3204 X120000-0    Ba De Lo Ni Po     003 --     M2V M6V
+.             0305 X542000-0    Ba Lo Ni Po        004 --     F6V M7V
+.             0805 X765000-0    Ba Lo Ni           004 --     F8V M2V
+.             2105 X878000-0    Ba Lo Ni           010 --     F2V M4V
 .             2205 X433000-0    Ba Lo Ni Po        004 --     F0V 
 .             2405 X83A000-0    Ba Lo Ni Wa        004 --     G0IV M6V 
 .             2505 X546000-0    Ba Lo Ni           013 --     G6V 
@@ -52,14 +52,14 @@ Listanaya
 .             1506 X565000-0    Ba Lo Ni           011 --     F4V 
 .             1606 X232000-0    Ba Lo Ni Po        001 --     M2V 
 .             2506 X100000-0    Ba Lo Ni Va        003 --     M0V 
-.             0207 X648000-0    Ba Lo Ni           005 --     K8V M0D 
-.             0407 X453000-0    Ba Lo Ni Po        002 --     F0V M0D 
+.             0207 X648000-0    Ba Lo Ni           005 --     K8V M0V
+.             0407 X453000-0    Ba Lo Ni Po        002 --     F0V M0V
 .             0607 X656000-0    Ba Lo Ni           000 --     F5V 
 .             0707 X746000-0    Ba Lo Ni           000 --     F8V M7V 
 .             1007 X7B2000-0    Ba Fl Lo Ni        000 --     M2V M4V 
 .             1207 X538000-0    Ba Lo Ni           001 --     M8II 
-.             3207 X59A000-0    Ba Lo Ni Wa        003 --     F2V M1D 
-.             0208 X7B5000-0    Ba Fl Lo Ni        015 --     M0V M3D 
+.             3207 X59A000-0    Ba Lo Ni Wa        003 --     F2V M1V
+.             0208 X7B5000-0    Ba Fl Lo Ni        015 --     M0V M3V
 .             0408 X528000-0    Ba Lo Ni           003 --     M0V 
 .             0608 X311000-0    Ba Ic Lo Ni        004 --     F1V M8V M8V 
 .             0908 X497000-0    Ba Lo Ni           010 --     F0V 
@@ -68,132 +68,132 @@ Listanaya
 .             2308 X434000-0    Ba Lo Ni           016 --     M3V K3V 
 .             2508 X000000-0    As Ba Lo Ni        001 --     M4V 
 .             3008 X457000-0    Ba Lo Ni           002 --     F6V M6D F7V 
-.             0609 X868000-0    Ba Lo Ni           001 --     G5V M7D 
+.             0609 X868000-0    Ba Lo Ni           001 --     G5V M7V
 .             0709 X683000-0    Ba Lo Ni           012 --     F8V 
 .             1009 X300000-0    Ba Lo Ni Va        011 --     M5III G1V 
-.             1209 X565000-0    Ba Lo Ni           004 --     F4V M3D 
-.             2309 X000000-0    As Ba Lo Ni        003 --     M4D 
-.             2509 X559000-0    Ba Lo Ni           007 --     F5V M7D 
+.             1209 X565000-0    Ba Lo Ni           004 --     F4V M3V
+.             2309 X000000-0    As Ba Lo Ni        003 --     M4V
+.             2509 X559000-0    Ba Lo Ni           007 --     F5V M7V
 .             0110 XAF1000-0    Ba Fl Lo Ni        010 --     G1V 
-.             0310 X773000-0    Ba Lo Ni           012 --     F4V M3D 
-.             0710 X330000-0    Ba De Lo Ni Po     025 --     K6V M8D 
+.             0310 X773000-0    Ba Lo Ni           012 --     F4V M3V
+.             0710 X330000-0    Ba De Lo Ni Po     025 --     K6V M8V
 .             1210 X302000-0    Ba Ic Lo Ni Va     002 --     M6II 
 .             1810 X68A000-0    Ba Lo Ni Wa        013 --     K1V 
-.             2210 X260000-0    Ba De Lo Ni        013 --     F8V M7D 
+.             2210 X260000-0    Ba De Lo Ni        013 --     F8V M7V
 .             2610 X521000-0    Ba Lo Ni Po        001 --     M0V 
-.             0611 X7C6000-0    Ba Fl Lo Ni        001 --     M5V M0D 
+.             0611 X7C6000-0    Ba Fl Lo Ni        001 --     M5V M0V
 .             0811 X352000-0    Ba Lo Ni Po        015 --     K1V 
 .             1011 X000000-0    As Ba Lo Ni        010 --     M3V 
-.             1111 X7A2000-0    Ba Fl Lo Ni        002 --     M4II M1D 
-.             1211 X564000-0    Ba Lo Ni           000 --     F2V M3D 
-.             1811 X332000-0    Ba Lo Ni Po        001 --     F9V M4D 
+.             1111 X7A2000-0    Ba Fl Lo Ni        002 --     M4II M1V
+.             1211 X564000-0    Ba Lo Ni           000 --     F2V M3V
+.             1811 X332000-0    Ba Lo Ni Po        001 --     F9V M4V
 .             1911 X5A5000-0    Ba Fl Lo Ni        000 --     M7III M2V 
-.             2511 X410000-0    Ba Lo Ni           005 --     M6V M5D 
+.             2511 X410000-0    Ba Lo Ni           005 --     M6V M5V
 .             2811 X210000-0    Ba Lo Ni           003 --     M6V 
 .             3111 X675000-0    Ba Lo Ni           003 --     F8V 
-.             1112 X574000-0    Ba Lo Ni           005 --     G0V M5D 
-.             2212 X427000-0    Ba Lo Ni           002 --     A5V M8D 
-.             1013 X888000-0    Ba Lo Ni           027 --     F1V M5D 
+.             1112 X574000-0    Ba Lo Ni           005 --     G0V M5V
+.             2212 X427000-0    Ba Lo Ni           002 --     A5V M8V
+.             1013 X888000-0    Ba Lo Ni           027 --     F1V M5V
 .             1213 X200000-0    Ba Lo Ni Va        001 --     F4V 
-.             1413 X332000-0    Ba Lo Ni Po        015 --     M8V M3D M7D 
+.             1413 X332000-0    Ba Lo Ni Po        015 --     M8V M3D M7V
 Aekhogh       2413 D558142-7    Lo Ni              704 Va     F3V 
 .             3113 X443000-0    Ba Lo Ni Po        003 --     K5V 
 .             0214 X482000-0    Ba Lo Ni           003 --     F9V 
-.             0614 X446000-0    Ba Lo Ni           003 --     F9V M0D 
-.             1014 X654000-0    Ba Lo Ni           010 --     F2V M5D 
+.             0614 X446000-0    Ba Lo Ni           003 --     F9V M0V
+.             1014 X654000-0    Ba Lo Ni           010 --     F2V M5V
 .             1114 X5A1000-0    Ba Fl Lo Ni        013 --     M8V 
-.             1214 X632000-0    Ba Lo Ni Po        024 --     F6V M2D 
+.             1214 X632000-0    Ba Lo Ni Po        024 --     F6V M2V
 .             1314 X666000-0    Ba Lo Ni           020 --     F3V 
 Gharuerr      1914 D483211-4  C Lo Ni              600 Va     F1V 
 Sogzaerrars   2014 D00087A-4    As Na              813 Va     G1V 
-Oudaer        2114 E201577-5  C Ic Ni Va           627 Va     M0V M6D M8D 
+Oudaer        2114 E201577-5  C Ic Ni Va           627 Va     M0V M6D M8V
 .             0215 X544000-0    Ba Lo Ni           014 --     F6V 
-.             0815 X666000-0    Ba Lo Ni           004 --     M5V M8D 
+.             0815 X666000-0    Ba Lo Ni           004 --     M5V M8V
 .             1115 XA6A000-0    Ba Lo Ni Wa        025 --     G9V M3D F1V 
 Oegzogh       1615 C685679-2  G Ag Ni              214 VE     G7V 
 Forrthorrkur  2515 B87997C-A    Hi In              803 Va     F7V 
-Uedzkfal      2815 C95A873-9    Wa                 804 Va     F0V M3D M4V M1D 
+Uedzkfal      2815 C95A873-9    Wa                 804 Va     F0V M3D M4V M1V
 .             0816 X475000-0    Ba Lo Ni           020 --     F7V 
 .             0916 X633000-0    Ba Lo Ni Po        000 --     M1V 
 Uelus         1716 E466ABC-B  C Hi In              601 VE     K2V 
 Rarrghoth     2216 D766573-4  C Ag Ni              704 Va     F1V 
-Ouoedengueks  2316 C874764-4    Ag                 707 Va     F1V M7D M0D 
-.             0317 X435000-0    Ba Lo Ni           001 --     M0V M7D 
-Ollaz         1217 C747975-9    Hi In              821 Va     F4V M3D 
-Tsagakaeng    1617 C527103-7  G Lo Ni              102 VE     M7V M4D 
+Ouoedengueks  2316 C874764-4    Ag                 707 Va     F1V M7D M0V
+.             0317 X435000-0    Ba Lo Ni           001 --     M0V M7V
+Ollaz         1217 C747975-9    Hi In              821 Va     F4V M3V
+Tsagakaeng    1617 C527103-7  G Lo Ni              102 VE     M7V M4V
 Thegaeldhaen  1717 C300675-6    Na Ni Va           402 VE     G5V 
 Aekfueghz     2617 EA85102-1  C Lo Ni              801 Va     F1V 
 Ksaedaghoull  2817 E487799-5    Ag Ri              124 Va     M3V 
-.             0518 X403000-0    Ba Ic Lo Ni Va     027 --     K0V M3D 
+.             0518 X403000-0    Ba Ic Lo Ni Va     027 --     K0V M3V
 Oullae        1418 C350641-5  G De Ni Po           210 Va     F1V 
 Gnoungarraen  1618 B698775-8    Ag                 810 VE     F1V 
 Rolundhung    1718 C527420-6  C Ni                 722 VE     M2V 
 Gozuthaerr    1918 C679779-7                       804 Va     M1V 
 Oetsranu      2718 A330366-9  G De Lo Ni Po        904 Va     M4V 
-Soukaerrgun   0919 B327862-6                       810 Va     F0V M2D 
-Zavaegvinakh  1419 C83A644-8  G Ni Wa              714 Va     F9V M1D 
+Soukaerrgun   0919 B327862-6                       810 Va     F0V M2V
+Zavaegvinakh  1419 C83A644-8  G Ni Wa              714 Va     F9V M1V
 Vaesaelgvuer  1619 C575796-5    Ag                 203 VE     F5V 
-Gofae         2519 C365577-8    Ag Ni              803 Va     F3V M3D 
+Gofae         2519 C365577-8    Ag Ni              803 Va     F3V M3V
 Kheloen       2719 E555203-2    Lo Ni              423 Va     G8V M3D F7V 
-Doeoea        2819 C00067A-6  G As Na Ni           815 Va     K2V M8D 
+Doeoea        2819 C00067A-6  G As Na Ni           815 Va     K2V M8V
 Faghzenthaez  0420 B455A77-D  C Hi In              813 Va     F7V 
-Entharan      0720 D77A674-3    Ni Wa              305 Va     F8V M8D 
+Entharan      0720 D77A674-3    Ni Wa              305 Va     F8V M8V
 Gangkhourkne  1820 B404378-6  C Ic Lo Ni Va        702 Va     M3V 
-Dirueuegh     2520 A7A0365-D    De Lo Ni           104 Va     M0V M1D 
+Dirueuegh     2520 A7A0365-D    De Lo Ni           104 Va     M0V M1V
 .             3220 X554000-0    Ba Lo Ni           002 --     F5V 
-Goeaeo        0321 B846342-8    Lo Ni              202 Va     F3V M7D 
+Goeaeo        0321 B846342-8    Lo Ni              202 Va     F3V M7V
 Kaenggvaeg    1121 B332599-B  G Ni Po              800 Va     M3V 
 Gvughonuerrg  1421 B6A1897-6  G Fl                 902 Va     F4V 
-Vangdhaghagz  1921 C67A462-5    Ni Wa              523 Va     F1V M5D 
-Zoghorsaers   2521 C997544-5  C Ag Ni              703 Va     F0V M0D 
-Khueu         2721 C545000-3    Ba Lo Ni           612 Va     F5V M4D 
+Vangdhaghagz  1921 C67A462-5    Ni Wa              523 Va     F1V M5V
+Zoghorsaers   2521 C997544-5  C Ag Ni              703 Va     F0V M0V
+Khueu         2721 C545000-3    Ba Lo Ni           612 Va     F5V M4V
 .             3021 X540000-0    Ba De Lo Ni Po     022 --     F0V 
 .             3121 X000000-0    As Ba Lo Ni        012 --     G4V 
 Zouzol        0122 E414673-3  C Ic Ni              211 Va     M2V M7D F4V 
 Uergzik       1122 E9B4337-8    Fl Lo Ni           200 Va     M6V 
-Tague         2722 C401757-9    Ic Na Va           105 Va     M2V M5D 
+Tague         2722 C401757-9    Ic Na Va           105 Va     M2V M5V
 Khoeangong    0323 CAAA530-6    Fl Ni Wa           100 Va     M1V 
-Kaeksingu     0423 A6A5553-C    Fl Ni              904 Va     G9V M0D 
-Ukhag         1023 E78757B-1    Ag Ni              407 Va     F5V M2D M6D 
-Gharaegoukh   1423 CA76546-8    Ag Ni              104 Va     K5V M0D 
+Kaeksingu     0423 A6A5553-C    Fl Ni              904 Va     G9V M0V
+Ukhag         1023 E78757B-1    Ag Ni              407 Va     F5V M2D M6V
+Gharaegoukh   1423 CA76546-8    Ag Ni              104 Va     K5V M0V
 Agueghgvul    2123 B686AA8-7  G Hi In              401 Va     K1V 
 Aeghung       2223 E448225-4    Lo Ni              202 Va     M1V 
 Dakhoe        2923 C5A5511-8    Fl Ni              310 Va     F2V M8V 
 Kurzek        0224 C67AA78-B    Hi In Wa           810 Va     F7V 
 Ororr         0724 C697676-6  C Ag Ni              501 Va     M6V 
-Aokhsour      0924 E3466AE-0    Ag Ni              421 Va     F9V M3D 
+Aokhsour      0924 E3466AE-0    Ag Ni              421 Va     F9V M3V
 Thullueouoz   1325 C414578-6    Ic Ni              100 Va     G3V 
 Ekhtok        2525 C400445-6    Ni Va              201 Va     M3II M8V 
-Dhaeaok       2725 C435442-5  G Ni                 604 Va     M4V M8D 
+Dhaeaok       2725 C435442-5  G Ni                 604 Va     M4V M8V
 Gaghaendhakh  0626 C560544-3    De Ni              411 Va     F5V 
 Sogvozuen     0926 B94A566-9  C Ni Wa              113 Va     F8V 
 Kakhounang    1126 C400454-7    Ni Va              118 Va     M5V M7V 
-Vee           2226 B47059D-7  G De Ni              215 Va     F6V M0D 
+Vee           2226 B47059D-7  G De Ni              215 Va     F6V M0V
 Dello         0427 C457879-5                       801 Va     K0V 
 Uaerr         1027 B370779-9  G De                 600 Va     K9V 
-Ueounaghzaen  1127 A8A3137-8    Fl Lo Ni           603 Va     G9V M0D 
+Ueounaghzaen  1127 A8A3137-8    Fl Lo Ni           603 Va     G9V M0V
 Ououghzdarrg  2027 C130676-9    De Na Ni Po        603 Va     M0V 
-Voeea         2627 C55367B-7    Ag Ni Po           511 Va     F1V M0D 
-Eaou          2927 C592778-6                       703 Va     F1V M6D F3V M8D 
-Vaueekh       3027 C465111-6    Lo Ni              701 Va     F4V M1D 
-Uuengrarz     3127 B9B7375-8  G Fl Lo Ni           824 Va     F2V M5D 
+Voeea         2627 C55367B-7    Ag Ni Po           511 Va     F1V M0V
+Eaou          2927 C592778-6                       703 Va     F1V M6D F3V M8V
+Vaueekh       3027 C465111-6    Lo Ni              701 Va     F4V M1V
+Uuengrarz     3127 B9B7375-8  G Fl Lo Ni           824 Va     F2V M5V
 Kagzoez       0228 C987587-3    Ag Ni              511 Va     F1V 
-Eoe           0928 D865876-3                       900 Va     M4V M2D 
-Gaetstheng    1228 C758878-3  G                    205 Va     G1V M3D 
-Akhsthagrae   1628 A73A558-F  G Ni Wa              202 Va     A0V M6D 
-Aorrgdhoull   1828 C330465-7    De Ni Po           224 Va     K0V M7D 
-Gvoeaer       2828 C000103-C    As Lo Ni           400 Va     F0V M4D 
-Khanougae     2928 B667447-8  G Ni                 902 Va     M2V M6D 
-Dzerkoerorr   3028 C9B6413-9  G Fl Ni              714 Va     K8V M0D 
+Eoe           0928 D865876-3                       900 Va     M4V M2V
+Gaetstheng    1228 C758878-3  G                    205 Va     G1V M3V
+Akhsthagrae   1628 A73A558-F  G Ni Wa              202 Va     A0V M6V
+Aorrgdhoull   1828 C330465-7    De Ni Po           224 Va     K0V M7V
+Gvoeaer       2828 C000103-C    As Lo Ni           400 Va     F0V M4V
+Khanougae     2928 B667447-8  G Ni                 902 Va     M2V M6V
+Dzerkoerorr   3028 C9B6413-9  G Fl Ni              714 Va     K8V M0V
 Ounorronokhs  3128 B9B5221-5    Fl Lo Ni           714 Va     K0V 
 Ksougaeks     0529 E574532-3    Ag Ni              402 Va     F0V M8D M1V 
-Vougghaerrg   0729 C624676-4  G Ni                 314 Va     F6V M8D 
+Vougghaerrg   0729 C624676-4  G Ni                 314 Va     F6V M8V
 Ouaeig        1229 C579877-6  G                    905 Va     F6V 
-Rrunruer      1729 C446358-4    Lo Ni              822 Va     F1V M8D 
+Rrunruer      1729 C446358-4    Lo Ni              822 Va     F1V M8V
 Ouro          3229 C435975-7  G Hi In              300 Va     F8V 
 Khurrgguedha  0730 B5486A8-8  C Ag Ni              213 Va     G4V 
 Aerrnaen      0830 C300376-6  G Lo Ni Va           302 Va     M0V 
-Uue           1230 C372555-7    Ni                 613 Va     F4V M7D 
+Uue           1230 C372555-7    Ni                 613 Va     F4V M7V
 Vaengoerz     1430 E646303-2  C Lo Ni              222 Va     F2V 
 Aedaer        1530 C300525-9  C Ni Va              101 Va     M3III G3V 
 Uverrghouz    2030 C110446-9    Ni                 600 VL     M5V M7V 
@@ -202,87 +202,87 @@ Ourzurrgaegz  2530 C220558-6    De Ni Po           700 VL     M0V
 Gzouksknuedh  2630 C7C3365-8    Fl Lo Ni           824 VL     M7V M2V M2V 
 Ea            2830 C97A536-9    Ni Wa              503 VL     F1V 
 Edhungueoe    3130 C534222-8  G Lo Ni              812 Va     F5V 
-Arzoerzueu    0231 C858510-7    Ag Ni              513 Va     F9V M5D 
+Arzoerzueu    0231 C858510-7    Ag Ni              513 Va     F9V M5V
 Vangkfugz     0331 D6B2541-1  G Fl Ni              100 Va     M4V 
 Kukaluzurr    0631 E9A8476-8  C Fl Ni              524 Va     M4III M4V 
 Ouakhsaer     1131 CAC8543-6  G Fl Ni              802 Va     M0V 
 Oughakaer     1531 C270544-7  C De Ni              121 Va     F6V 
-Tigue         1931 C120345-7  C De Lo Ni Po        704 VL     M0V M3D 
+Tigue         1931 C120345-7  C De Lo Ni Po        704 VL     M0V M3V
 Oksoghzukh    2031 C412485-6  G Ic Ni              403 VL     M0V 
-Zoukang       2131 E8C4262-5  C Fl Lo Ni           712 VL     M6V M0D 
-Oursarrgen    2231 C757000-7    Ba Lo Ni           604 VL     F6V M8D 
-Agzong        2331 E666455-4  C Ni                 312 VL     F1V M1D 
-Zuedzetsnarr  2431 E574358-5    Lo Ni              803 VL     F8V M4D 
-Gaegonadh     2931 E677100-5    Lo Ni              403 VL     K2V M0D 
-Theve         0132 B676665-6  G Ag Ni              603 Va     F5V M3D 
+Zoukang       2131 E8C4262-5  C Fl Lo Ni           712 VL     M6V M0V
+Oursarrgen    2231 C757000-7    Ba Lo Ni           604 VL     F6V M8V
+Agzong        2331 E666455-4  C Ni                 312 VL     F1V M1V
+Zuedzetsnarr  2431 E574358-5    Lo Ni              803 VL     F8V M4V
+Gaegonadh     2931 E677100-5    Lo Ni              403 VL     K2V M0V
+Theve         0132 B676665-6  G Ag Ni              603 Va     F5V M3V
 Akhorarz      0732 B536573-A    Ni                 405 Va     G2V M7V 
 Sadzaeoe      1032 E636613-4  C Ni                 602 Va     M8V 
 Oufuenong     1532 C200275-6    Lo Ni Va           822 Va     F0V 
 Aeghadz       2032 C573236-5  G Lo Ni              820 VL     M8V 
-Zoadzoun      2232 E68677B-3  C Ag                 815 VL     K6V M7D 
+Zoadzoun      2232 E68677B-3  C Ag                 815 VL     K6V M7V
 Tsoea         2432 B362978-7    Hi In              500 VL     K2V 
-Agaeksots     2532 C7B2887-5  C Fl                 310 VL     F4V M7D 
+Agaeksots     2532 C7B2887-5  C Fl                 310 VL     F4V M7V
 Ghaghzfoghoz  2732 D300243-8    Lo Ni Va           516 VL     M0II K6V 
 Kfarrelong    2832 C553541-5    Ag Ni Po           124 VL     K3V 
-Roghularrg    2932 C000325-A    As Lo Ni           405 VL     M1V M0D 
-Akdzogh       1133 C677131-7    Lo Ni              506 Va     G9V M8D 
+Roghularrg    2932 C000325-A    As Lo Ni           405 VL     M1V M0V
+Akdzogh       1133 C677131-7    Lo Ni              506 Va     G9V M8V
 Gaghirr       1333 E644789-5  C Ag                 611 Va     F2V 
-Khueksengouz  1433 C659742-8                       800 Va     F5V M2D 
-Uegurel       1533 B100521-B    Ni Va              303 Va     K8V M1D 
-Roelae        1633 C9A7477-5  G Fl Ni              810 Va     G3V M4D 
+Khueksengouz  1433 C659742-8                       800 Va     F5V M2V
+Uegurel       1533 B100521-B    Ni Va              303 Va     K8V M1V
+Roelae        1633 C9A7477-5  G Fl Ni              810 Va     G3V M4V
 Azaelarrg     1933 A769537-D    Ni                 101 VL     F5V 
 Geu           2733 E556745-5    Ag                 300 VL     F6V 
-Kfurorron     2833 C377966-7  H Hi In              914 VL     F3V M5D 
-Dzallunoerr   2933 C568645-5    Ag Ni Ri           702 VL     G1V M6D 
-Iaghongun     0334 E241876-5    Po                 220 Va     F3V M7D 
+Kfurorron     2833 C377966-7  H Hi In              914 VL     F3V M5V
+Dzallunoerr   2933 C568645-5    Ag Ni Ri           702 VL     G1V M6V
+Iaghongun     0334 E241876-5    Po                 220 Va     F3V M7V
 Aezuen        0434 BAC986A-8    Fl                 402 Va     M7V 
 Knueue        1434 B737000-7    Ba Lo Ni           910 Va     F0V 
 Saauroung     1834 A423103-E    Lo Ni Po           904 Va     F4V 
 Aerrge        3234 C447333-6  G Lo Ni              721 Va     F3V 
 Uag           1135 X98A67A-1  C Ni Wa              310 Va     F6V 
-Dhavukhong    1235 C89A756-6  C Wa                 931 Va     F0V M7D 
+Dhavukhong    1235 C89A756-6  C Wa                 931 Va     F0V M7V
 Gvaearaerr    1335 E864231-4  C Lo Ni              803 Va     M1V 
 Iagfag        1635 E7A0788-6    De                 900 Va     M1V 
 Akozgon       2135 C778465-6    Ni                 313 Va     F9V 
-Ararrkughzen  2335 C587133-8    Lo Ni              436 Va     F7V M5D M7D 
+Ararrkughzen  2335 C587133-8    Lo Ni              436 Va     F7V M5D M7V
 Kfaenganoeng  2635 A665211-9    Lo Ni              804 Va     G5V 
-Kfuefue       2735 B471362-5    Lo Ni              101 Va     F8V M7D 
+Kfuefue       2735 B471362-5    Lo Ni              101 Va     F8V M7V
 Guenourr      3035 E435A76-A  C Hi In              102 Va     F1V 
 Kughuuego     0236 C797155-7    Lo Ni              900 Va     F9V 
 Kfukuegzviks  0736 A34287B-A  C Po                 513 Va     F8V 
 Uerrueth      1436 AAE8514-E    Fl Ni              500 Va     M8V 
-Voesez        1836 B000988-C  G As Hi Na           913 Va     F0D M5D 
+Voesez        1836 B000988-C  G As Hi Na           913 Va     F0D M5V
 Aoksuguleng   2336 X637343-2  C Lo Ni              700 Va     F1V 
 Dhalaelang    3036 C654576-7    Ag Ni              403 Va     K6V 
 Uesuue        0137 C21136A-6    Ic Lo Ni           902 Va     K1V 
-Elaeguegh     0637 E3438DD-0    Po                 301 Va     F1V M6D 
-Oesez         0737 C579145-8    Lo Ni              304 Va     F7V M3D 
+Elaeguegh     0637 E3438DD-0    Po                 301 Va     F1V M6V
+Oesez         0737 C579145-8    Lo Ni              304 Va     F7V M3V
 Dhoevaerrg    0937 A88A211-A  G Lo Ni Wa           610 Va     F3V 
 Khoaror       2037 X7A3253-0    Fl Lo Ni           722 Va     K9V 
-Adhidhuethur  2437 B365874-8                       913 Va     G6V M4D 
+Adhidhuethur  2437 B365874-8                       913 Va     G6V M4V
 Tsuervokhour  3237 C353121-8  C Lo Ni Po           120 Va     M1V 
 Lueghars      0438 E583675-1    Ag Ni              200 Va     F6V 
-Kulaerzik     1038 A779A88-D  G Hi In              115 Va     F5V M2D 
+Kulaerzik     1038 A779A88-D  G Hi In              115 Va     F5V M2V
 Ngouangkar    1438 C557797-8  G Ag                 602 Va     M6V 
 Onang         1638 C676400-9    Ni                 702 Va     M5V 
 Anzaeksaer    1938 E110666-8  C Na Ni              300 Va     F1V 
 Fouee         2438 C674446-2    Ni                 504 Va     K6V 
-Aekhue        0139 E568302-1  C Lo Ni              803 Va     F6V M8D 
+Aekhue        0139 E568302-1  C Lo Ni              803 Va     F6V M8V
 Ukerzar       0639 C999563-6  C Ni                 510 Va     F0V 
 Akhsalguen    0839 E130202-9  C De Lo Ni Po        511 Va     M0V 
 Daeluek       1339 D434977-8    Hi In              112 Va     F2V 
 Khoetszunakh  1439 C546454-5  H Ni                 902 Va     F3V 
-Thonguets     1939 A3309EJ-E  G De Hi In Na Po     122 Va     F1V M6D 
+Thonguets     1939 A3309EJ-E  G De Hi In Na Po     122 Va     F1V M6V
 Tekgvangudh   2539 B438558-C  H Ni                 502 Va     M5V 
-Egkonotsang   2639 C515434-7  G Ic Ni              415 Va     G6V M4D 
+Egkonotsang   2639 C515434-7  G Ic Ni              415 Va     G6V M4V
 Onuerrg       0640 C564300-8    Lo Ni              201 Va     F7V 
-Anggvoung     0940 C477677-5  G Ag Ni              322 Va     F8V M0D 
+Anggvoung     0940 C477677-5  G Ag Ni              322 Va     F8V M0V
 Raaeuedh      1040 B8C9401-8  G Fl Ni              800 Va     M5V 
 Aroun         1140 C525764-6  C                    722 Va     G7V 
-Raekdzaekue   1240 C769756-9  G Ri                 913 Va     F9V M3D 
-Orrorzgaerz   1440 B667575-4    Ag Ni              901 Va     F9V M5D 
+Raekdzaekue   1240 C769756-9  G Ri                 913 Va     F9V M3V
+Orrorzgaerz   1440 B667575-4    Ag Ni              901 Va     F9V M5V
 Gnofaeghu     1640 C847321-4    Lo Ni              225 Va     F8V 
-Aeeaeoer      1740 C533876-4    Na Po              902 Va     F3V M8D 
+Aeeaeoer      1740 C533876-4    Na Po              902 Va     F3V M8V
 Dhouergorrg   2440 B528775-7  G                    711 Va     M7III 
 Aaeghz        2640 A89A972-E  G Hi In Wa           200 Va     G3V 
 Kfukhsanoug   2840 C535546-5  G Ni                 100 Va     K1V 

--- a/res/Sectors/M1105/OeghzVaerrghr.sec
+++ b/res/Sectors/M1105/OeghzVaerrghr.sec
@@ -10,216 +10,216 @@ Oeghz Vaerrghr
 #--------1---------2---------3---------4---------5---------6---
 #PlanetName   Loc. UPP Code   B   Notes         Z  PBG Al LRX *
 #----------   ---- ---------  - --------------- -  --- -- --- -
-.             0301 X558000-0    Ba Lo Ni           005 --     F4V M7D 
-.             0501 X242000-0    Ba Lo Ni Po        014 --     F7V M5D 
+.             0301 X558000-0    Ba Lo Ni           005 --     F4V M7V
+.             0501 X242000-0    Ba Lo Ni Po        014 --     F7V M5V
 .             0601 X524000-0    Ba Lo Ni           013 --     G3III M1V 
-.             0701 X5A0000-0    Ba De Lo Ni        009 --     K8V K9D 
-.             0901 X639000-0    Ba Lo Ni           001 --     M5V M5D 
-.             1101 X795000-0    Ba Lo Ni           002 --     M8V M7D 
+.             0701 X5A0000-0    Ba De Lo Ni        009 --     K8V K9V
+.             0901 X639000-0    Ba Lo Ni           001 --     M5V M5V
+.             1101 X795000-0    Ba Lo Ni           002 --     M7V M8V
 .             1401 X160000-0    Ba De Lo Ni        002 --     F3V 
-Aezoenkuksan  1901 C675200-5  G Lo Ni              704 Va     M3V M6D 
+Aezoenkuksan  1901 C675200-5  G Lo Ni              704 Va     M3V M6V
 Koksgzaen     2001 C888156-4  C Lo Ni              801 Va     F9V 
-Uksorkfagz    2101 C745979-7  G Hi In              305 Va     F5V M5D 
+Uksorkfagz    2101 C745979-7  G Hi In              305 Va     F5V M5V
 Dadhaeg       3001 A550673-9    De Ni Po           120 Va     F1V 
 Dhoelkhuz     0202 C325575-6  H Ni                 423 Va     M0V 
-.             1202 X200000-0    Ba Lo Ni Va        012 --     K7D 
-.             1602 X343000-0    Ba Lo Ni Po        005 --     M2V M2D 
-Oeksae        2002 B470200-C    De Lo Ni           602 Va     F9V M6D 
+.             1202 X200000-0    Ba Lo Ni Va        012 --     K7V
+.             1602 X343000-0    Ba Lo Ni Po        005 --     M2V M2V
+Oeksae        2002 B470200-C    De Lo Ni           602 Va     F9V M6V
 Sogzughsog    2402 C224566-8    Ni                 421 Va     M4II M4V 
 Oksuth        2702 A354576-9    Ag Ni              102 Va     F5V 
 Kaerztaeghz   2802 E8B3500-3  C Fl Ni              711 Va     F2V M4V 
 Rongurrgh     2902 D477454-9    Ni                 203 Va     F9V 
-Ozuezagekaez  3002 B588102-B  G Lo Ni              700 Va     M4V M7D 
-Esoullo       0103 C737572-7  C Ni                 527 Va     M0V M6D 
-Llaegzrang    0403 B436614-B  C Ni                 606 Va     K0V M5D 
+Ozuezagekaez  3002 B588102-B  G Lo Ni              700 Va     M4V M7V
+Esoullo       0103 C737572-7  C Ni                 527 Va     M0V M6V
+Llaegzrang    0403 B436614-B  C Ni                 606 Va     K0V M5V
 Ogaeghelrroz  0703 CA7A333-B    Lo Ni Wa           502 Va     G0V 
-Eva           1003 D656614-6    Ag Ni              103 Va     F6V M8D 
+Eva           1003 D656614-6    Ag Ni              103 Va     F6V M8V
 Uekhson       2003 C54199C-7    Hi In Po           332 Va     F5V 
 Egegaer       2203 E793420-4  C Ni                 925 Va     F9V 
-Zuedhue       2603 B776799-5  G Ag                 614 Va     F9V M8D 
+Zuedhue       2603 B776799-5  G Ag                 614 Va     F9V M8V
 Ksuennurr     2903 E4035AF-5    Ic Ni Va           323 Va     M8V 
 Uekhaegzaksa  3003 EA86484-3  C Ni                 805 Va     K8V 
 Khaeueuea     0304 B7648AE-5                       812 Va     F1V 
-Angoerraerr   0504 E979766-0  C                    613 Va     F0V M2D 
+Angoerraerr   0504 E979766-0  C                    613 Va     F0V M2V
 Rafoudhrag    0904 B424221-D    Lo Ni              601 Va     G2IV 
-Tseuoigong    1204 D988699-4    Ag Ni Ri           403 Va     F9V M8D 
-Ksuetsaeo     2104 C6467A7-4    Ag                 136 Va     F1V M2D 
+Tseuoigong    1204 D988699-4    Ag Ni Ri           403 Va     F9V M8V
+Ksuetsaeo     2104 C6467A7-4    Ag                 136 Va     F1V M2V
 Ue            2204 D688879-0                       705 Va     F7V 
-Agvooe        2504 E580678-6  C De Ni              801 Va     F3V M3D 
+Agvooe        2504 E580678-6  C De Ni              801 Va     F3V M3V
 Ullotoeksuk   3104 B567559-7    Ag Ni              602 Va     F6V 
 Gaeollaezar   0405 B554300-9    Lo Ni              923 Va     F6V 
 Ikhegzarr     0605 C410673-A  C Na Ni              104 Va     F8V 
 Gungtekhs     0805 B444636-7  C Ag Ni              504 Va     K7V 
 Erzuksdhaz    1005 C312446-6    Ic Ni              612 Va     M2V 
-Uksoaedh      1105 C565597-5  C Ag Ni              702 Va     F5V M6D 
-Dhaedhag      2105 C757266-5    Lo Ni              901 Va     F7V M3D 
+Uksoaedh      1105 C565597-5  C Ag Ni              702 Va     F5V M6V
+Dhaedhag      2105 C757266-5    Lo Ni              901 Va     F7V M3V
 Kukfag        2705 E889200-8    Lo Ni              604 Va     K8V 
 Foelloe       2805 B479457-8    Ni                 500 Va     F3V 
 Saegzoutsong  0306 C332AB9-E    Hi In Na Po        211 Va     G8V 
 Nuenuegzroz   1106 CA8A5A8-6    Ni Wa              422 Va     F0V 
 Aegourr       1706 E547203-4  C Lo Ni              511 Va     G4V 
-Utsoeg        1906 C9B5640-5    Fl Ni              304 Va     F0III M8D 
+Utsoeg        1906 C9B5640-5    Fl Ni              304 Va     F0III M8V
 Gnughgang     2006 E735664-5    Ni                 302 Va     M0V 
 Oekhungor     2106 X463101-0  C Lo Ni              222 Va     F4V 
-Vaeoesun      2706 CAC1896-3  C Fl                 616 Va     M7V M6D 
-Aezarzgerz    3206 D8C8877-3    Fl                 502 Va     F2V M7D 
-Saenule       0207 E554776-2  C Ag                 402 Va     K9V M4D 
+Vaeoesun      2706 CAC1896-3  C Fl                 616 Va     M6V M7V
+Aezarzgerz    3206 D8C8877-3    Fl                 502 Va     F2V M7V
+Saenule       0207 E554776-2  C Ag                 402 Va     K9V M4V
 Saeorr        0307 B75A562-B  G Ni Wa              903 Va     K9V 
-Akhsersukh    0607 C8B9521-9  C Fl Ni              521 Va     M8V M0V 
+Akhsersukh    0607 C8B9521-9  C Fl Ni              521 Va     M0V M8V
 Gzoefaae      0807 B8A4137-8    Fl Lo Ni           701 Va     M8V 
 Guaaekhokhs   1507 C254477-7    Ni                 625 Va     F1V 
 Ghaeaegurr    1907 C545ACA-7    Hi In              602 Va     F2V 
 Dhosoerrkar   2007 C100004-7    Lo Ni Va           400 Va     M5V 
-Oethforoez    2807 C565766-4    Ag Ri              100 Va     F1V M1D 
+Oethforoez    2807 C565766-4    Ag Ri              100 Va     F1V M1V
 Dzuerrou      2907 B53A352-9    Lo Ni Wa           501 Va     F9V 
 Ghoekraks     3007 C450675-5  C De Ni Po           201 Va     G0V 
 Onaengagarr   0208 C323676-7    Na Ni Po           100 Va     M6III 
 Ozoksangeghz  0308 C34897C-9  C Hi In              700 Va     M8V 
 Ghaellurs     1208 C344300-7    Lo Ni              701 Va     F5V 
-Oaeksaso      1908 D425775-6  G                    715 Va     M6V M3D 
+Oaeksaso      1908 D425775-6  G                    715 Va     M3V M6V
 Fagofa        2208 D3777CG-4  C Ag                 323 Va     G7V 
 Guekne        2508 D459665-6  C Ni                 410 Va     F0V 
-Ksueaengurr   0809 D400510-7  C Ni Va              602 Va     M3V M5D 
+Ksueaengurr   0809 D400510-7  C Ni Va              602 Va     M3V M5V
 Zuaoedae      1809 A345322-A  G Lo Ni              205 Va     K8V 
 Iaa           2409 C688689-3  G Ag Ni              904 Va     M6V 
 Vologh        2909 C687998-6    Hi In              712 Va     G8V 
-Uerrae        3209 X421512-4    Ni Po              406 Va     K7V M5D 
-Rruezugzal    0110 A843A7B-E  G Hi In Po           703 Va     F2V M7D F3V M4D 
-Zerrgaek      0210 E848888-2  C                    526 Va     F0V M5D 
-Oekhsang      0310 C580772-4  G De                 723 Va     F2V M7D 
-Tsueuerrg     0610 C696457-8  C Ni                 420 Va     F6V M2D 
-Khaereae      0810 B6937CF-7    Ag                 706 Va     F0V M6D 
+Uerrae        3209 X421512-4    Ni Po              406 Va     K7V M5V
+Rruezugzal    0110 A843A7B-E  G Hi In Po           703 Va     F2V M7V F3V M4V
+Zerrgaek      0210 E848888-2  C                    526 Va     F0V M5V
+Oekhsang      0310 C580772-4  G De                 723 Va     F2V M7V
+Tsueuerrg     0610 C696457-8  C Ni                 420 Va     F6V M2V
+Khaereae      0810 B6937CF-7    Ag                 706 Va     F0V M6V
 Ghungun       0910 C565421-3  G Ni                 111 Va     F1V 
 Ksasae        1210 D546242-4    Lo Ni              415 Va     F9V M1V 
-Ukue          1410 C574300-A    Lo Ni              206 Va     F7V M0D 
+Ukue          1410 C574300-A    Lo Ni              206 Va     F7V M0V
 Vaerrouoerrg  1810 C523446-6    Ni Po              203 Va     M8V 
 Ugzragzzaen   1910 A000569-A    As Ni              702 Va     M2V 
-Ouggorrghan   2310 E232263-9    Lo Ni Po           202 Va     M2V M3D 
-Uekuthuefa    2410 B77377B-4    Ag                 713 Va     F2V M4D 
-Gododonae     2510 E52726B-7  C Lo Ni              314 Va     F9IV M3D 
+Ouggorrghan   2310 E232263-9    Lo Ni Po           202 Va     M2V M3V
+Uekuthuefa    2410 B77377B-4    Ag                 713 Va     F2V M4V
+Gododonae     2510 E52726B-7  C Lo Ni              314 Va     F9IV M3V
 Faoetonadz    3010 B580525-6    De Ni              505 Va     G0V 
 Zarzaerran    3110 E435575-4  C Ni                 500 Va     M5V 
-Souda         0211 C000552-7  H As Ni              503 Va     F0V M6D 
+Souda         0211 C000552-7  H As Ni              503 Va     F0V M6V
 Aerrghdhoeng  0511 C210122-5  C Lo Ni              300 Va     K3V 
 Tserrgoun     0711 E594544-3  C Ag Ni              802 Va     M6V 
 Tsuekhueks    1411 C200212-6    Lo Ni Va           600 Va     M6II K8V 
 Oekhuek       1711 D448424-4    Ni                 203 Va     M4V 
-Togvoersour   1811 C000535-7    As Ni              101 Va     G9V M6D 
+Togvoersour   1811 C000535-7    As Ni              101 Va     G9V M6V
 Ksuere        2311 D260226-5    De Lo Ni           101 Va     F2V 
-Oghaghuks     2711 C110610-9    Na Ni              215 Va     M7V M8D 
-Zueknedh      3211 X84A401-0    Ni Wa              723 Va     F3V M1D M4D 
-Oukfuek       0112 E465466-3  C Ni                 208 Va     G7V M2D 
+Oghaghuks     2711 C110610-9    Na Ni              215 Va     M7V M8V
+Zueknedh      3211 X84A401-0    Ni Wa              723 Va     F3V M1V M4V
+Oukfuek       0112 E465466-3  C Ni                 208 Va     G7V M2V
 Ougtours      0612 C676435-6  G Ni                 103 Va     F7V 
-Luegfoghaegh  0712 X569869-1  C Ri                 800 Va     G5V M1D 
-Aedidhak      1012 C426545-8    Ni                 407 Va     K9V M1D 
-Taekoedzoe    1512 E8B7464-4    Fl Ni              806 Va     M4V M6D 
-Ngueknou      1912 C514979-6  C Hi Ic              320 Va     F5V M1D 
+Luegfoghaegh  0712 X569869-1  C Ri                 800 Va     G5V M1V
+Aedidhak      1012 C426545-8    Ni                 407 Va     K9V M1V
+Taekoedzoe    1512 E8B7464-4    Fl Ni              806 Va     M4V M6V
+Ngueknou      1912 C514979-6  C Hi Ic              320 Va     F5V M1V
 Vaaendhadh    2112 C321387-7  G Lo Ni Po           700 Va     M3V 
-Farrokh       2212 X537463-4    Ni                 716 Va     K4V M3D 
+Farrokh       2212 X537463-4    Ni                 716 Va     K4V M3V
 Outuengokh    2312 B421342-6    Lo Ni Po           400 Va     G4V 
-Aeourrg       2412 C20297C-8  C Hi Ic Na Va        403 Va     F2D 
+Aeourrg       2412 C20297C-8  C Hi Ic Na Va        403 Va     F2V
 Sueuezosue    2612 B999678-5    Ni                 402 Va     F4V 
 Rueaeulaerz   2712 B795783-5  G Ag                 902 Va     M8V 
 Orrvanungzan  2812 D746253-8  C Lo Ni              921 Va     F7V 
 Orrengruth    3112 C483647-5  C Ag Ni Ri           403 Va     M4V 
 Vikuu         3212 C767104-8  G Lo Ni              401 Va     G8V 
-Llaevogoa     0113 C300433-7  G Ni Va              104 Va     M1V M3D M3D 
+Llaevogoa     0113 C300433-7  G Ni Va              104 Va     M1V M3V M3V
 Orrorrgokhs   0313 C666000-4    Ba Lo Ni           810 Va     F4V 
 Tonez         0513 E424678-7  C Ni                 901 Va     F4III M6V 
 Sueeksaerz    0613 X366469-0    Ni                 721 Va     G0V 
-Gvizola       0813 B310679-9  G Na Ni              706 Va     M0V M3D 
-Gatsuerrueza  0913 C8D2242-A    Fl Lo Ni           902 Va     F0V M4D 
+Gvizola       0813 B310679-9  G Na Ni              706 Va     M0V M3V
+Gatsuerrueza  0913 C8D2242-A    Fl Lo Ni           902 Va     F0V M4V
 Eghzag        1713 E68A365-7    Lo Ni Wa           403 Va     F0V 
-Rraegkun      1913 CA9A559-A  G Ni Wa              214 Va     F3V M3D M3D 
+Rraegkun      1913 CA9A559-A  G Ni Wa              214 Va     F3V M3V M3V
 Gogkak        2213 B432456-7    Ni Po              800 Va     M8V 
 Urodh         2513 E87A377-4    Lo Ni Wa           120 Va     M3V 
 Niluzo        0214 C501551-5  G Ic Ni Va           524 Va     G4V 
-Gakhrarztaer  1914 B160435-C  G De Ni              700 Va     M8V M4D 
-Llueudhae     2214 X330656-3  C De Na Ni Po        310 Va     A1V M6D 
+Gakhrarztaer  1914 B160435-C  G De Ni              700 Va     M4V M8V
+Llueudhae     2214 X330656-3  C De Na Ni Po        310 Va     A1V M6V
 Ngegoerr      2514 D773672-6    Ag Ni              201 Va     K6V 
-Tsueraeats    2714 E241666-1  C Ni Po              304 Va     F5V M1D 
+Tsueraeats    2714 E241666-1  C Ni Po              304 Va     F5V M1V
 Agongoruaei   2914 E000200-9  C As Lo Ni           504 Va     M0V M5V 
 Khaosoezel    0315 B643A77-9  C Hi In Po           404 Va     F6V 
 Oekhoksoug    0615 B645002-9    Lo Ni              604 Va     F9V 
-Kotsi         0715 E410552-7    Ni                 700 Va     F2V M5D 
-Ongekikoegh   0915 E9E6978-6  C Fl Hi In           600 Va     F9V M4D 
+Kotsi         0715 E410552-7    Ni                 700 Va     F2V M5V
+Ongekikoegh   0915 E9E6978-6  C Fl Hi In           600 Va     F9V M4V
 Kfaekaeaoe    1015 C666658-3    Ag Ni Ri           300 Va     F2V 
-Onadhagz      1315 A744530-9  G Ag Ni              503 Va     K5V M2D 
+Onadhagz      1315 A744530-9  G Ag Ni              503 Va     K5V M2V
 Llaueth       1415 C331468-B  H Ni Po              802 Va     M3V 
-Nanoe         1515 E969215-7  C Lo Ni              114 Va     M3V M2D 
-Aeudh         2215 CAA4845-7  C Fl                 505 Va     M8V M5D 
+Nanoe         1515 E969215-7  C Lo Ni              114 Va     M2V M3V
+Aeudh         2215 CAA4845-7  C Fl                 505 Va     M8V M5V
 Kolunoung     2715 D598420-2  G Ni                 911 Va     F9V 
 Atsgoer       3015 C76869B-3  C Ag Ni Ri           400 Va     F1V 
-Aeksdzaz      0516 C200878-6  G Na Va              621 Va     F2D 
+Aeksdzaz      0516 C200878-6  G Na Va              621 Va     F2V
 Anugh         0716 D342421-6  C Ni Po              413 Va     F1V 
-Zueaer        1216 B343425-7  G Ni Po              100 Va     M8V M7D 
+Zueaer        1216 B343425-7  G Ni Po              100 Va     M7V M8V
 Tsoezraeng    1316 E965875-5                       603 Va     F4V 
-Ghodedhkhun   2316 E000415-5    As Ni              601 Va     M3V M6D 
-Daenval       0117 C130779-5  G De Na Po           413 Va     M6V M4D 
+Ghodedhkhun   2316 E000415-5    As Ni              601 Va     M3V M6V
+Daenval       0117 C130779-5  G De Na Po           413 Va     M4V M6V
 Odhurokuedz   0217 C9D1349-4    Fl Lo Ni           303 Va     M1II K2V 
 Gvidanaegh    0717 A233511-B  G Ni Po              603 Va     M2V 
 Goknuefou     1817 B65A575-A    Ni Wa              301 Va     F2V 
 Nagvingfakh   2017 E543311-5  C Lo Ni Po           701 Va     F3V 
-Senfukigsar   3217 C8589BA-7  G Hi In              526 Va     F0V M3D 
+Senfukigsar   3217 C8589BA-7  G Hi In              526 Va     F0V M3V
 Ghauen        0118 EAE8556-3  C Fl Ni              423 Va     G7V 
 Aekhanongdoz  0618 E100346-4    Lo Ni Va           202 Va     M1V 
 Vavou         0818 C310332-4    Lo Ni              100 Va     M7III 
-Ghangvoth     1018 C253411-5    Ni Po              501 Va     F6V M7D 
+Ghangvoth     1018 C253411-5    Ni Po              501 Va     F6V M7V
 Saerfakh      2518 B333645-8  G Na Ni Po           705 Va     K7V M0V 
 Khevaeaekill  2718 X674A9A-5  C Hi In              500 Va     F2V 
-Ghugaekhus    3118 C300878-6  G Na Va              906 Va     F9D M3D 
+Ghugaekhus    3118 C300878-6  G Na Va              906 Va     F9V M3V
 Vuknuezugz    0419 D674894-3                       102 Va     F5V 
 Rraoudh       0619 E456474-3  C Ni                 610 Va     F5V 
-Unguenkourrg  0719 C223574-7    Ni Po              724 Va     K2V M5D 
-Gokho         1019 A376653-A  G Ag Ni              715 Va     F7V M0D 
-Rarzuegh      2319 C100777-6    Na Va              413 Va     K5V M8D 
+Unguenkourrg  0719 C223574-7    Ni Po              724 Va     K2V M5V
+Gokho         1019 A376653-A  G Ag Ni              715 Va     F7V M0V
+Rarzuegh      2319 C100777-6    Na Va              413 Va     K5V M8V
 Uekuegz       2919 D736654-6  C Ni                 313 Va     K3V 
 Dokoghogna    0320 C679100-9    Lo Ni              702 Va     M0V 
 Sesaeg        0420 C220440-9  C De Ni Po           110 Va     F4V 
-Gagzigh       0720 E324556-8  C Ni                 814 Va     K7V M2D 
+Gagzigh       0720 E324556-8  C Ni                 814 Va     K7V M2V
 Ourdoerr      0920 D6418BA-3  C Po                 100 Va     F9V 
 Rraerrvaegh   1020 AABA502-F    Fl Ni Wa           903 Va     F7V 
-Knathaedh     1120 D264510-4  C Ag Ni              104 Va     F7V M0D 
+Knathaedh     1120 D264510-4  C Ag Ni              104 Va     F7V M0V
 Dzodengugh    2220 B6A6540-9  C Fl Ni              611 Va     M0V 
 Aefengkoeg    2320 C58859A-4    Ag Ni              802 Va     F7V 
-Sakuel        3120 C6B1441-3    Fl Ni              106 Va     M1V M0V 
-Rrugae        0421 E575A77-9    Hi In              202 Va     K6V M5D 
+Sakuel        3120 C6B1441-3    Fl Ni              106 Va     M0V M1V
+Rrugae        0421 E575A77-9    Hi In              202 Va     K6V M5V
 Kollarrgh     0721 C000420-6  G As Ni              904 Va     M7V 
 Aeuae         0821 B412121-6    Ic Lo Ni           712 Va     F3III M7V 
 Kounging      1321 C745777-5  G Ag                 322 Va     F2V 
 Voeu          2021 C466335-3    Lo Ni              304 Va     F8V 
-Akfue         0422 C464322-9  C Lo Ni              520 Va     F2V M5D 
+Akfue         0422 C464322-9  C Lo Ni              520 Va     F2V M5V
 Ongoth        0622 E8A0657-8  C De Ni              210 Va     M8V 
 Naerzuer      2522 C120656-8  G De Na Ni Po        402 Va     M2V 
 Kazegzrun     0123 C452547-7    Ni Po              302 Va     F1V 
-Zugangouth    0323 C2006BC-5    Na Ni Va           804 Va     M3V M1V 
+Zugangouth    0323 C2006BC-5    Na Ni Va           804 Va     M1V M3V
 Ouduengal     0923 C120533-7  G De Ni Po           212 Va     M2V 
-Kuediguengur  2323 E683110-6    Lo Ni              504 Va     F9V M1D 
+Kuediguengur  2323 E683110-6    Lo Ni              504 Va     F9V M1V
 Khorrnegfue   2423 B421158-D  G Lo Ni Po           103 Va     K9V 
 Kedaegvarroa  0824 B433977-A    Hi In Na Po        700 Va     F4V 
-Ekhtsaen      1424 D786400-6  C Ni                 401 Va     F6V M3D 
+Ekhtsaen      1424 D786400-6  C Ni                 401 Va     F6V M3V
 Dheksokhots   1724 C998345-6  G Lo Ni              102 Va     M7V 
 Dzugol        2524 CAB6000-9    Ba Fl Lo Ni        125 Va     K7V M1V 
-Doghzsur      2624 B344684-9  G Ag Ni              302 Va     K1V M3D 
-Ghaeedhunoun  0425 A671532-9  G Ni                 703 Va     F7V M5D 
+Doghzsur      2624 B344684-9  G Ag Ni              302 Va     K1V M3V
+Ghaeedhunoun  0425 A671532-9  G Ni                 703 Va     F7V M5V
 Zaerrgfonoe   0525 B654137-5    Lo Ni              800 Va     F5V 
-Gudak         0825 B464355-A    Lo Ni              521 Va     F9V M1D 
+Gudak         0825 B464355-A    Lo Ni              521 Va     F9V M1V
 Gugknaenagz   1325 X57866A-0  C Ag Ni              420 Va     F2V 
-Kfudzu        1825 C78A267-5    Lo Ni Wa           705 Va     F5V M2D 
+Kfudzu        1825 C78A267-5    Lo Ni Wa           705 Va     F5V M2V
 Zurrarroung   2125 B553220-7    Lo Ni Po           100 Va     F2V 
-Faerouvagh    3125 A000477-C    As Ni              912 Va     M8V M0D 
+Faerouvagh    3125 A000477-C    As Ni              912 Va     M0V M8V
 Rouudz        0526 C428335-5  G Lo Ni              703 Va     G0V 
-Enkfez        1126 D458110-3    Lo Ni              914 Va     G5V M6D 
+Enkfez        1126 D458110-3    Lo Ni              914 Va     G5V M6V
 Zauezu        1226 D400744-6  C Na Va              210 Va     M6III 
-Aaeofael      1426 B797769-9    Ag                 403 Va     F6V M5D 
+Aaeofael      1426 B797769-9    Ag                 403 Va     F6V M5V
 Kfaekfuerang  1826 B652441-6    Ni Po              310 Va     F3V 
 Ngaeksaang    2226 X436446-0    Ni                 302 Va     M2V 
 Ogzoekfuz     2426 C98A566-B    Ni Wa              903 Va     F9V 
-Llaelae       3026 E401203-9  C Ic Lo Ni Va        910 Va     K4V M7D 
-Ngazeng       0227 X401753-0    Ic Na Va           202 Va     F0V M6D 
+Llaelae       3026 E401203-9  C Ic Lo Ni Va        910 Va     K4V M7V
+Ngazeng       0227 X401753-0    Ic Na Va           202 Va     F0V M6V
 Vaedhonguen   0427 B53948A-D    Ni                 510 Va     K4V 
 Gourrouen     0527 C201634-5    Ic Na Ni Va        211 Va     K3V 
-Aeghaegz      0827 C78647A-8  C Ni                 815 Va     G1V M8D 
+Aeghaegz      0827 C78647A-8  C Ni                 815 Va     G1V M8V
 Toutsungknuz  1227 D200143-5  C Lo Ni Va           204 Va     M6V 
 Gaengaso      1527 D9C3667-5    Fl Ni              901 Va     M6V 
 Llegdzon      2527 E100369-4    Lo Ni Va           413 Va     G1V 
@@ -227,32 +227,32 @@ Furrgazgi     3127 C527264-5    Lo Ni              600 Va     M8III
 Gologhksoes   0228 C564256-5    Lo Ni              102 Va     F1V 
 Orrghuerrang  0728 B4108DD-3    Na                 910 Va     F1V 
 Tsuengurrel   0828 C100688-7    Na Ni Va           323 Va     K4V M1V 
-Rruou         1228 B886256-A    Lo Ni              705 Va     F9V M4D 
+Rruou         1228 B886256-A    Lo Ni              705 Va     F9V M4V
 Fenaedhgen    2328 C442522-9  G Ni Po              402 Va     G6V 
 Dhagztsaedz   2628 D98A373-2    Lo Ni Wa           300 Va     F3V 
 Tsueghkfakhs  0729 B230794-C    De Na Po           602 Va     M6V 
 Vaenllarrg    0829 D000573-7  G As Ni              201 Va     K1V 
-Zusa          1129 C868799-7  C Ag Ri              906 Va     F9V M0D 
-Dhaetsaek     1229 B9A8538-8  G Fl Ni              114 Va     M0V M5D 
-Dueaeza       1329 C250876-3    De Po              922 Va     K9V M5D 
+Zusa          1129 C868799-7  C Ag Ri              906 Va     F9V M0V
+Dhaetsaek     1229 B9A8538-8  G Fl Ni              114 Va     M0V M5V
+Dueaeza       1329 C250876-3    De Po              922 Va     K9V M5V
 Kedhugh       2229 C355779-3    Ag                 500 Va     F3V 
-Kherdaerroez  2629 E648103-5    Lo Ni              113 Va     F1V M5D 
-Gaezun        0130 C300751-B    Na Va              107 Va     M5V M3D 
+Kherdaerroez  2629 E648103-5    Lo Ni              113 Va     F1V M5V
+Gaezun        0130 C300751-B    Na Va              107 Va     M5V M3V
 Aekfuerrg     0730 C422310-8  G Lo Ni Po           720 Va     F2V 
 Rikarrga      2130 E866633-1  C Ag Ni              102 Va     F0V 
 Aedhuegael    0231 B424110-9  C Lo Ni              414 Va     K2V 
 Gaesuelluedz  0531 C234ACC-C  G Hi In              413 Va     F7V 
 Tongoughz     0631 B776123-A    Lo Ni              414 Va     F9V M5V 
-Zazoezeraerr  0831 B100A7A-C  G Hi Na Va           713 Va     M2V M2D 
+Zazoezeraerr  0831 B100A7A-C  G Hi Na Va           713 Va     M2V M2V
 Oenkaen       1231 C452410-6    Ni Po              823 Va     F7V 
-Rouksun       0232 D45868B-2  C Ag Ni              500 Va     F1V M3D 
-Ksoursdhigz   0432 E764320-3  C Lo Ni              405 Va     F5V M1D 
-Tsounaeooe    0632 B200443-A  C Ni Va              905 Va     M1V M4D 
+Rouksun       0232 D45868B-2  C Ag Ni              500 Va     F1V M3V
+Ksoursdhigz   0432 E764320-3  C Lo Ni              405 Va     F5V M1V
+Tsounaeooe    0632 B200443-A  C Ni Va              905 Va     M1V M4V
 Aerkforrghug  0832 CAD197B-5    Fl Hi In           701 Va     K5V 
-Surrgaekhs    1432 E346340-3  C Lo Ni              722 Va     F5V M5D 
+Surrgaekhs    1432 E346340-3  C Lo Ni              722 Va     F5V M5V
 Ksunaghaers   2832 C200003-6  C Lo Ni Va           704 Va     M3V 
-Rroedhgol     3032 X15057A-3  C De Ni Po           810 Va     F1V M3D 
-Fazadzaeks    0133 B656204-C  C Lo Ni              405 Va     F5V M3D 
+Rroedhgol     3032 X15057A-3  C De Ni Po           810 Va     F1V M3V
+Fazadzaeks    0133 B656204-C  C Lo Ni              405 Va     F5V M3V
 Sokakh        0233 E764534-1  C Ag Ni              413 Va     F5V 
 Ghaknaghz     0733 C7A1466-6    Fl Ni              206 Va     K7V M3V 
 Ugaelurzoung  0933 A354478-D    Ni                 714 Va     F3V 
@@ -261,40 +261,40 @@ Ueuth         1833 C200534-6    Ni Va              500 Va     K2V
 Dhakuezerr    1933 C436440-6  C Ni                 102 Va     G9V 
 Daenfagung    2633 D7385AC-2    Ni                 404 Va     K0V 
 Aeraegers     0234 C66389A-3  H Ri                 103 Va     F8V 
-Ougvuerrgh    0334 C2007A6-5  G Na Va              914 Va     M5V M5D 
+Ougvuerrgh    0334 C2007A6-5  G Na Va              914 Va     M5V M5V
 Khagazog      1134 C322868-9    Na Po              411 Va     F5V 
 Ngueogz       1234 C833578-A    Ni Po              803 Va     K4V 
 Aegung        1334 B99A874-5  H Wa                 524 Va     F0V 
 Roeldzall     1534 C400532-8  H Ni Va              503 Va     M0V 
 Ghotorrar     2534 B678625-4    Ag Ni              202 Va     F5V 
 Uekoeae       0635 A381775-8  G                    800 Va     K8V 
-Esoer         1135 C794521-5    Ag Ni              324 Va     F6V M1D 
+Esoer         1135 C794521-5    Ag Ni              324 Va     F6V M1V
 Gadouruekir   1435 A100634-9  G Na Ni Va           503 Va     M0V 
 Dhiuueo       1935 E58579B-3    Ag Ri              404 Va     F9V 
-Kfaerzunsok   2735 D798A77-9    Hi In              603 Va     K8V M1D 
+Kfaerzunsok   2735 D798A77-9    Hi In              603 Va     K8V M1V
 Kako          0336 B875212-8  G Lo Ni              723 VX     F1V 
 Atal          0836 B596147-7    Lo Ni              814 Va     F6V 
 Iuer          1136 D745759-1    Ag                 804 Va     F4V 
 Uerraen       0337 C263123-6  G Lo Ni              201 VX     F7V 
-Aegho         1137 CAB6676-3    Fl Ni              600 Va     G8III M1D 
+Aegho         1137 CAB6676-3    Fl Ni              600 Va     G8III M1V
 Khoegverr     1337 E694976-6    Hi In              900 Va     F1V 
 Kfugouz       1537 C456522-6  G Ag Ni              800 Va     M5V 
 Aekhurrgtaen  1837 C000977-D    As Hi Na           212 Va     F9V 
-Dhavasunu     1937 A9B5626-8  G Fl Ni              821 Va     M4V M3D 
+Dhavasunu     1937 A9B5626-8  G Fl Ni              821 Va     M4V M3V
 Aekoeou       2137 E564213-6    Lo Ni              300 Va     F9V 
 Ugueth        0138 B658201-A  G Lo Ni              402 VX     M4V 
-Ezosaedz      0338 C472687-5    Ni                 607 VX     F1V M8D 
+Ezosaedz      0338 C472687-5    Ni                 607 VX     F1V M8V
 Oogu          0638 E88A585-8  C Ni Wa              303 Va     F6V 
-Kolle         0738 E742511-1    Ni Po              603 Va     F2V M6D 
+Kolle         0738 E742511-1    Ni Po              603 Va     F2V M6V
 Odzong        0938 C110311-8    Lo Ni              613 Va     M2V 
-Ugllerz       1238 X9A9100-3    Fl Lo Ni           600 Va     M6V M2D 
-Rregedz       1638 D562974-8    Hi In              305 Va     F8V M7D 
+Ugllerz       1238 X9A9100-3    Fl Lo Ni           600 Va     M2V M6V
+Rregedz       1638 D562974-8    Hi In              305 Va     F8V M7V
 Okaekou       2038 C465444-3  G Ni                 923 Va     F2V 
-Aee           2438 C554442-5    Ni                 903 Va     G6V M2D 
+Aee           2438 C554442-5    Ni                 903 Va     G6V M2V
 Thuegzaez     2638 C200777-3  G Na Va              413 Va     M6V 
-Dhuonofae     3138 C46589D-6  G Ri                 424 Va     F8V M8D 
+Dhuonofae     3138 C46589D-6  G Ri                 424 Va     F8V M8V
 Kidzouorrgh   0639 B76A975-7  G Hi In Wa           802 Va     F7V 
-Regaeks       0739 C433777-5  G Na Po              202 Va     M6V M8D 
+Regaeks       0739 C433777-5  G Na Po              202 Va     M6V M8V
 Aighgoeng     0939 D36489C-3  C Ri                 202 Va     F5V 
 Zokuorr       1139 C5A1A78-8    Fl Hi In           300 Va     F4V 
 Gvurrghdang   1239 C310976-7    Hi Na              804 Va     K1V 
@@ -307,4 +307,4 @@ Khunog        1440 C799620-3    Ni                 810 Va     G4V
 Girsaghirz    1540 B739200-9    Lo Ni              223 Va     M6V 
 Okhsouzoul    1640 B8B0340-7    De Lo Ni           602 Va     M1V 
 Ueoekaerr     1940 E262876-6  C                    603 Va     F6V 
-Rukhoevirz    2540 C233476-7  G Ni Po              922 Va     F4V M8D 
+Rukhoevirz    2540 C233476-7  G Ni Po              922 Va     F4V M8V

--- a/res/Sectors/M1105/Rfigh.sec
+++ b/res/Sectors/M1105/Rfigh.sec
@@ -8,96 +8,96 @@ Rfigh
 #--------1---------2---------3---------4---------5---------6---
 #PlanetName   Loc. UPP Code   B   Notes         Z  PBG Al LRX *
 #----------   ---- ---------  - --------------- -  --- -- --- -
-.             0101 X685000-0    Ba Lo Ni           002 --     F8V M0D 
+.             0101 X685000-0    Ba Lo Ni           002 --     F8V M0V
 .             0201 X516000-0    Ba Ic Lo Ni        002 --     F7IV 
-.             0301 XAC4000-0    Ba Fl Lo Ni        006 --     M4V M4D 
+.             0301 XAC4000-0    Ba Fl Lo Ni        006 --     M4V M4V
 .             1701 X561000-0    Ba Lo Ni           002 --     F3V 
-.             2101 X76A000-0    Ba Lo Ni Wa        004 --     F0V M2D K8V 
-.             2501 X568000-0    Ba Lo Ni           002 --     F3V M5D 
+.             2101 X76A000-0    Ba Lo Ni Wa        004 --     F0V M2V K8V
+.             2501 X568000-0    Ba Lo Ni           002 --     F3V M5V
 .             2701 X227000-0    Ba Lo Ni           002 --     M8V 
-.             3101 X110000-0    Ba Lo Ni           001 --     M3V M7D 
+.             3101 X110000-0    Ba Lo Ni           001 --     M3V M7V
 .             0102 X898000-0    Ba Lo Ni           000 --     F4V 
 .             0502 X57A000-0    Ba Lo Ni Wa        013 --     F5V 
 .             0602 X585000-0    Ba Lo Ni           010 --     F3V 
 .             1102 X226000-0    Ba Lo Ni           013 --     G3V 
 .             1602 X768000-0    Ba Lo Ni           003 --     G5V 
-.             1902 X796000-0    Ba Lo Ni           002 --     F4V M3D 
+.             1902 X796000-0    Ba Lo Ni           002 --     F4V M3V
 .             2102 X78A000-0    Ba Lo Ni Wa        014 --     M8V 
 .             2202 XAB4000-0    Ba Fl Lo Ni        010 --     M4V 
 .             0403 X203000-0    Ba Ic Lo Ni Va     002 --     M8V 
-.             1103 X658000-0    Ba Lo Ni           002 --     F5V M4D 
+.             1103 X658000-0    Ba Lo Ni           002 --     F5V M4V
 .             1503 X6B5000-0    Ba Fl Lo Ni        010 --     G1V 
 .             2103 X230000-0    Ba De Lo Ni Po     001 --     G9V M1V 
 .             2903 X867000-0    Ba Lo Ni           002 --     M3V 
 .             3103 X692000-0    Ba Lo Ni           006 --     F5V G4V 
-.             0104 X774000-0    Ba Lo Ni           014 --     F3V M8D 
-.             0304 X853000-0    Ba Lo Ni Po        010 --     F1V M6D 
-.             0404 X769000-0    Ba Lo Ni           013 --     F7V M2D 
-.             0604 X745000-0    Ba Lo Ni           005 --     F4V M2D 
+.             0104 X774000-0    Ba Lo Ni           014 --     F3V M8V
+.             0304 X853000-0    Ba Lo Ni Po        010 --     F1V M6V
+.             0404 X769000-0    Ba Lo Ni           013 --     F7V M2V
+.             0604 X745000-0    Ba Lo Ni           005 --     F4V M2V
 .             0904 X561000-0    Ba Lo Ni           005 --     K9V 
-.             1404 X889000-0    Ba Lo Ni           012 --     F5V M5D 
-.             1804 X000000-0    As Ba Lo Ni        001 --     F6D 
+.             1404 X889000-0    Ba Lo Ni           012 --     F5V M5V
+.             1804 X000000-0    As Ba Lo Ni        001 --     F6V
 .             2304 X548000-0    Ba Lo Ni           004 --     G6V M7V 
-.             2404 X642000-0    Ba Lo Ni Po        022 --     F7V M5D 
-.             2704 X430000-0    Ba De Lo Ni Po     006 --     M0V M0D 
+.             2404 X642000-0    Ba Lo Ni Po        022 --     F7V M5V
+.             2704 X430000-0    Ba De Lo Ni Po     006 --     M0V M0V
 .             2804 X98A000-0    Ba Lo Ni Wa        004 --     F5V 
-.             2904 X87A000-0    Ba Lo Ni Wa        000 --     F2V M8D 
+.             2904 X87A000-0    Ba Lo Ni Wa        000 --     F2V M8V
 .             3204 X688000-0    Ba Lo Ni           004 --     G3V 
 .             0405 X574000-0    Ba Lo Ni           005 --     F2V 
-.             0805 X528000-0    Ba Lo Ni           003 --     G6IV M2D 
+.             0805 X528000-0    Ba Lo Ni           003 --     G6IV M2V
 .             0905 X98A000-0    Ba Lo Ni Wa        004 --     K9V 
 .             1005 X674000-0    Ba Lo Ni           004 --     F0V M5V 
 .             1205 X8D5000-0    Ba Fl Lo Ni        000 --     M3V M7V 
 .             1405 X342000-0    Ba Lo Ni Po        002 --     F9V 
 .             1505 X542000-0    Ba Lo Ni Po        002 --     F8V 
 .             1805 X200000-0    Ba Lo Ni Va        003 --     K5V 
-.             3005 X341000-0    Ba Lo Ni Po        003 --     F9V M0D 
+.             3005 X341000-0    Ba Lo Ni Po        003 --     F9V M0V
 .             3105 X776000-0    Ba Lo Ni           001 --     G8V 
 .             0106 X565000-0    Ba Lo Ni           013 --     F1V 
-.             0306 X324000-0    Ba Lo Ni           016 --     M1V M7D 
-.             0606 X455000-0    Ba Lo Ni           003 --     G6V M6D M0D 
+.             0306 X324000-0    Ba Lo Ni           016 --     M1V M7V
+.             0606 X455000-0    Ba Lo Ni           003 --     G6V M6V M0V
 .             1006 X8B9000-0    Ba Fl Lo Ni        003 --     F9III 
-.             1106 X97A000-0    Ba Lo Ni Wa        001 --     F5V M4D 
+.             1106 X97A000-0    Ba Lo Ni Wa        001 --     F5V M4V
 .             1306 X854000-0    Ba Lo Ni           012 --     M6V 
 .             2406 X674000-0    Ba Lo Ni           024 --     G6V 
 .             2506 X200000-0    Ba Lo Ni Va        012 --     F2V 
-.             0707 X88A000-0    Ba Lo Ni Wa        013 --     F0V M3D 
+.             0707 X88A000-0    Ba Lo Ni Wa        013 --     F0V M3V
 .             0807 X320000-0    Ba De Lo Ni Po     003 --     K0V 
-.             1207 X433000-0    Ba Lo Ni Po        003 --     F1V M5D 
+.             1207 X433000-0    Ba Lo Ni Po        003 --     F1V M5V
 .             1307 X8C6000-0    Ba Fl Lo Ni        012 --     K8III 
 .             1407 X160000-0    Ba De Lo Ni        012 --     G7V 
-.             1507 X757000-0    Ba Lo Ni           035 --     G4V M5D 
+.             1507 X757000-0    Ba Lo Ni           035 --     G4V M5V
 .             1707 X312000-0    Ba Ic Lo Ni        000 --     M0V 
 .             2607 X410000-0    Ba Lo Ni           002 --     A5V 
-.             3007 X681000-0    Ba Lo Ni           025 --     F4V M5D 
+.             3007 X681000-0    Ba Lo Ni           025 --     F4V M5V
 .             3207 X663000-0    Ba Lo Ni           002 --     F1V 
 .             0508 X000000-0    As Ba Lo Ni        003 --     M6V 
 .             0708 X885000-0    Ba Lo Ni           003 --     F1V 
 .             0808 X676000-0    Ba Lo Ni           000 --     M3V 
-.             1008 X100000-0    Ba Lo Ni Va        010 --     G3V M8D 
+.             1008 X100000-0    Ba Lo Ni Va        010 --     G3V M8V
 .             1308 X120000-0    Ba De Lo Ni Po     002 --     M8V 
 .             1508 X686000-0    Ba Lo Ni           000 --     G4V 
 .             1608 X697000-0    Ba Lo Ni           000 --     F1V 
 .             2608 X140000-0    Ba De Lo Ni Po     000 --     M2V 
-.             2808 X643000-0    Ba Lo Ni Po        017 --     F8V M3D 
+.             2808 X643000-0    Ba Lo Ni Po        017 --     F8V M3V
 .             0309 X343000-0    Ba Lo Ni Po        022 --     F3V 
 .             0509 X645000-0    Ba Lo Ni           002 --     M6V 
-.             0609 X437000-0    Ba Lo Ni           003 --     M7V M5D 
-.             0809 X424000-0    Ba Lo Ni           016 --     M4V G3D 
-.             0909 X100000-0    Ba Lo Ni Va        006 --     M2V M5D 
+.             0609 X437000-0    Ba Lo Ni           003 --     M5V M7V
+.             0809 X424000-0    Ba Lo Ni           016 --     G3V M4V
+.             0909 X100000-0    Ba Lo Ni Va        006 --     M2V M5V
 .             1109 X323000-0    Ba Lo Ni Po        022 --     G5V 
 .             1309 X511000-0    Ba Ic Lo Ni        025 --     F6IV M4V 
-.             1409 X78A000-0    Ba Lo Ni Wa        005 --     G7V M5D 
-.             1509 X853000-0    Ba Lo Ni Po        024 --     F7V M4D 
-.             1809 X310000-0    Ba Lo Ni           002 --     M5V M5D 
-.             2109 X561000-0    Ba Lo Ni           016 --     G0V M5D F1V M8D 
+.             1409 X78A000-0    Ba Lo Ni Wa        005 --     G7V M5V
+.             1509 X853000-0    Ba Lo Ni Po        024 --     F7V M4V
+.             1809 X310000-0    Ba Lo Ni           002 --     M5V M5V
+.             2109 X561000-0    Ba Lo Ni           016 --     F1V M5V G0V M8V
 .             2409 X515000-0    Ba Ic Lo Ni        000 --     F7V 
 .             2609 X552000-0    Ba Lo Ni Po        024 --     F4V 
 .             3209 X464000-0    Ba Lo Ni           010 --     F0V 
 .             0110 XA98000-0    Ba Lo Ni           004 --     G7V 
 .             0410 X310000-0    Ba Lo Ni           004 --     K3II M1V 
 .             0510 X557000-0    Ba Lo Ni           034 --     F0V F4V 
-.             0710 X352000-0    Ba Lo Ni Po        010 --     F0V M6D 
+.             0710 X352000-0    Ba Lo Ni Po        010 --     F0V M6V
 .             0810 X252000-0    Ba Lo Ni Po        013 --     F0V 
 .             0910 X6B2000-0    Ba Fl Lo Ni        002 --     K2IV 
 .             1010 X303000-0    Ba Ic Lo Ni Va     001 --     M5V 
@@ -105,25 +105,25 @@ Rfigh
 .             1210 X574000-0    Ba Lo Ni           010 --     F2V 
 .             1410 X344000-0    Ba Lo Ni           001 --     F0V 
 .             1810 X468000-0    Ba Lo Ni           000 --     F6V 
-.             2310 X998000-0    Ba Lo Ni           012 --     F0V M8D 
+.             2310 X998000-0    Ba Lo Ni           012 --     F0V M8V
 .             3210 X501000-0    Ba Ic Lo Ni Va     004 --     K8V 
 .             0211 X464000-0    Ba Lo Ni           024 --     F0V 
 .             0411 X635000-0    Ba Lo Ni           023 --     M3V 
-.             0711 X8A7000-0    Ba Fl Lo Ni        004 --     M8V M6D 
-.             0911 X97A000-0    Ba Lo Ni Wa        014 --     F0V M6D 
+.             0711 X8A7000-0    Ba Fl Lo Ni        004 --     M6V M8V
+.             0911 X97A000-0    Ba Lo Ni Wa        014 --     F0V M6V
 .             1711 X435000-0    Ba Lo Ni           001 --     F8V 
 .             3011 X352000-0    Ba Lo Ni Po        000 --     K0V 
-.             3211 X226000-0    Ba Lo Ni           003 --     M0V M6D 
-.             0312 X97A000-0    Ba Lo Ni Wa        006 --     F4V M2D 
+.             3211 X226000-0    Ba Lo Ni           003 --     M0V M6V
+.             0312 X97A000-0    Ba Lo Ni Wa        006 --     F4V M2V
 .             0712 X460000-0    Ba De Lo Ni        001 --     G0V 
 .             0912 X210000-0    Ba Lo Ni           014 --     M5III K8V 
-.             1112 X764000-0    Ba Lo Ni           023 --     F9V M6D 
+.             1112 X764000-0    Ba Lo Ni           023 --     F9V M6V
 .             1312 X265000-0    Ba Lo Ni           003 --     F4V 
 .             1712 X000000-0    As Ba Lo Ni        000 --     M2V 
 .             1912 X410000-0    Ba Lo Ni           000 --     A3IV 
 .             2112 X365000-0    Ba Lo Ni           003 --     F0V 
 .             2712 X678000-0    Ba Lo Ni           000 --     F2V 
-.             3112 X785000-0    Ba Lo Ni           018 --     G0V M5D 
+.             3112 X785000-0    Ba Lo Ni           018 --     G0V M5V
 .             0113 XAD5000-0    Ba Fl Lo Ni        000 --     M7V 
 .             0213 X582000-0    Ba Lo Ni           013 --     K5V 
 .             0713 X140000-0    Ba De Lo Ni Po     022 --     F6V 
@@ -134,58 +134,58 @@ Rfigh
 .             1813 X698000-0    Ba Lo Ni           002 --     F4V 
 .             2013 X434000-0    Ba Lo Ni           003 --     M8V 
 .             2213 X312000-0    Ba Ic Lo Ni        000 --     M5III 
-.             2313 X270000-0    Ba De Lo Ni        016 --     G0V M0D 
-.             2513 X484000-0    Ba Lo Ni           015 --     F5V M5D 
+.             2313 X270000-0    Ba De Lo Ni        016 --     G0V M0V
+.             2513 X484000-0    Ba Lo Ni           015 --     F5V M5V
 .             3013 X543000-0    Ba Lo Ni Po        014 --     K0V 
 .             3213 X140000-0    Ba De Lo Ni Po     003 --     F8V 
-.             0114 X461000-0    Ba Lo Ni           017 --     G9V M0D 
-.             0414 X571000-0    Ba Lo Ni           016 --     G1V M6D F3V 
-.             0614 X8D1000-0    Ba Fl Lo Ni        004 --     M7V M0D 
-.             1114 X310000-0    Ba Lo Ni           008 --     M5V M6D 
-.             1314 X542000-0    Ba Lo Ni Po        004 --     F8V M3D M0D 
-.             1614 X510000-0    Ba Lo Ni           004 --     K9V M5D 
-.             1914 X698000-0    Ba Lo Ni           037 --     F3V M6D M7D 
+.             0114 X461000-0    Ba Lo Ni           017 --     G9V M0V
+.             0414 X571000-0    Ba Lo Ni           016 --     F3V M6V G1V
+.             0614 X8D1000-0    Ba Fl Lo Ni        004 --     M7V M0V
+.             1114 X310000-0    Ba Lo Ni           008 --     M5V M6V
+.             1314 X542000-0    Ba Lo Ni Po        004 --     F8V M3V M0V
+.             1614 X510000-0    Ba Lo Ni           004 --     K9V M5V
+.             1914 X698000-0    Ba Lo Ni           037 --     F3V M6V M7V
 .             2114 X343000-0    Ba Lo Ni Po        002 --     F7V 
-.             2314 X210000-0    Ba Lo Ni           013 --     M3V M2V 
-.             2414 X845000-0    Ba Lo Ni           001 --     G1V M2D 
+.             2314 X210000-0    Ba Lo Ni           013 --     M2V M3V
+.             2414 X845000-0    Ba Lo Ni           001 --     G1V M2V
 .             3214 X478000-0    Ba Lo Ni           013 --     F5V 
-.             0115 X658000-0    Ba Lo Ni           014 --     F6V M3D 
+.             0115 X658000-0    Ba Lo Ni           014 --     F6V M3V
 .             0815 X310000-0    Ba Lo Ni           013 --     F1V 
 .             1015 X200000-0    Ba Lo Ni Va        012 --     M1V 
-.             1315 X364000-0    Ba Lo Ni           013 --     G8V M7D 
+.             1315 X364000-0    Ba Lo Ni           013 --     G8V M7V
 .             1415 X898000-0    Ba Lo Ni           004 --     F9V 
-.             1515 X99A000-0    Ba Lo Ni Wa        004 --     G0V M3D 
+.             1515 X99A000-0    Ba Lo Ni Wa        004 --     G0V M3V
 .             1815 X875000-0    Ba Lo Ni           013 --     F6V 
 .             2015 X300000-0    Ba Lo Ni Va        012 --     F9V 
-.             2715 X8A9000-0    Ba Fl Lo Ni        023 --     M6V M4D 
-.             3015 X669000-0    Ba Lo Ni           001 --     F3V M6D 
+.             2715 X8A9000-0    Ba Fl Lo Ni        023 --     M4V M6V
+.             3015 X669000-0    Ba Lo Ni           001 --     F3V M6V
 .             3115 X200000-0    Ba Lo Ni Va        023 --     M3V 
-.             3215 X210000-0    Ba Lo Ni           002 --     M0III K6D 
+.             3215 X210000-0    Ba Lo Ni           002 --     M0III K6V
 .             0316 X510000-0    Ba Lo Ni           003 --     M4III M5V 
-.             0816 X384000-0    Ba Lo Ni           000 --     G3V M5D 
-.             1116 X400000-0    Ba Lo Ni Va        004 --     G2V M7D 
-.             1316 X967000-0    Ba Lo Ni           015 --     G7V M8D 
-.             1416 X895000-0    Ba Lo Ni           027 --     G0V M3D M7D 
+.             0816 X384000-0    Ba Lo Ni           000 --     G3V M5V
+.             1116 X400000-0    Ba Lo Ni Va        004 --     G2V M7V
+.             1316 X967000-0    Ba Lo Ni           015 --     G7V M8V
+.             1416 X895000-0    Ba Lo Ni           027 --     G0V M3V M7V
 .             1516 X455000-0    Ba Lo Ni           012 --     F6V 
-.             1616 X638000-0    Ba Lo Ni           004 --     M7V G9V M2D 
+.             1616 X638000-0    Ba Lo Ni           004 --     G9V M7V M2V
 .             1716 X683000-0    Ba Lo Ni           046 --     F3V F4V 
 .             1916 X220000-0    Ba De Lo Ni Po     010 --     F3V 
 .             2016 X63A000-0    Ba Lo Ni Wa        003 --     M4V 
 .             2116 X7C2000-0    Ba Fl Lo Ni        010 --     G7V 
-.             2316 X88A000-0    Ba Lo Ni Wa        002 --     G1V M3D 
+.             2316 X88A000-0    Ba Lo Ni Wa        002 --     G1V M3V
 .             2416 X868000-0    Ba Lo Ni           015 --     G9V 
-.             2616 X467000-0    Ba Lo Ni           003 --     F9V M8D 
+.             2616 X467000-0    Ba Lo Ni           003 --     F9V M8V
 .             2716 X564000-0    Ba Lo Ni           012 --     F5V 
-.             2916 X360000-0    Ba De Lo Ni        004 --     F7V M5D 
-.             3016 X682000-0    Ba Lo Ni           005 --     F3V M7D 
+.             2916 X360000-0    Ba De Lo Ni        004 --     F7V M5V
+.             3016 X682000-0    Ba Lo Ni           005 --     F3V M7V
 .             3116 X668000-0    Ba Lo Ni           003 --     F9V 
 .             0317 X425000-0    Ba Lo Ni           017 --     M5V M5V 
 .             0517 X200000-0    Ba Lo Ni Va        000 --     F2V 
 .             0617 X597000-0    Ba Lo Ni           001 --     F5V 
 .             0717 X846000-0    Ba Lo Ni           004 --     G0V 
-.             1017 X957000-0    Ba Lo Ni           004 --     M6V F5V M4D 
+.             1017 X957000-0    Ba Lo Ni           004 --     F5V M6V M4V
 .             1117 X653000-0    Ba Lo Ni Po        004 --     K1V 
-.             1817 X696000-0    Ba Lo Ni           017 --     G0V M1D 
+.             1817 X696000-0    Ba Lo Ni           017 --     G0V M1V
 .             2117 X775000-0    Ba Lo Ni           012 --     M0V 
 .             2317 X999000-0    Ba Lo Ni           002 --     G8V 
 .             2517 X472000-0    Ba Lo Ni           001 --     K5V 
@@ -194,136 +194,136 @@ Rfigh
 .             3217 X110000-0    Ba Lo Ni           002 --     F2IV 
 .             0518 X000000-0    As Ba Lo Ni        000 --     K6V 
 .             0618 X758000-0    Ba Lo Ni           013 --     F8V 
-.             0718 X9B3000-0    Ba Fl Lo Ni        005 --     M0V M8D 
+.             0718 X9B3000-0    Ba Fl Lo Ni        005 --     M0V M8V
 .             0918 XA88000-0    Ba Lo Ni           004 --     F2V 
 .             1318 X210000-0    Ba Lo Ni           000 --     M1III 
 .             1418 XAA3000-0    Ba Fl Lo Ni        002 --     M3V 
 .             1518 X510000-0    Ba Lo Ni           012 --     K0V 
 .             1618 X864000-0    Ba Lo Ni           013 --     F2V 
 .             1818 X000000-0    As Ba Lo Ni        023 --     F0V 
-.             2118 X300000-0    Ba Lo Ni Va        002 --     G1V M3D 
-.             2218 X659000-0    Ba Lo Ni           026 --     F7V M0D 
+.             2118 X300000-0    Ba Lo Ni Va        002 --     G1V M3V
+.             2218 X659000-0    Ba Lo Ni           026 --     F7V M0V
 .             2618 X200000-0    Ba Lo Ni Va        002 --     M4V 
-.             2918 X7A2000-0    Ba Fl Lo Ni        004 --     M1V M7D 
+.             2918 X7A2000-0    Ba Fl Lo Ni        004 --     M1V M7V
 .             0919 X334000-0    Ba Lo Ni           002 --     M7V 
 .             1819 X664000-0    Ba Lo Ni           024 --     F3V 
 .             2119 X629000-0    Ba Lo Ni           014 --     K7V 
 .             2219 X453000-0    Ba Lo Ni Po        004 --     F1V 
 .             2419 X766000-0    Ba Lo Ni           014 --     F1V 
-.             2519 X455000-0    Ba Lo Ni           013 --     F1V M8D 
+.             2519 X455000-0    Ba Lo Ni           013 --     F1V M8V
 .             2619 X210000-0    Ba Lo Ni           003 --     M2V 
-.             0120 X799000-0    Ba Lo Ni           012 --     F0V M8D 
-.             0520 X83A000-0    Ba Lo Ni Wa        005 --     M6V M1D 
-.             0620 X634000-0    Ba Lo Ni           001 --     K6V M8D 
-.             0720 X361000-0    Ba Lo Ni           024 --     F6V M8D 
+.             0120 X799000-0    Ba Lo Ni           012 --     F0V M8V
+.             0520 X83A000-0    Ba Lo Ni Wa        005 --     M1V M6V
+.             0620 X634000-0    Ba Lo Ni           001 --     K6V M8V
+.             0720 X361000-0    Ba Lo Ni           024 --     F6V M8V
 .             1120 X682000-0    Ba Lo Ni           013 --     F1V 
 .             1320 X436000-0    Ba Lo Ni           000 --     M1III 
-.             1420 X000000-0    As Ba Lo Ni        001 --     M4V M1D 
+.             1420 X000000-0    As Ba Lo Ni        001 --     M1V M4V
 .             1520 X541000-0    Ba Lo Ni Po        000 --     F3V 
-.             1620 X000000-0    As Ba Lo Ni        016 --     K9V M2D 
-.             1720 X662000-0    Ba Lo Ni           012 --     F1V M2D 
-.             1920 X362000-0    Ba Lo Ni           015 --     F5V M8D 
-.             2020 X699000-0    Ba Lo Ni           002 --     F8V M8D 
+.             1620 X000000-0    As Ba Lo Ni        016 --     K9V M2V
+.             1720 X662000-0    Ba Lo Ni           012 --     F1V M2V
+.             1920 X362000-0    Ba Lo Ni           015 --     F5V M8V
+.             2020 X699000-0    Ba Lo Ni           002 --     F8V M8V
 .             2220 X200000-0    Ba Lo Ni Va        014 --     M7V 
-.             2320 X300000-0    Ba Lo Ni Va        003 --     M5V M8D 
-.             2520 X442000-0    Ba Lo Ni Po        026 --     G2V M5D 
+.             2320 X300000-0    Ba Lo Ni Va        003 --     M5V M8V
+.             2520 X442000-0    Ba Lo Ni Po        026 --     G2V M5V
 .             3120 X000000-0    As Ba Lo Ni        004 --     K8V M1V 
 .             0421 X431000-0    Ba Lo Ni Po        004 --     M7V 
-.             0921 X454000-0    Ba Lo Ni           014 --     F2V M3D 
+.             0921 X454000-0    Ba Lo Ni           014 --     F2V M3V
 .             1121 X8B0000-0    Ba De Lo Ni        001 --     M2V 
 .             1421 X110000-0    Ba Lo Ni           002 --     M7V 
-.             1621 X341000-0    Ba Lo Ni Po        016 --     M0V M3D 
+.             1621 X341000-0    Ba Lo Ni Po        016 --     M0V M3V
 .             1721 X454000-0    Ba Lo Ni           004 --     K9V 
-.             1821 X754000-0    Ba Lo Ni           012 --     K5V M5D 
-.             2521 X573000-0    Ba Lo Ni           014 --     F0V M2D 
+.             1821 X754000-0    Ba Lo Ni           012 --     K5V M5V
+.             2521 X573000-0    Ba Lo Ni           014 --     F0V M2V
 .             2721 X553000-0    Ba Lo Ni Po        001 --     K7V 
-.             2821 X6B5000-0    Ba Fl Lo Ni        008 --     M8V M3D 
+.             2821 X6B5000-0    Ba Fl Lo Ni        008 --     M3V M8V
 .             3021 X100000-0    Ba Lo Ni Va        020 --     M0V M0V 
-.             0122 X324000-0    Ba Lo Ni           027 --     K5V M7D M3D 
-.             0222 X614000-0    Ba Ic Lo Ni        01B --     M7V M7D M0D 
+.             0122 X324000-0    Ba Lo Ni           027 --     K5V M7V M3V
+.             0222 X614000-0    Ba Ic Lo Ni        01B --     M0V M7V M7V
 .             0622 X9A6000-0    Ba Fl Lo Ni        003 --     M1V 
 .             1122 X8C5000-0    Ba Fl Lo Ni        003 --     F7IV M1V 
 .             1322 X876000-0    Ba Lo Ni           011 --     F9V 
 .             1622 X335000-0    Ba Lo Ni           004 --     F7V 
 .             1922 X233000-0    Ba Lo Ni Po        004 --     F5V 
-.             2222 X575000-0    Ba Lo Ni           025 --     F9V M1D 
+.             2222 X575000-0    Ba Lo Ni           025 --     F9V M1V
 .             2422 X347000-0    Ba Lo Ni           004 --     G7V 
-.             2622 X768000-0    Ba Lo Ni           015 --     M7V M7D 
+.             2622 X768000-0    Ba Lo Ni           015 --     M7V M7V
 .             3222 X350000-0    Ba De Lo Ni Po     012 --     F7V 
 .             0723 X358000-0    Ba Lo Ni           012 --     F8V 
-.             1423 X150000-0    Ba De Lo Ni Po     003 --     F6V M5D 
+.             1423 X150000-0    Ba De Lo Ni Po     003 --     F6V M5V
 .             1523 X110000-0    Ba Lo Ni           013 --     G9IV G6V 
 .             1623 X849000-0    Ba Lo Ni           002 --     F9V 
 .             1923 X527000-0    Ba Lo Ni           010 --     M6III K8V 
-.             2323 X699000-0    Ba Lo Ni           006 --     F7V M6D 
+.             2323 X699000-0    Ba Lo Ni           006 --     F7V M6V
 .             2723 X534000-0    Ba Lo Ni           023 --     M7III M0V 
 .             2823 X000000-0    As Ba Lo Ni        012 --     F5V 
 .             2923 X646000-0    Ba Lo Ni           003 --     F6V 
-.             3123 X495000-0    Ba Lo Ni           024 --     F2V M4D 
+.             3123 X495000-0    Ba Lo Ni           024 --     F2V M4V
 .             0524 X687000-0    Ba Lo Ni           003 --     F5V 
-.             0924 X888000-0    Ba Lo Ni           022 --     G7V M3D 
+.             0924 X888000-0    Ba Lo Ni           022 --     G7V M3V
 .             1424 X7A2000-0    Ba Fl Lo Ni        003 --     M6V 
 .             1524 X368000-0    Ba Lo Ni           022 --     F1V 
-.             1824 X794000-0    Ba Lo Ni           001 --     F4V M6D 
-.             2124 X400000-0    Ba Lo Ni Va        036 --     M5V M6D 
+.             1824 X794000-0    Ba Lo Ni           001 --     F4V M6V
+.             2124 X400000-0    Ba Lo Ni Va        036 --     M5V M6V
 .             2224 X331000-0    Ba Lo Ni Po        000 --     M5V 
 .             2324 X360000-0    Ba De Lo Ni        000 --     F0V 
 .             2524 X9A6000-0    Ba Fl Lo Ni        002 --     M3V 
 .             2824 X342000-0    Ba Lo Ni Po        002 --     F7V 
 .             2924 X435000-0    Ba Lo Ni           012 --     G8V 
 .             3124 X557000-0    Ba Lo Ni           011 --     F9V F9V 
-.             3224 X684000-0    Ba Lo Ni           003 --     K6V M5D 
+.             3224 X684000-0    Ba Lo Ni           003 --     K6V M5V
 .             0725 X366000-0    Ba Lo Ni           000 --     F0V 
-.             1325 X526000-0    Ba Lo Ni           002 --     F6V M5D 
+.             1325 X526000-0    Ba Lo Ni           002 --     F6V M5V
 .             1525 X570000-0    Ba De Lo Ni        012 --     G8V 
 .             2225 X969000-0    Ba Lo Ni           000 --     F4V 
 .             2525 X79A000-0    Ba Lo Ni Wa        000 --     F3V 
 .             2725 X87A000-0    Ba Lo Ni Wa        000 --     G5V 
-.             2825 X412000-0    Ba Ic Lo Ni        013 --     G5V M5D 
-.             2925 X535000-0    Ba Lo Ni           003 --     F6V M4D 
-.             3025 X8A7000-0    Ba Fl Lo Ni        013 --     F7II M8D 
-.             0526 X656000-0    Ba Lo Ni           004 --     M2V M4D 
+.             2825 X412000-0    Ba Ic Lo Ni        013 --     G5V M5V
+.             2925 X535000-0    Ba Lo Ni           003 --     F6V M4V
+.             3025 X8A7000-0    Ba Fl Lo Ni        013 --     F7II M8V
+.             0526 X656000-0    Ba Lo Ni           004 --     M2V M4V
 .             0726 X85A000-0    Ba Lo Ni Wa        005 --     F2V 
 .             1126 X222000-0    Ba Lo Ni Po        004 --     M6V 
-.             1426 X471000-0    Ba Lo Ni           004 --     F6V M2D 
+.             1426 X471000-0    Ba Lo Ni           004 --     F6V M2V
 .             1626 X596000-0    Ba Lo Ni           005 --     G9V 
-.             1726 X663000-0    Ba Lo Ni           026 --     F3V M2D 
+.             1726 X663000-0    Ba Lo Ni           026 --     F3V M2V
 .             1826 X547000-0    Ba Lo Ni           000 --     K1V 
 .             2626 X200000-0    Ba Lo Ni Va        004 --     K8V 
-.             2926 X534000-0    Ba Lo Ni           004 --     M8V M7D 
+.             2926 X534000-0    Ba Lo Ni           004 --     M7V M8V
 .             3126 X120000-0    Ba De Lo Ni Po     012 --     F7V 
 .             3226 X754000-0    Ba Lo Ni           010 --     F7V 
 .             0627 X684000-0    Ba Lo Ni           003 --     F1V 
 .             1027 X593000-0    Ba Lo Ni           002 --     F8V 
 .             1427 X221000-0    Ba Lo Ni Po        000 --     M7V 
-.             1627 X767000-0    Ba Lo Ni           022 --     F6V M7D 
-.             1827 X888000-0    Ba Lo Ni           005 --     K3V M6D 
+.             1627 X767000-0    Ba Lo Ni           022 --     F6V M7V
+.             1827 X888000-0    Ba Lo Ni           005 --     K3V M6V
 .             1927 X656000-0    Ba Lo Ni           021 --     F4V 
 .             2027 X451000-0    Ba Lo Ni Po        010 --     F4V 
-.             2127 X100000-0    Ba Lo Ni Va        001 --     M2V M6D 
+.             2127 X100000-0    Ba Lo Ni Va        001 --     M2V M6V
 .             2227 X235000-0    Ba Lo Ni           012 --     M4II G8V 
-.             2527 X555000-0    Ba Lo Ni           007 --     F8V M0D 
-.             2727 X442000-0    Ba Lo Ni Po        002 --     F8V M4D 
+.             2527 X555000-0    Ba Lo Ni           007 --     F8V M0V
+.             2727 X442000-0    Ba Lo Ni Po        002 --     F8V M4V
 .             3027 X548000-0    Ba Lo Ni           004 --     F0V 
 .             3127 X222000-0    Ba Lo Ni Po        010 --     F3II 
-.             0328 X230000-0    Ba De Lo Ni Po     003 --     M2V M1D 
-.             0628 X210000-0    Ba Lo Ni           015 --     M4V M2D 
-.             0728 X8A3000-0    Ba Fl Lo Ni        006 --     M6V F5V M8D 
-.             0928 X462000-0    Ba Lo Ni           000 --     F0V M2D 
+.             0328 X230000-0    Ba De Lo Ni Po     003 --     M1V M2V
+.             0628 X210000-0    Ba Lo Ni           015 --     M2V M4V
+.             0728 X8A3000-0    Ba Fl Lo Ni        006 --     F5V M6V M8V
+.             0928 X462000-0    Ba Lo Ni           000 --     F0V M2V
 .             1528 X515000-0    Ba Ic Lo Ni        001 --     M6II M1V 
-.             1628 X7B5000-0    Ba Fl Lo Ni        002 --     K2V M5D 
+.             1628 X7B5000-0    Ba Fl Lo Ni        002 --     K2V M5V
 .             1928 X240000-0    Ba De Lo Ni Po     000 --     M0V 
-.             2328 X768000-0    Ba Lo Ni           025 --     G9V M4D 
-.             2428 X562000-0    Ba Lo Ni           026 --     F6V M5D 
-.             3028 X610000-0    Ba Lo Ni           004 --     M0V M7D 
+.             2328 X768000-0    Ba Lo Ni           025 --     G9V M4V
+.             2428 X562000-0    Ba Lo Ni           026 --     F6V M5V
+.             3028 X610000-0    Ba Lo Ni           004 --     M0V M7V
 .             0529 X341000-0    Ba Lo Ni Po        001 --     F8V 
 .             0629 X460000-0    Ba De Lo Ni        001 --     M1V 
 .             0829 X66A000-0    Ba Lo Ni Wa        003 --     F2V 
-.             1129 X241000-0    Ba Lo Ni Po        011 --     F2V M3D 
+.             1129 X241000-0    Ba Lo Ni Po        011 --     F2V M3V
 .             1529 X100000-0    Ba Lo Ni Va        002 --     M4V 
 .             1929 X100000-0    Ba Lo Ni Va        000 --     K6III 
-.             2129 X202000-0    Ba Ic Lo Ni Va     002 --     M2V G0D 
-.             2229 X233000-0    Ba Lo Ni Po        002 --     M6V M2D 
+.             2129 X202000-0    Ba Ic Lo Ni Va     002 --     M2V G0V
+.             2229 X233000-0    Ba Lo Ni Po        002 --     M2V M6V
 .             2429 X633000-0    Ba Lo Ni Po        000 --     M0V 
 .             2729 XAD2000-0    Ba Fl Lo Ni        000 --     K3V 
 .             2829 X658000-0    Ba Lo Ni           004 --     K8V 
@@ -331,91 +331,91 @@ Rfigh
 .             0130 X550000-0    Ba De Lo Ni Po     000 --     F5V 
 .             0530 X8C8000-0    Ba Fl Lo Ni        010 --     F5V 
 .             0630 X360000-0    Ba De Lo Ni        000 --     F1V 
-.             0730 X987000-0    Ba Lo Ni           003 --     F9V M1D 
-.             0930 X886000-0    Ba Lo Ni           002 --     F1V M5D 
-.             1330 X765000-0    Ba Lo Ni           026 --     G8V M2D 
-.             2030 X593000-0    Ba Lo Ni           005 --     F7V M4D 
+.             0730 X987000-0    Ba Lo Ni           003 --     F9V M1V
+.             0930 X886000-0    Ba Lo Ni           002 --     F1V M5V
+.             1330 X765000-0    Ba Lo Ni           026 --     G8V M2V
+.             2030 X593000-0    Ba Lo Ni           005 --     F7V M4V
 .             2130 X556000-0    Ba Lo Ni           011 --     F7V 
 .             2430 X410000-0    Ba Lo Ni           000 --     M2V 
 .             0531 X221000-0    Ba Lo Ni Po        003 --     M0V 
-.             0831 X423000-0    Ba Lo Ni Po        000 --     M0V M4D 
+.             0831 X423000-0    Ba Lo Ni Po        000 --     M0V M4V
 .             0931 X9B5000-0    Ba Fl Lo Ni        001 --     K1V 
 .             1131 X767000-0    Ba Lo Ni           000 --     F7V 
 .             1231 X400000-0    Ba Lo Ni Va        010 --     F0IV 
-.             1431 X678000-0    Ba Lo Ni           023 --     F1V M4D 
-.             1831 X400000-0    Ba Lo Ni Va        004 --     M2V M8D 
+.             1431 X678000-0    Ba Lo Ni           023 --     F1V M4V
+.             1831 X400000-0    Ba Lo Ni Va        004 --     M2V M8V
 .             2031 X468000-0    Ba Lo Ni           003 --     F8V 
-.             2331 X100000-0    Ba Lo Ni Va        002 --     A0V M8D 
+.             2331 X100000-0    Ba Lo Ni Va        002 --     A0V M8V
 .             2431 X310000-0    Ba Lo Ni           023 --     K8V 
 .             2831 X224000-0    Ba Lo Ni           001 --     M4II 
 .             3031 X782000-0    Ba Lo Ni           002 --     F4V 
 .             0132 X000000-0    As Ba Lo Ni        001 --     M0V 
-.             0732 X541000-0    Ba Lo Ni Po        004 --     F8V M6D 
-.             1032 X100000-0    Ba Lo Ni Va        020 --     A6V M3D 
-.             1332 X758000-0    Ba Lo Ni           001 --     F7V M6D 
+.             0732 X541000-0    Ba Lo Ni Po        004 --     F8V M6V
+.             1032 X100000-0    Ba Lo Ni Va        020 --     A6V M3V
+.             1332 X758000-0    Ba Lo Ni           001 --     F7V M6V
 .             1732 X223000-0    Ba Lo Ni Po        004 --     F5V 
 .             1832 X100000-0    Ba Lo Ni Va        001 --     F8V 
 .             2232 X7B4000-0    Ba Fl Lo Ni        011 --     M2V 
-.             2632 X555000-0    Ba Lo Ni           022 --     F0V M5D F2V 
-.             3032 X212000-0    Ba Ic Lo Ni        007 --     M2V M2D 
-.             3132 X570000-0    Ba De Lo Ni        004 --     F1V M1D 
+.             2632 X555000-0    Ba Lo Ni           022 --     F0V M5V F2V
+.             3032 X212000-0    Ba Ic Lo Ni        007 --     M2V M2V
+.             3132 X570000-0    Ba De Lo Ni        004 --     F1V M1V
 .             3232 X200000-0    Ba Lo Ni Va        002 --     M3V 
 .             0233 X9A3000-0    Ba Fl Lo Ni        000 --     A6V 
 .             0333 X000000-0    As Ba Lo Ni        001 --     A7V 
-.             0433 X400000-0    Ba Lo Ni Va        002 --     M3V M4D 
-.             0733 X9E5000-0    Ba Fl Lo Ni        002 --     M7V M4D 
+.             0433 X400000-0    Ba Lo Ni Va        002 --     M3V M4V
+.             0733 X9E5000-0    Ba Fl Lo Ni        002 --     M4V M7V
 .             1333 X343000-0    Ba Lo Ni Po        000 --     F2V 
-.             1733 X778000-0    Ba Lo Ni           000 --     K3V M3D 
+.             1733 X778000-0    Ba Lo Ni           000 --     K3V M3V
 .             1833 X212000-0    Ba Ic Lo Ni        013 --     M0V 
-.             1933 X100000-0    Ba Lo Ni Va        004 --     M7V M3V 
+.             1933 X100000-0    Ba Lo Ni Va        004 --     M3V M7V
 .             2133 X342000-0    Ba Lo Ni Po        001 --     M6V 
 .             2433 X585000-0    Ba Lo Ni           003 --     F9V 
 .             2733 X762000-0    Ba Lo Ni           011 --     K2V 
-.             2833 X786000-0    Ba Lo Ni           004 --     G6V M5D 
+.             2833 X786000-0    Ba Lo Ni           004 --     G6V M5V
 .             3233 X120000-0    Ba De Lo Ni Po     023 --     F1V 
-.             0434 X370000-0    Ba De Lo Ni        024 --     F2V M7D 
+.             0434 X370000-0    Ba De Lo Ni        024 --     F2V M7V
 .             0834 X223000-0    Ba Lo Ni Po        013 --     F1V 
-.             1034 X88A000-0    Ba Lo Ni Wa        002 --     F5V M3D 
-.             1134 X867000-0    Ba Lo Ni           003 --     F2V M3D 
+.             1034 X88A000-0    Ba Lo Ni Wa        002 --     F5V M3V
+.             1134 X867000-0    Ba Lo Ni           003 --     F2V M3V
 .             1234 X573000-0    Ba Lo Ni           022 --     F3V 
-.             1434 X576000-0    Ba Lo Ni           012 --     F2V M8D 
+.             1434 X576000-0    Ba Lo Ni           012 --     F2V M8V
 .             1734 X658000-0    Ba Lo Ni           021 --     F2V 
 .             2034 X569000-0    Ba Lo Ni           004 --     F9V 
 .             2234 X310000-0    Ba Lo Ni           011 --     F4V 
-.             2434 XA9A000-0    Ba Lo Ni Wa        010 --     G8V M8D 
-.             2634 X788000-0    Ba Lo Ni           011 --     F5V M7D 
-.             2834 X747000-0    Ba Lo Ni           025 --     F1V M3D 
+.             2434 XA9A000-0    Ba Lo Ni Wa        010 --     G8V M8V
+.             2634 X788000-0    Ba Lo Ni           011 --     F5V M7V
+.             2834 X747000-0    Ba Lo Ni           025 --     F1V M3V
 .             3034 XAC4000-0    Ba Fl Lo Ni        002 --     M4V 
 .             0735 X310000-0    Ba Lo Ni           010 --     M0V 
 .             0935 X100000-0    Ba Lo Ni Va        003 --     F7V 
 .             1135 X140000-0    Ba De Lo Ni Po     000 --     G7V 
 .             1335 X7A3000-0    Ba Fl Lo Ni        002 --     M2V 
 .             1635 X230000-0    Ba De Lo Ni Po     000 --     M8V 
-.             1835 X8A4000-0    Ba Fl Lo Ni        014 --     M6V M2D 
+.             1835 X8A4000-0    Ba Fl Lo Ni        014 --     M2V M6V
 .             2035 X537000-0    Ba Lo Ni           012 --     M6V 
-.             2135 X7A5000-0    Ba Fl Lo Ni        020 --     M0V M8D 
-.             2235 X535000-0    Ba Lo Ni           011 --     K3V M0D 
+.             2135 X7A5000-0    Ba Fl Lo Ni        020 --     M0V M8V
+.             2235 X535000-0    Ba Lo Ni           011 --     K3V M0V
 .             2535 X648000-0    Ba Lo Ni           013 --     F1V 
 .             2735 X656000-0    Ba Lo Ni           003 --     F7V 
 .             2835 X463000-0    Ba Lo Ni           004 --     M5V 
 .             0136 X524000-0    Ba Lo Ni           013 --     M8V 
 .             0736 X53A000-0    Ba Lo Ni Wa        004 --     M2III 
-.             0836 X9AA000-0    Ba Fl Lo Ni Wa     004 --     M0V M7D 
-.             1036 X787000-0    Ba Lo Ni           003 --     G6V M1D 
+.             0836 X9AA000-0    Ba Fl Lo Ni Wa     004 --     M0V M7V
+.             1036 X787000-0    Ba Lo Ni           003 --     G6V M1V
 .             1436 X587000-0    Ba Lo Ni           000 --     F8V 
-.             1736 X443000-0    Ba Lo Ni Po        002 --     F8V M2D 
+.             1736 X443000-0    Ba Lo Ni Po        002 --     F8V M2V
 .             1836 X355000-0    Ba Lo Ni           002 --     M1V 
-.             2236 X242000-0    Ba Lo Ni Po        006 --     M8V M8D 
+.             2236 X242000-0    Ba Lo Ni Po        006 --     M8V M8V
 .             2336 X6A2000-0    Ba Fl Lo Ni        010 --     M8V 
 .             2436 X74A000-0    Ba Lo Ni Wa        000 --     F8V 
-.             2636 X635000-0    Ba Lo Ni           004 --     M3V M3D 
+.             2636 X635000-0    Ba Lo Ni           004 --     M3V M3V
 .             2736 X561000-0    Ba Lo Ni           000 --     F8V 
 .             3236 X425000-0    Ba Lo Ni           000 --     M3V 
-.             0837 X563000-0    Ba Lo Ni           012 --     F0V M5D 
+.             0837 X563000-0    Ba Lo Ni           012 --     F0V M5V
 .             1037 X574000-0    Ba Lo Ni           013 --     K8V 
 .             1137 X6B1000-0    Ba Fl Lo Ni        024 --     F3V 
 .             1637 X565000-0    Ba Lo Ni           004 --     F1V 
-.             1737 X534000-0    Ba Lo Ni           000 --     M2V M2D 
+.             1737 X534000-0    Ba Lo Ni           000 --     M2V M2V
 .             2037 X436000-0    Ba Lo Ni           000 --     M6V 
 .             2137 X120000-0    Ba De Lo Ni Po     012 --     G5V 
 .             2337 X869000-0    Ba Lo Ni           000 --     F4V 
@@ -425,32 +425,32 @@ Rfigh
 .             0138 X253000-0    Ba Lo Ni Po        014 --     F5V 
 .             0538 X371000-0    Ba Lo Ni           013 --     F9V 
 .             1638 X788000-0    Ba Lo Ni           001 --     M8V 
-.             1738 X696000-0    Ba Lo Ni           013 --     F8V M8D 
+.             1738 X696000-0    Ba Lo Ni           013 --     F8V M8V
 .             2138 X654000-0    Ba Lo Ni           012 --     G5V 
 .             3138 X77A000-0    Ba Lo Ni Wa        000 --     G3V 
-.             3238 X658000-0    Ba Lo Ni           002 --     F2V M2D 
+.             3238 X658000-0    Ba Lo Ni           002 --     F2V M2V
 .             0139 X201000-0    Ba Ic Lo Ni Va     003 --     G6V M4V 
 .             0239 X733000-0    Ba Lo Ni Po        001 --     M5V 
-.             0439 X432000-0    Ba Lo Ni Po        012 --     F8V M5D 
+.             0439 X432000-0    Ba Lo Ni Po        012 --     F8V M5V
 .             0639 X000000-0    As Ba Lo Ni        023 --     K1V 
 .             1039 X444000-0    Ba Lo Ni           012 --     G8V 
 .             1239 X858000-0    Ba Lo Ni           023 --     F4V 
-.             1339 X564000-0    Ba Lo Ni           006 --     F2V M6D 
+.             1339 X564000-0    Ba Lo Ni           006 --     F2V M6V
 .             1439 X221000-0    Ba Lo Ni Po        013 --     M4V M4V 
 .             1639 X8A7000-0    Ba Fl Lo Ni        002 --     M7V 
-.             1739 X357000-0    Ba Lo Ni           004 --     F3V M2D 
-.             1839 X513000-0    Ba Ic Lo Ni        006 --     M2V M0V 
+.             1739 X357000-0    Ba Lo Ni           004 --     F3V M2V
+.             1839 X513000-0    Ba Ic Lo Ni        006 --     M0V M2V
 .             1939 X472000-0    Ba Lo Ni           003 --     F2V 
 .             2039 X200000-0    Ba Lo Ni Va        021 --     K8V 
 .             2339 X89A000-0    Ba Lo Ni Wa        010 --     F5V 
 .             2839 XAE7000-0    Ba Fl Lo Ni        003 --     K8V 
 .             0240 X371000-0    Ba Lo Ni           004 --     F9V 
-.             0440 X445000-0    Ba Lo Ni           006 --     F9V M7D 
+.             0440 X445000-0    Ba Lo Ni           006 --     F9V M7V
 .             0940 X361000-0    Ba Lo Ni           022 --     F9V 
 .             1040 X150000-0    Ba De Lo Ni Po     013 --     M5V 
 .             1640 X959000-0    Ba Lo Ni           034 --     F4V 
 .             2040 X676000-0    Ba Lo Ni           002 --     M4V 
 .             2140 X984000-0    Ba Lo Ni           003 --     F1V 
-.             2240 XAC6000-0    Ba Fl Lo Ni        007 --     G2V M7D 
-.             2340 X555000-0    Ba Lo Ni           026 --     F7V M0D 
-.             2440 X400000-0    Ba Lo Ni Va        002 --     M8V M1D 
+.             2240 XAC6000-0    Ba Fl Lo Ni        007 --     G2V M7V
+.             2340 X555000-0    Ba Lo Ni           026 --     F7V M0V
+.             2440 X400000-0    Ba Lo Ni Va        002 --     M1V M8V

--- a/res/Sectors/M1105/Rzakki.sec
+++ b/res/Sectors/M1105/Rzakki.sec
@@ -16,224 +16,224 @@ Rzakki
 .             2001 X346000-0    Ba Lo Ni           002 --     F9V 
 .             2201 X371000-0    Ba Lo Ni           014 --     F5V 
 .             0402 X896000-0    Ba Lo Ni           000 --     F1V 
-.             0602 XAE7000-0    Ba Fl Lo Ni        033 --     G0V M5D 
+.             0602 XAE7000-0    Ba Fl Lo Ni        033 --     G0V M5V
 .             1102 X444000-0    Ba Lo Ni           010 --     K8V 
 .             1202 X556000-0    Ba Lo Ni           003 --     M4V 
-.             1402 X545000-0    Ba Lo Ni           001 --     F0V M3D 
+.             1402 X545000-0    Ba Lo Ni           001 --     F0V M3V
 .             1702 X658000-0    Ba Lo Ni           000 --     M6V 
-.             1802 X76A000-0    Ba Lo Ni Wa        004 --     F0V M2D 
+.             1802 X76A000-0    Ba Lo Ni Wa        004 --     F0V M2V
 .             2202 X200000-0    Ba Lo Ni Va        000 --     M0III 
 .             2602 X120000-0    Ba De Lo Ni Po     003 --     G1V 
 .             2702 X300000-0    Ba Lo Ni Va        004 --     G0V 
 .             3102 X201000-0    Ba Ic Lo Ni Va     022 --     M0V 
-.             0703 X534000-0    Ba Lo Ni           000 --     K8V M0V 
+.             0703 X534000-0    Ba Lo Ni           000 --     K8V M0V
 .             0803 X211000-0    Ba Ic Lo Ni        002 --     M1V 
-.             0903 X444000-0    Ba Lo Ni           039 --     G4V M6D 
+.             0903 X444000-0    Ba Lo Ni           039 --     G4V M6V
 .             1003 X596000-0    Ba Lo Ni           001 --     F1V 
 .             1103 X485000-0    Ba Lo Ni           014 --     G2V 
 .             1403 X76A000-0    Ba Lo Ni Wa        002 --     F7V 
 .             1503 X424000-0    Ba Lo Ni           022 --     K6V 
-.             2303 X7C5000-0    Ba Fl Lo Ni        014 --     K4III M8D 
+.             2303 X7C5000-0    Ba Fl Lo Ni        014 --     K4III M8V
 .             1304 X427000-0    Ba Lo Ni           001 --     M5V 
-.             2004 X150000-0    Ba De Lo Ni Po     020 --     F8V M8D 
+.             2004 X150000-0    Ba De Lo Ni Po     020 --     F8V M8V
 .             2104 X332000-0    Ba Lo Ni Po        004 --     F9V 
-.             2204 X429000-0    Ba Lo Ni           003 --     F7V M6D 
-.             3004 X250000-0    Ba De Lo Ni Po     017 --     F5V M0D 
-.             0405 X323000-0    Ba Lo Ni Po        004 --     M6V M3D 
+.             2204 X429000-0    Ba Lo Ni           003 --     F8V M8V
+.             3004 X250000-0    Ba De Lo Ni Po     017 --     F5V M0V
+.             0405 X323000-0    Ba Lo Ni Po        004 --     M3V M6V
 .             0605 X749000-0    Ba Lo Ni           002 --     M7V 
 .             0805 XA7A000-0    Ba Lo Ni Wa        024 --     G4V G7V 
-.             0905 X201000-0    Ba Ic Lo Ni Va     000 --     M3V M1D 
-.             1105 X250000-0    Ba De Lo Ni Po     035 --     F9V M7D 
-.             1305 X578000-0    Ba Lo Ni           004 --     F8V M2D 
+.             0905 X201000-0    Ba Ic Lo Ni Va     000 --     M1V M3V
+.             1105 X250000-0    Ba De Lo Ni Po     035 --     F9V M7V
+.             1305 X578000-0    Ba Lo Ni           004 --     F8V M2V
 .             1505 X69A000-0    Ba Lo Ni Wa        011 --     F4V M1V 
 .             1605 X120000-0    Ba De Lo Ni Po     013 --     M8V 
 .             2205 X243000-0    Ba Lo Ni Po        002 --     F9V 
 .             2805 X578000-0    Ba Lo Ni           003 --     F2V 
 .             3005 X6B1000-0    Ba Fl Lo Ni        012 --     K3V 
 .             0106 X579000-0    Ba Lo Ni           023 --     F0V 
-.             0606 X454000-0    Ba Lo Ni           007 --     F8V M7D 
+.             0606 X454000-0    Ba Lo Ni           007 --     F8V M7V
 .             0906 X586000-0    Ba Lo Ni           004 --     F8V 
 .             1306 X669000-0    Ba Lo Ni           001 --     F4V 
-.             1606 X985000-0    Ba Lo Ni           003 --     G0V M0D 
+.             1606 X985000-0    Ba Lo Ni           003 --     G0V M0V
 .             2006 X877000-0    Ba Lo Ni           000 --     F7V 
 .             2206 X655000-0    Ba Lo Ni           000 --     M4V 
-.             0107 X979000-0    Ba Lo Ni           002 --     F2V M8D 
+.             0107 X979000-0    Ba Lo Ni           002 --     F2V M8V
 .             0807 X310000-0    Ba Lo Ni           002 --     M8V 
 .             1007 X9B2000-0    Ba Fl Lo Ni        000 --     M2V 
-.             1107 X234000-0    Ba Lo Ni           000 --     M0V M1D 
-.             1207 X232000-0    Ba Lo Ni Po        005 --     M6V M2D 
+.             1107 X234000-0    Ba Lo Ni           000 --     M0V M1V
+.             1207 X232000-0    Ba Lo Ni Po        005 --     M2V M6V
 .             1407 X381000-0    Ba Lo Ni           003 --     F3V 
 .             2007 X97A000-0    Ba Lo Ni Wa        005 --     K3V 
-.             2307 X222000-0    Ba Lo Ni Po        021 --     F0V M4D 
+.             2307 X222000-0    Ba Lo Ni Po        021 --     F0V M4V
 .             2407 X352000-0    Ba Lo Ni Po        002 --     F1V 
-.             2607 X575000-0    Ba Lo Ni           005 --     K7V M7D 
-.             0308 X300000-0    Ba Lo Ni Va        017 --     M6V M1V 
-.             0608 X9C6000-0    Ba Fl Lo Ni        000 --     M1V M0D 
-.             0908 X240000-0    Ba De Lo Ni Po     003 --     F0V M3D 
+.             2607 X575000-0    Ba Lo Ni           005 --     K7V M7V
+.             0308 X300000-0    Ba Lo Ni Va        017 --     M1V M6V
+.             0608 X9C6000-0    Ba Fl Lo Ni        000 --     M0V M1V
+.             0908 X240000-0    Ba De Lo Ni Po     003 --     F0V M3V
 .             1008 XA77000-0    Ba Lo Ni           011 --     F9V 
 .             1208 X55A000-0    Ba Lo Ni Wa        003 --     F6V 
-.             1508 X301000-0    Ba Ic Lo Ni Va     003 --     M2D M0D 
+.             1508 X301000-0    Ba Ic Lo Ni Va     003 --     M0V M2V
 .             1608 X200000-0    Ba Lo Ni Va        021 --     K7V 
-.             1808 X512000-0    Ba Ic Lo Ni        014 --     K5V M3D 
-.             1908 X454000-0    Ba Lo Ni           013 --     F4V M6D M5D 
+.             1808 X512000-0    Ba Ic Lo Ni        014 --     K5V M3V
+.             1908 X454000-0    Ba Lo Ni           013 --     K5V M3V
 .             2408 X332000-0    Ba Lo Ni Po        004 --     M0V 
 .             2908 X564000-0    Ba Lo Ni           021 --     F4V 
-.             0709 X536000-0    Ba Lo Ni           033 --     M2V M6D 
-.             0809 X684000-0    Ba Lo Ni           015 --     F8V M4D 
+.             0709 X536000-0    Ba Lo Ni           033 --     M2V M6V
+.             0809 X684000-0    Ba Lo Ni           015 --     F8V M4V
 .             1009 XAC6000-0    Ba Fl Lo Ni        003 --     M8V 
-.             1609 X636000-0    Ba Lo Ni           004 --     M1V M4D 
-.             2109 X9B5000-0    Ba Fl Lo Ni        000 --     M8V M0D 
+.             1609 X636000-0    Ba Lo Ni           004 --     M1V M4V
+.             2109 X9B5000-0    Ba Fl Lo Ni        000 --     M0V M8V
 .             2509 X797000-0    Ba Lo Ni           002 --     F8V 
 .             0110 X445000-0    Ba Lo Ni           004 --     F6V 
-.             0410 X434000-0    Ba Lo Ni           006 --     K8V M1D 
-.             0510 X87A000-0    Ba Lo Ni Wa        020 --     K8V M3D 
+.             0410 X434000-0    Ba Lo Ni           006 --     K8V M1V
+.             0510 X87A000-0    Ba Lo Ni Wa        020 --     K8V M3V
 .             1310 X757000-0    Ba Lo Ni           004 --     K8V 
 .             1510 X404000-0    Ba Ic Lo Ni Va     002 --     M1II 
 .             1810 X582000-0    Ba Lo Ni           001 --     F6V 
 .             2010 X515000-0    Ba Ic Lo Ni        011 --     M2V 
 .             2110 X9B2000-0    Ba Fl Lo Ni        000 --     M7V 
 .             2210 X537000-0    Ba Lo Ni           001 --     M4V 
-.             2510 X579000-0    Ba Lo Ni           007 --     M8V M3D 
-.             0211 X644000-0    Ba Lo Ni           004 --     F9V M0D 
+.             2510 X579000-0    Ba Lo Ni           007 --     M3V M8V
+.             0211 X644000-0    Ba Lo Ni           004 --     F9V M0V
 .             0411 X647000-0    Ba Lo Ni           000 --     K1V 
 .             0911 X412000-0    Ba Ic Lo Ni        002 --     M6V 
 .             1211 X887000-0    Ba Lo Ni           003 --     F7V 
 .             1811 X457000-0    Ba Lo Ni           023 --     F8V 
 .             1911 XAF3000-0    Ba Fl Lo Ni        010 --     M4V 
-.             2111 X6B1000-0    Ba Fl Lo Ni        026 --     K3V M1D 
+.             2111 X6B1000-0    Ba Fl Lo Ni        026 --     K3V M1V
 .             3111 X000000-0    As Ba Lo Ni        020 --     M0V 
 .             0312 X301000-0    Ba Ic Lo Ni Va     024 --     G1III 
 .             1112 X361000-0    Ba Lo Ni           000 --     F6V 
 .             2612 X301000-0    Ba Ic Lo Ni Va     000 --     K8V 
-.             0213 X343000-0    Ba Lo Ni Po        002 --     F8V M8D 
+.             0213 X343000-0    Ba Lo Ni Po        002 --     F8V M8V
 .             0613 X78A000-0    Ba Lo Ni Wa        006 --     M0V M0V 
 .             1113 X527000-0    Ba Lo Ni           002 --     M4V 
 .             1213 X110000-0    Ba Lo Ni           003 --     F1V 
-.             1313 X89A000-0    Ba Lo Ni Wa        002 --     F3V M2D 
+.             1313 X89A000-0    Ba Lo Ni Wa        002 --     F3V M2V
 .             1613 X785000-0    Ba Lo Ni           003 --     F7V 
-.             1913 X446000-0    Ba Lo Ni           016 --     F1V M2D 
+.             1913 X446000-0    Ba Lo Ni           016 --     F1V M2V
 .             2113 X9E7000-0    Ba Fl Lo Ni        000 --     M7V 
 .             3013 X8D6000-0    Ba Fl Lo Ni        002 --     M4V 
 .             0214 X200000-0    Ba Lo Ni Va        001 --     K1V 
-.             0614 X446000-0    Ba Lo Ni           002 --     G2V M1D 
+.             0614 X446000-0    Ba Lo Ni           002 --     G2V M1V
 .             0914 X557000-0    Ba Lo Ni           013 --     G1V 
 .             1014 X403000-0    Ba Ic Lo Ni Va     016 --     M1V M6V 
-.             1514 X666000-0    Ba Lo Ni           013 --     F7V M6D 
+.             1514 X666000-0    Ba Lo Ni           013 --     F7V M6V
 .             2114 XAE6000-0    Ba Fl Lo Ni        010 --     M6V 
 .             2214 X432000-0    Ba Lo Ni Po        014 --     F6III 
 .             2314 X539000-0    Ba Lo Ni           000 --     M3V 
 .             2414 X350000-0    Ba De Lo Ni Po     014 --     G4V 
 .             3214 X583000-0    Ba Lo Ni           002 --     F2V 
-.             0315 X432000-0    Ba Lo Ni Po        020 --     F4V M8D 
-.             0815 X310000-0    Ba Lo Ni           007 --     M5V M6D 
+.             0315 X432000-0    Ba Lo Ni Po        020 --     F4V M8V
+.             0815 X310000-0    Ba Lo Ni           007 --     M5V M6V
 .             1315 X583000-0    Ba Lo Ni           000 --     K7V 
 .             1415 X334000-0    Ba Lo Ni           000 --     M0V 
-.             1815 X473000-0    Ba Lo Ni           013 --     M1V M1D 
+.             1815 X473000-0    Ba Lo Ni           013 --     M1V M1V
 .             2015 X574000-0    Ba Lo Ni           000 --     M5V 
-.             2115 X351000-0    Ba Lo Ni Po        002 --     F6V M2D 
-.             2315 X64A000-0    Ba Lo Ni Wa        000 --     F4V M5D 
+.             2115 X351000-0    Ba Lo Ni Po        002 --     K3V M1V
+.             2315 X64A000-0    Ba Lo Ni Wa        000 --     F4V M5V
 .             2415 X99A000-0    Ba Lo Ni Wa        002 --     F9V 
 .             0316 X200000-0    Ba Lo Ni Va        004 --     G5V 
-.             0416 X681000-0    Ba Lo Ni           006 --     M3V M5D 
+.             0416 X681000-0    Ba Lo Ni           006 --     M3V M5V
 .             1216 X686000-0    Ba Lo Ni           034 --     M3V 
 .             1416 X65A000-0    Ba Lo Ni Wa        014 --     M5V 
 .             1516 X421000-0    Ba Lo Ni Po        023 --     M8V 
-.             1616 X200000-0    Ba Lo Ni Va        036 --     F3V M5D F8V M8D 
-.             1816 X424000-0    Ba Lo Ni           004 --     K2V M5D 
-.             1916 X354000-0    Ba Lo Ni           005 --     F3V M7D 
-.             2216 X000000-0    As Ba Lo Ni        001 --     M0V M1D 
+.             1616 X200000-0    Ba Lo Ni Va        036 --     F3V M5V F8V M8V
+.             1816 X424000-0    Ba Lo Ni           004 --     K2V M5V
+.             1916 X354000-0    Ba Lo Ni           005 --     F3V M7V
+.             2216 X000000-0    As Ba Lo Ni        001 --     M0V M1V
 .             2416 X8B4000-0    Ba Fl Lo Ni        006 --     K2V M3V 
 .             2616 XAA4000-0    Ba Fl Lo Ni        033 --     G7V 
-.             3016 X110000-0    Ba Lo Ni           000 --     F9V M5D 
-.             0717 X243000-0    Ba Lo Ni Po        006 --     F3V M5D M3V M8D 
-.             0917 X796000-0    Ba Lo Ni           024 --     F8V M0D 
-.             1017 X410000-0    Ba Lo Ni           013 --     M3V M8D 
+.             3016 X110000-0    Ba Lo Ni           000 --     F9V M5V
+.             0717 X243000-0    Ba Lo Ni Po        006 --     F3V M5V M3V M8V
+.             0917 X796000-0    Ba Lo Ni           024 --     F8V M0V
+.             1017 X410000-0    Ba Lo Ni           013 --     M3V M8V
 .             1217 X767000-0    Ba Lo Ni           003 --     F8V 
 .             1617 X233000-0    Ba Lo Ni Po        014 --     G6III 
 .             2417 X895000-0    Ba Lo Ni           004 --     F5V 
-.             3217 X7A1000-0    Ba Fl Lo Ni        004 --     M3V M1III 
-.             0618 X65A000-0    Ba Lo Ni Wa        002 --     F4V M6D 
+.             3217 X7A1000-0    Ba Fl Lo Ni        004 --     M1III M3V
+.             0618 X65A000-0    Ba Lo Ni Wa        002 --     F4V M6V
 .             1118 XA68000-0    Ba Lo Ni           010 --     M4V 
-.             2418 X524000-0    Ba Lo Ni           000 --     F9V M6D 
+.             2418 X524000-0    Ba Lo Ni           000 --     F9V M6V
 .             2818 X500000-0    Ba Lo Ni Va        014 --     M2V 
 .             3218 X8A6000-0    Ba Fl Lo Ni        000 --     M8V 
-.             0819 X464000-0    Ba Lo Ni           021 --     F7V M7D 
-.             0919 X340000-0    Ba De Lo Ni Po     006 --     F3V M7D 
+.             0819 X464000-0    Ba Lo Ni           021 --     F7V M7V
+.             0919 X340000-0    Ba De Lo Ni Po     006 --     F3V M7V
 .             1119 X628000-0    Ba Lo Ni           004 --     M7V 
-.             1319 X86A000-0    Ba Lo Ni Wa        016 --     F9V M5D 
-Tholats       1819 C2326AA-A    Na Ni Po           501 Va     M7V M7D 
+.             1319 X86A000-0    Ba Lo Ni Wa        016 --     F9V M5V
+Tholats       1819 C2326AA-A    Na Ni Po           501 Va     M7V M7V
 Aengi         1919 C562101-7  C Lo Ni              124 Va     F4V 
 .             2519 X301000-0    Ba Ic Lo Ni Va     004 --     M0V 
-.             2819 X472000-0    Ba Lo Ni           004 --     F1V M5D 
+.             2819 X472000-0    Ba Lo Ni           004 --     F1V M5V
 .             0520 X766000-0    Ba Lo Ni           004 --     F2V 
 .             0620 X9C4000-0    Ba Fl Lo Ni        010 --     K1V 
-.             0720 X72A000-0    Ba Lo Ni Wa        000 --     M6V M1D 
+.             0720 X72A000-0    Ba Lo Ni Wa        000 --     M1V M6V
 .             0820 X66A000-0    Ba Lo Ni Wa        002 --     F3V 
-Notsezdzuok   2420 C733564-9    Ni Po              325 Va     M7V M8D 
+Notsezdzuok   2420 C733564-9    Ni Po              325 Va     M7V M8V
 .             2720 X523000-0    Ba Lo Ni Po        004 --     K8V 
-.             0121 X9C9000-0    Ba Fl Lo Ni        006 --     M2V M2D 
-Raeourrghats  1121 C454443-6    Ni                 823 Va     F6V M7V 
+.             0121 X9C9000-0    Ba Fl Lo Ni        006 --     M2V M2V
+Raeourrghats  1121 C454443-6    Ni                 823 Va     F6V M7V
 Aegzaedhudz   1221 B425761-8  G                    103 Va     M3II G0V 
 Khugaedh      1321 C583643-5    Ag Ni Ri           602 Va     F4V 
-Ueoe          1421 C541400-6    Ni Po              434 Va     F2V M1D 
+Ueoe          1421 C541400-6    Ni Po              434 Va     F2V M1V
 Dukhuegoegho  1521 C569877-4                       500 Va     F6V 
-Uthzekora     1921 B200686-A  G Na Ni Va           500 Va     M2V M5D 
+Uthzekora     1921 B200686-A  G Na Ni Va           500 Va     M2V M5V
 Zourazanin    2021 E230357-3    De Lo Ni Po        910 Va     M6V 
-Golghogllal   2321 E000222-7  C As Lo Ni           303 Va     M3V M0D 
-.             0922 X969000-0    Ba Lo Ni           004 --     F3V M7D 
+Golghogllal   2321 E000222-7  C As Lo Ni           303 Va     M0V M3V
+.             0922 X969000-0    Ba Lo Ni           004 --     F3V M7V
 .             1022 X240000-0    Ba De Lo Ni Po     004 --     F2V 
 Ueaedz        1622 C120A97-B  C De Hi In Na Po     111 Va     F7V 
-.             0123 X524000-0    Ba Lo Ni           028 --     M0V M7D 
+.             0123 X524000-0    Ba Lo Ni           028 --     M0V M7V
 .             0623 X568000-0    Ba Lo Ni           020 --     F4V 
 .             0723 X558000-0    Ba Lo Ni           011 --     F4V 
 Gogaal        1323 B757410-6  G Ni                 514 Va     G1V 
 Oezouk        1423 D84A577-8  C Ni Wa              110 Va     F0V 
 Loengkfodz    1623 C410479-9    Ni                 600 Va     G6V 
 Zoethael      1923 E10078A-6  C Na Va              705 Va     M0V 
-Agadhzurz     2023 B53A79A-7    Wa                 503 Va     G5V M5D 
+Agadhzurz     2023 B53A79A-7    Wa                 503 Va     G5V M5V
 Vozorrgvorr   2523 E84A874-8    Wa                 200 Va     F4V 
 Dokiaiz       2723 C999A77-D  G Hi In              211 Va     F5V 
 Gvoeghoglleg  2923 A100661-B    Na Ni Va           700 Va     M4V 
 Vaekazirrg    1024 D562787-2  G                    513 Va     F5V 
-Sangakh       1224 C674001-2  C Lo Ni              614 Va     F4V M7D 
+Sangakh       1224 C674001-2  C Lo Ni              614 Va     F4V M7V
 .             0125 X87A000-0    Ba Lo Ni Wa        000 --     F3V 
 .             0325 X677000-0    Ba Lo Ni           012 --     F2V 
 .             0525 X562000-0    Ba Lo Ni           000 --     F5V 
-Rrouae        1225 C8C08BA-7  G De                 303 Va     F7V M5D 
-Ifoknughor    1325 B300433-8    Ni Va              605 Va     K7V M6D 
+Rrouae        1225 C8C08BA-7  G De                 303 Va     F7V M5V
+Ifoknughor    1325 B300433-8    Ni Va              605 Va     K7V M6V
 Enksael       1825 C698334-2  G Lo Ni              703 Va     F8V 
 Kutadhviz     2025 C563765-8    Ag Ri              504 Va     M7V 
-Uallaeo       2225 CAD9434-9  G Fl Ni              101 Va     M3V M6D 
-.             0126 X100000-0    Ba Lo Ni Va        005 --     F2IV M2D 
+Uallaeo       2225 CAD9434-9  G Fl Ni              101 Va     M3V M6V
+.             0126 X100000-0    Ba Lo Ni Va        005 --     F2IV M2V
 .             0526 X220000-0    Ba De Lo Ni Po     002 --     F0IV 
-Noengdolrokh  1026 E471544-4  C Ni                 916 Va     F6V M5D 
-Ghaerrgvorr   1726 D558778-1    Ag                 501 Va     F8V M1D 
+Noengdolrokh  1026 E471544-4  C Ni                 916 Va     F6V M5V
+Ghaerrgvorr   1726 D558778-1    Ag                 501 Va     F8V M1V
 Llouzas       1826 C20097B-5  G Hi Na Va           900 Va     F3V 
 Dhagzun       2426 D483400-8    Ni                 313 Va     F3V 
-Llaenazaeng   2926 C364884-5                       401 Va     F6V M2D 
-Oegkhurugvaz  3026 B327443-7  G Ni                 604 Va     M8V M7D 
+Llaenazaeng   2926 C364884-5                       401 Va     F6V M2V
+Oegkhurugvaz  3026 B327443-7  G Ni                 604 Va     M7V M8V
 Llengoerr     3126 C547361-5  G Lo Ni              710 Va     F3V 
-Aegugz        1127 D5A3223-4  G Fl Lo Ni           403 Va     M1V M2D 
+Aegugz        1127 D5A3223-4  G Fl Lo Ni           403 Va     M1V M2V
 Oeko          1727 B685542-A    Ag Ni              713 Va     F4V 
 Oe            2227 C688645-3  G Ag Ni Ri           914 Va     F8V 
 Zonarrgh      2727 C221436-4  G Ni Po              500 Va     G3V 
-Noukugzaegoe  3227 B36256A-A  G Ni                 534 Va     F0V M0D 
+Noukugzaegoe  3227 B36256A-A  G Ni                 534 Va     F0V M0V
 Aetsoul       0628 C453425-6  C Ni Po              802 Va     G4V 
-Llae          1528 C9A7876-6  G Fl                 122 VU     G2V M7D 
+Llae          1528 C9A7876-6  G Fl                 122 VU     G2V M7V
 Kikuegher     2228 C978300-8    Lo Ni              400 Va     M7V 
 Goeloznoz     3028 C210978-9  G Hi Na              114 Va     K5V 
 .             0129 X534000-0    Ba Lo Ni           002 --     M6V 
-Ikhtaez       0529 D9B5438-5  H Fl Ni              500 Va     M0V M6D 
+Ikhtaez       0529 D9B5438-5  H Fl Ni              500 Va     M0V M6V
 Koekllighz    1429 C5A0000-8  C Ba De Lo Ni        800 VU     M1V 
-Khasouts      1629 C410A75-9  G Hi Na              803 VU     F1V M5D 
-Khougnukh     2629 C78579B-2  C Ag Ri              104 Va     F9V M8D 
+Khasouts      1629 C410A75-9  G Hi Na              803 VU     F1V M5V
+Khougnukh     2629 C78579B-2  C Ag Ri              104 Va     F9V M8V
 Ksaegveng     3029 C577344-7    Lo Ni              503 Va     F9V 
-.             0230 X696000-0    Ba Lo Ni           005 --     F8V M1D 
+.             0230 X696000-0    Ba Lo Ni           005 --     F8V M1V
 Dzingae       0930 C845876-4  H                    913 Va     F2V 
-Ghoangkouts   1330 C323431-7    Ni Po              803 VU     M4V M8D 
+Ghoangkouts   1330 C323431-7    Ni Po              803 VU     M4V M8V
 Avukfou       1830 B21047A-D    Ni                 801 Va     A5IV 
 Karruenekh    2230 C84A577-6  C Ni Wa              903 Va     F7V 
-Orrouroerr    2830 E256100-7    Lo Ni              316 Va     F6V M4D 
+Orrouroerr    2830 E256100-7    Lo Ni              316 Va     F6V M4V
 Ouruekoez     3130 EAA78AE-0  C Fl                 714 Va     F9V 
 Voenaenneg    0431 E100343-9  C Lo Ni Va           900 Va     G1V 
 Sookszuekho   0931 C898676-4  G Ag Ni              623 Va     G2V 
@@ -241,39 +241,39 @@ Rokhougsuen   1731 C400646-7    Na Ni Va           413 Va     M7V
 Ighghakhits   2031 C266444-8    Ni                 623 Va     F0V 
 Rukhzurrgh    2631 D77A975-6    Hi In Wa           113 VZ     F7V 
 Thoughivo     3131 C460321-7    De Lo Ni           804 Va     F1V 
-Khodzitsverr  0632 A887575-D    Ag Ni              301 Va     F7V M2D 
+Khodzitsverr  0632 A887575-D    Ag Ni              301 Va     F7V M2V
 Roeksvoks     0832 B322320-9    Lo Ni Po           504 Va     M7II M0V 
-Ozgvilulvagh  1732 D86A154-6  C Lo Ni Wa           923 Va     F8V M0D 
-Dhaeaeng      1832 C666400-A  C Ni                 715 Va     F2V M8D 
+Ozgvilulvagh  1732 D86A154-6  C Lo Ni Wa           923 Va     F8V M0V
+Dhaeaeng      1832 C666400-A  C Ni                 715 Va     F2V M8V
 Kakunoeg      1932 C260210-6  C De Lo Ni           903 Va     M1V 
 Soentsaets    2132 A256426-A  G Ni                 901 Va     F2V 
 Igkizlurz     2332 C85A778-5    Wa                 801 Va     F2V 
 Oerrgsuerrgh  2632 D361799-3    Ri                 800 VZ     G8V 
-Dzuedonuegho  3032 C10057B-8  G Ni Va              302 Va     M1V M7D 
-Kouazu        0633 C56056A-7  C De Ni              901 Va     F3V M1D 
+Dzuedonuegho  3032 C10057B-8  G Ni Va              302 Va     M1V M7V
+Kouazu        0633 C56056A-7  C De Ni              901 Va     F3V M1V
 Rokean        1033 X353772-0  C Ag Po              324 Va     F6V 
 Ongral        1533 C533100-5    Lo Ni Po           103 Va     M7V 
 Zaeuzkhokh    1633 C000221-9    As Lo Ni           601 Va     M4V 
 Foezksar      2333 A66466A-6    Ag Ni Ri           214 Va     F5V 
-Gadae         2633 E586312-3  C Lo Ni              901 VZ     K6V M7D 
+Gadae         2633 E586312-3  C Lo Ni              901 VZ     K6V M7V
 .             0134 X656000-0    Ba Lo Ni           013 --     M3V 
 Voksaerzaerz  1934 C663125-7    Lo Ni              921 Va     F9V 
 Gazanvoerso   0935 D353111-3  C Lo Ni Po           203 Va     F8V 
-Aegksounorz   1235 C9E4765-9    Fl                 603 Va     G2V M6D 
+Aegksounorz   1235 C9E4765-9    Fl                 603 Va     G2V M6V
 Aeghdaz       3235 C353558-4    Ag Ni Po           600 Va     M2V 
-Otoghauen     0436 C8999A7-6  C Hi In              510 Va     F0V M8D 
+Otoghauen     0436 C8999A7-6  C Hi In              510 Va     F0V M8V
 Etsaefadh     0536 C120576-7    De Ni Po           121 Va     K5V 
-Konarung      1136 B451498-8    Ni Po              301 Va     M5V M1D 
+Konarung      1136 B451498-8    Ni Po              301 Va     M1V M5V
 Dhagzarer     2736 D6A5589-2    Fl Ni              100 Va     M7V 
 Roudzgvae     2836 X272402-3  C Ni                 303 Va     F9V 
 Oezkhaerzoz   0937 C2108AF-9    Na                 120 Va     F9V 
-Onun          0238 B5478BB-7  G                    505 Va     F7V M0D 
+Onun          0238 B5478BB-7  G                    505 Va     F7V M0V
 Ikdzuthongka  0438 C673400-8    Ni                 414 Va     F8V 
 Gharagzael    0738 C13085A-8  G De Na Po           500 Va     F8V 
 Sozooeg       0938 C994A79-B  C Hi In              621 Va     F2V 
 Sesogz        1338 C1005A9-B  C Ni Va              502 Va     M1V 
 Ksoarokhaks   2038 C120976-7  C De Hi In Na Po     113 Va     F0V 
 Aekhourkots   0539 C1306AB-9    De Na Ni Po        605 Va     M7V 
-Ngoerrkueng   0740 D777400-8  C Ni                 124 Va     F5V M7D 
-Kurrghorrouk  2140 A678657-7    Ag Ni              402 Va     F1V M4D 
+Ngoerrkueng   0740 D777400-8  C Ni                 124 Va     F5V M7V
+Kurrghorrouk  2140 A678657-7    Ag Ni              402 Va     F1V M4V
 Raghzzegzon   2440 C536000-8    Ba Lo Ni           920 Va     M7V 

--- a/res/Sectors/M1105/VegVergakh.sec
+++ b/res/Sectors/M1105/VegVergakh.sec
@@ -82,7 +82,7 @@ Veg Vergakh
 .             2808 X300000-0    Ba Lo Ni Va        023 --     F8V 
 .             3008 X337000-0    Ba Lo Ni           001 --     M4V 
 .             3108 X312000-0    Ba Ic Lo Ni        004 --     M4V 
-.             0109 X223000-0    Ba Lo Ni Po        002 --     M3V M1V
+.             0109 X223000-0    Ba Lo Ni Po        002 --     M1V M3V
 .             0809 X447000-0    Ba Lo Ni           021 --     F6V 
 .             0909 X796000-0    Ba Lo Ni           010 --     F2V 
 .             1509 X88A000-0    Ba Lo Ni Wa        002 --     M8V 
@@ -205,7 +205,7 @@ Veg Vergakh
 .             2721 X557000-0    Ba Lo Ni           005 --     F1V M8V
 .             0622 X447000-0    Ba Lo Ni           013 --     G7V 
 .             1322 X9A5000-0    Ba Fl Lo Ni        000 --     M8V 
-.             1722 X100000-0    Ba Lo Ni Va        003 --     F4D 
+.             1722 X100000-0    Ba Lo Ni Va        003 --     F4V 
 .             2022 X140000-0    Ba De Lo Ni Po     013 --     G3V 
 .             3122 X637000-0    Ba Lo Ni           013 --     M4V
 .             0323 X85A000-0    Ba Lo Ni Wa        011 --     F1V M5V


### PR DESCRIPTION
@inexorabletash asked me to, when submitting bulk sector-data fixen, break up said fixen PRs into different classes of sectors, so here goes with squaring up the stellar data in Undeveloped Sectors.
I'm not making any deliberate attempt to canonicalise star sizes as per T5.10 Book 3 p 28.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is _swapped_ into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).

On top of the approach taken in #347  , the "Part-fix" commits clear the underbrush by only fixing up main-sequence "dwarfs" appearing at the end of their starline.  If this works out really well, I might just clear the underbrush on _all_ the remaining Undeveloped Sectors in my next PR.

Pipelining the Undeveloped Sectors gives me a chance to catch any stragglers from previous PRs as I go - looks like there's two, maybe three from the previous PR left over.