### PR TITLE
Fix Yiklerzdanzh sector stellar data

### DIFF
--- a/res/Sectors/M1105/yiklerzdanzh.sec
+++ b/res/Sectors/M1105/yiklerzdanzh.sec
@@ -10,25 +10,25 @@ Yiklerzdanzh
 Sabraiatl     0103 C899622-6    Ni                 500 Zh F2V G6V             
 Dliaench Dich 0105 B525523-A  Z Ni                 604 Zh G3V K5V             
 Zhdeeieplf    0106 C303266-B    Ic Ni Lo Va 0206   703 Zh M2V                 
-Zhdliafrplia  0107 C67A100-5    Wa Ni Lo           902 Zh F7V F1IV            
+Zhdliafrplia  0107 C67A100-5    Wa Ni Lo           902 Zh F1IV F7V            
 Dlarezhrbl    0110 C429444-7    Ni Lo              604 Zh M0V                 
-Priatl        0111 X300000-0    Ba Va           F  000 Zh M8V DM              
+Priatl        0111 X300000-0    Ba Va           F  000 Zh M8V D               
 Entbieb       0112 A76399B-D  Z Hi C3              304 Zh K5V                 
-Befta         0113 A452445-D    Ni Po Lo           223 Zh F2V DM              
+Befta         0113 A452445-D    Ni Po Lo           223 Zh F2V D               
 Siantaats     0114 C255304-9    Lo Ni              304 Zh F2V                 
-Iejve         0115 EA967CD-5    Ag                 200 Zh F8V DM              
-Al            0117 B554765-8  Z Ag O:0316          224 Zh F8V DM              
-Enz           0119 C10056E-8  K Ni Va O:0221    A  301 Sr M6V M4V DM          
+Iejve         0115 EA967CD-5    Ag                 200 Zh F8V D               
+Al            0117 B554765-8  Z Ag O:0316          224 Zh F8V D               
+Enz           0119 C10056E-8  K Ni Va O:0221    A  301 Sr M4V M6V D           
 Poison        0127 C8A8663-A    Fl Ni O:0225       414 TL M1V                 
-Exile         0130 E573268-5    Lo Ni Ex Pr 0527A  603 TL M1V DM              
+Exile         0130 E573268-5    Lo Ni Ex Pr 0527A  603 TL M1V D               
 Tavrniaplcha  0134 X445000-0    Ba                 002 Na M7V                 
-Viezhzdi' Shtaf  0137 C3117DD-7  M Ic Na              204 Na F7V DM              
+Viezhzdi' Shtaf  0137 C3117DD-7  M Ic Na              204 Na F7V D               
 Plafrezhdish  0138 D330233-E    De Po Lo Ni        625 Na F9II M5V            
 Klenjzhdont   0139 X592000-0    Ba                 002 Na M7V                 
 Chiadr Tsash  0201 X858000-0    Ba              F  013 Zh M5V                 
 Vachteblash   0206 B54664A-9    Ag Ni              612 Zh M3V                 
 Azh           0211 D4359BA-9    Hi                 112 Zh F7V                 
-Japradlie     0214 C573ACF-D  Z Hi In              323 Zh F4V DM              
+Japradlie     0214 C573ACF-D  Z Hi In              323 Zh F4V D               
 Ielzhola      0217 C6366B9-8    Ni                 323 Zh M3V                 
 Khaar         0221 B5728CE-A  K Cx              R  812 Sr G0V                 
 Pearl         0223 C9A7575-B  T Fl Ni              402 TL M8V                 
@@ -36,59 +36,59 @@ Right Way     0224 D78A241-6    Lo Ni Wa           100 TL K9V
 Quatrain      0225 A373999-C  T Hi In              910 TL F5V                 
 Broken Promise0226 X330000-0    Ba De Po        R  001 TL F8V M7V             
 Longnight     0228 B785340-B    Lo Ni              803 TL M5V                 
-Swarm         0229 B000310-B    As Lo Ni           703 TL F3IV DM             
-Glass Sea     0230 B370421-9    De Ni Lo An        701 TL F4V DM              
+Swarm         0229 B000310-B    As Lo Ni           703 TL F3IV D              
+Glass Sea     0230 B370421-9    De Ni Lo An        701 TL F4V D               
 Quicksilver   0233 X796000-0    Ba              R  010 Na K0V M5V             
-Zdaplaftliavr 0235 X221000-0    Ba Po              002 Na F5V DM              
+Zdaplaftliavr 0235 X221000-0    Ba Po              002 Na F5V D               
 Chablzhdia    0236 E655323-6    Lo Ni              720 Na M2V                 
-Zdalzi        0237 B688975-7    Hi                 903 Na K6V M4V DM DM       
+Zdalzi        0237 B688975-7    Hi                 903 Na K6V M4V D D         
 Dranshiqlbi'  0239 B485744-5    Ag Ri D3           610 Na M9III               
 Blech Netlbr  0302 B655362-6    Lo Ni O:0103       404 Zh F8V                 
-Fliaofraensh  0303 C679542-A    Ni                 615 Zh M2V F6V             
+Fliaofraensh  0303 C679542-A    Ni                 615 Zh F6V M2V             
 Zhaenzha      0305 A648613-B  Z Ag Ni D0           524 Zh M5III               
 Dlidl Razhbi  0309 A889368-9  Z Lo Ni O:0112       504 Zh F9IV                
 Vrier         0314 C7A4000-0    Ba Fl              020 Zh M0V                 
 Zhelzdatl     0316 A413985-E  Z Hi Ic In Na Cp     122 Zh K7V                 
 Yidlpiants    0318 B569566-8    Ni O:0518          501 Zh M9V                 
-Sietiefa      0319 C5245A8-E  Z Ni              F  913 Zh M1V DM              
+Sietiefa      0319 C5245A8-E  Z Ni              F  913 Zh M1V D               
 Yenzhshiavr   0322 E6A056E-8  K De Ni O:0221    A  334 Sr F3V M5V M1V         
 Pieflip       0323 C4305A7-B  T Ni De Po        A  510 TL K1V                 
 Zdemedre      0332 D424414-A    Lo Ni              335 Na G5V                 
 Vrontliedl    0338 X100000-0    Ba Va              003 Na M6V                 
-Denzjdetlizh  0340 X778000-0    Ba                 010 Na F2V DM              
+Denzjdetlizh  0340 X778000-0    Ba                 010 Na F2V D               
 Tsiesh Briafl 0402 X575600-0    Ag Ni Cw        F  200 Zh M2V                 
 Niblaitsrie   0410 XAC3000-0    Ba Fl           F  004 Zh G4V                 
 Sodliezhafr   0411 E477599-6    Ag Ni              900 Zh F9V                 
-Yintla        0414 B341424-B    Ni Po Lo           713 Zh F4V DM              
+Yintla        0414 B341424-B    Ni Po Lo           713 Zh F4V D               
 Anjjedl       0416 C534526-8    Ni                 112 Zh M4V                 
 Bridgeworld   0421 C7B156E-A  K Fl Ni O:0221    A  440 Sr M2V                 
 Fairwater     0423 CA9A845-B    Wa                 204 TL F5V M0V             
 Vivaldi       0424 A624856-A                       714 TL F0V                 
-Pebble        0426 E100300-8    Lo Ni Va        A  533 TL M4V DM              
+Pebble        0426 E100300-8    Lo Ni Va        A  533 TL M4V D               
 Shallowwater  0427 B431440-B    Ni Po Lo           204 TL K2V                 
 Salty Tears   0430 B235983-C  T Hi                 513 TL M9V                 
-Fair Deal     0431 B402771-7    Ic Na Va        R  804 TL G2IV DM             
-Fliblshichtia 0434 B678755-9    Ag                 822 Na K4V DM              
+Fair Deal     0431 B402771-7    Ic Na Va        R  804 TL G2IV D              
+Fliblshichtia 0434 B678755-9    Ag                 822 Na K4V D               
 Bliazheprvlaf 0435 C473233-E    Lo Ni              604 Na F6II M0V            
 Jdakrief      0439 B35666B-B    Ag Ni Pr O:0638    934 Na K9V                 
 Dishtieinshial0502 C65A544-9    Wa Ni              304 Zh K3V                 
-Jeprez        0514 A430689-D    De Ni Po Na        211 Zh M7V DM DM           
+Jeprez        0514 A430689-D    De Ni Po Na        211 Zh M7V D D             
 Driapleble    0515 B585997-8  Z Hi                 411 Zh M2V                 
 Zhdiejtofla   0516 B344656-8    Ag Ni C2           224 Zh K3V                 
-Chtepryinqrenz0517 B582478-9    Ni Lo              400 Zh F3V DM DM           
+Chtepryinqrenz0517 B582478-9    Ni Lo              400 Zh F3V D D             
 Kili          0518 A884344-B  Z Lo Ni              224 Zh F5V                 
 Piaplripref   0520 B87556E-A  K Ag Ni O:0221    A  624 Sr A6V                 
-Jelobrzech    0523 E87856E-8  K Ag Ni O:0221    A  201 Sr M7V DM              
-Fantasia      0524 B98A697-9  T Ni Wa              202 TL F6V DM              
+Jelobrzech    0523 E87856E-8  K Ag Ni O:0221    A  201 Sr M7V D               
+Fantasia      0524 B98A697-9  T Ni Wa              202 TL F6V D               
 Gale          0526 A583AC9-C  T Hi                 400 TL M0V                 
 Talpakuhome   0527 A7989C8-D  T Hi In Cx           202 TL K3V                 
 Chtashekldlanz0534 D452375-9    Lo Ni Po           905 Na M1V                 
 Siezhdaniapl  0536 X6A2000-0    Ba Fl              022 Na M3V                 
-Chiabenshzdol 0538 X320000-0    Ba De Po           002 Na M0V DM              
+Chiabenshzdol 0538 X320000-0    Ba De Po           002 Na M0V D               
 Dliatlirets   0540 X5527A9-0    Po C2              204 Na K0V                 
 Tsishia' Chins0604 A10069D-C  Z Na Ni Va           322 Zh M6V                 
 Chtesaidrdl   0605 D67A457-9    Wa Ni Lo           301 Zh F4V                 
-Diaiebr Vri'  0610 B370642-8  Z De Ni D4           413 Zh M0V DG              
+Diaiebr Vri'  0610 B370642-8  Z De Ni D4           413 Zh M0V D               
 Sotiezhojer   0611 C886300-9    Lo Ni              914 Zh M5V                 
 Adl           0612 CA78635-7    Ag Ni              923 Zh F7V                 
 Zhanj         0615 D444788-9    Ag                 123 Zh F7V                 
@@ -97,76 +97,76 @@ True Omen     0625 A8A4740-9    Fl                 200 TL M9V
 Haven         0626 B692779-9    Ri                 602 TL G2V                 
 Bayou         0627 B677977-C  T Hi In              722 TL G6V                 
 Firestar      0630 C200734-A    Na Va           A  900 TL B1V                 
-Chaos Fallen  0631 A0009A6-C  T As Hi In Na        732 TL F0V DM              
+Chaos Fallen  0631 A0009A6-C  T As Hi In Na        732 TL F0V D               
 Candlelight   0632 C110497-B    Ni Lo              520 TL M9V                 
-Sitiefladr    0638 A2679BB-B  M Hi                 613 Na M2V DM              
+Sitiefladr    0638 A2679BB-B  M Hi                 613 Na M2V D              
 Jansaze'      0640 X642000-0    Ba Po              002 Na M6V                 
 Stielivrtl    0701 A5647A7-9  Z Ag                 524 Zh M1V K3V             
 Poshtozhi'led 0702 E100467-7    Va Ni Lo O:0701 U  511 Zh M1V                 
 Tostaavr      0707 C6697A7-6                       715 Zh M5III G1V           
 Chtench       0708 A85AA45-B  Z Wa Hi Cp           305 Zh K3V M6V             
-Chtej         0711 C566620-7    Ag Ni              624 Zh K2V DM              
-Tle           0715 A5226B9-A    Na Ni Po           925 Zh M8V DM              
+Chtej         0711 C566620-7    Ag Ni              624 Zh K2V D               
+Tle           0715 A5226B9-A    Na Ni Po           925 Zh M8V D               
 Iepr          0716 C74A776-9  Z Wa                 425 Zh F3V                 
-Pezeibifiench 0723 D10066E-8  K Na Ni Va O:0221 A  604 Sr M1V DM              
-Takiwhibl     0725 C5845AB-5    Ag Ni              224 TC G6V DM              
-Tlachefrnin   0730 X666000-0    Ba                 024 Na DK                  
+Pezeibifiench 0723 D10066E-8  K Na Ni Va O:0221 A  604 Sr M1V D               
+Takiwhibl     0725 C5845AB-5    Ag Ni              224 TC G6V D               
+Tlachefrnin   0730 X666000-0    Ba                 024 Na D                   
 Ziedrdazonch  0731 X100000-0    Ba Va              004 Na G4V                 
-Friaprchivzhdo0738 E588600-6    Ag Ni C4        A  803 Na F1V M3V DM          
+Friaprchivzhdo0738 E588600-6    Ag Ni C4        A  803 Na F1V M3V D           
 Pliezh        0802 E588674-5    Ag Ni Ri D7     U  404 Zh M2V                 
 Zdeetsr       0803 C558ABA-8    Hi              U  423 Zh F7V                 
 Sinchsibrifl  0811 A54667A-B    Ag Ni              313 Zh F0V                 
-Zdinchij      0812 B6B0955-B  Z Hi De              901 Zh F9V DM              
+Zdinchij      0812 B6B0955-B  Z Hi De              901 Zh F9V D               
 Pablants      0814 A669530-C  Z Ni                 513 Zh G0V                 
 Iebia         0817 A856A97-F  * Hi                 713 Mi F8V                 
 Tietliejdia   0821 B85A76E-8  K Wa O:0221       A  804 Sr M8V                 
 Twinstar      0826 C463745-B    D3                 332 TL M4V M4V             
-Heaven's Scent 0828 CAD868D-A    Ni Mr              303 TC K5IV DM             
+Heaven's Scent 0828 CAD868D-A    Ni Mr              303 TC K5IV D              
 Jdid Va'      0830 X456000-0    Ba              A  000 Na M0V                 
 Chezh Daznish 0833 B526686-8  M Ni                 322 Na M0V                 
 Didtayinzhial 0834 E9D8564-1    Ni O:0833          713 Na M1V                 
 Zdoblze       0835 X000000-0    Ba As              022 Na M7V                 
-Qriensh Jdazh 0837 C544476-9    Lo Ni              612 Na M4V DM              
+Qriensh Jdazh 0837 C544476-9    Lo Ni              612 Na M4V D               
 Whahwhiv      0839 D79A440-B    Lo Ni Wa           732 TC F5V                 
 Vrjde Biavr   0902 C979523-6    Ni                 504 Zh M4III K4V           
 Dratsinj      0904 B85A414-9    Ni Wa Lo           324 Zh M1III               
 Fishieshnianj 0906 B98A768-7  Z Ri Wa An O:0708    524 Zh F4V M4V             
-Zhreyikr      0908 D203378-7    Ic Lo Ni Va        712 Zh DM                  
-Dlensh Zhdevl 0909 A100787-D    Na Va              813 Zh A2V DM              
+Zhreyikr      0908 D203378-7    Ic Lo Ni Va        712 Zh D                   
+Dlensh Zhdevl 0909 A100787-D    Na Va              813 Zh A2V D               
 Oelvli'       0911 C336579-7    Ni                 322 Zh M9V                 
 Akrnsivr      0913 A432622-9    Na Ni Po           120 Zh M8V                 
 Jdaplbretlkrie'  0914 B784430-9    Ni Lo              102 Zh G8V                 
-Jdefl         0915 C000387-A    As Ni Lo           915 Zh A9III DM            
-Dlebriejlienzh0916 B200777-B  Z Va Na              402 Zh M4V DM              
-Brifliench    0917 A000987-E  * Hi As Na In        622 Mi F4V DM              
+Jdefl         0915 C000387-A    As Ni Lo           915 Zh A9III D             
+Dlebriejlienzh0916 B200777-B  Z Va Na              402 Zh M4V D               
+Brifliench    0917 A000987-E  * Hi As Na In        622 Mi F4V D               
 Pedr          0919 D544134-5    Ni Lo              413 Mi F0V                 
 Steblietetl   0920 B341136-B  * Ni Po Lo           210 Mi K1V                 
 Chtiejtlenz   0921 B000764-8    As Na O:0922    A  911 Mc M9III M3V           
-Stiepldrofr   0922 B000894-A  * As Na              922 Mc M0V DM              
-Afafliia      0924 X583000-0    Ba                 004 Na M2II DM M0V         
+Stiepldrofr   0922 B000894-A  * As Na              922 Mc M0V D               
+Afafliia      0924 X583000-0    Ba                 004 Na M2II D M0V          
 Dlaprshant    0926 X100000-0    Ba Va           R  003 Na M9III               
 Ofrlansfrieepr0927 C621555-8    Ni Po              313 Na A6V                 
 Fordays Fortune 0929 A000987-E    As Na Hi In        114 Na F4III               
-Majdr         0934 C7B6345-7    Fl Lo Ni           804 Na M9V DM              
+Majdr         0934 C7B6345-7    Fl Lo Ni           804 Na M9V D               
 Vledriant     0940 X210000-0    Ba                 023 Na M5V                 
-Pevlaarvlints 1001 E565411-6    Ni Lo              112 Zh G8V K0V DM          
+Pevlaarvlints 1001 E565411-6    Ni Lo              112 Zh G8V K0V D           
 Kechiabrnz    1004 C5868C7-9                       504 Zh M9V                 
-Stoans Zhibr  1005 B110448-C    Ni Lo              115 Zh M7V M5V             
+Stoans Zhibr  1005 B110448-C    Ni Lo              115 Zh M5V M7V             
 Plaezhsaed    1009 C350568-A    De Ni Po O:1011    603 Zh M8V                 
 Shtansh Shikl 1010 B86A567-C    Ni Wa O:1011       603 Zh M2V                 
-Biebletl      1011 C8C4A75-D  Z Fl Hi              504 Zh F2V DM              
+Biebletl      1011 C8C4A75-D  Z Fl Hi              504 Zh F2V D               
 Rblinch       1013 A8A5755-C  Z Fl Cp              312 Zh M8V                 
 Stiedadapr    1015 A330488-A  * De Po Ni Lo        305 Mi F9V M1V             
 Plia'         1016 E513497-7    Ic Ni Lo           812 Mi F2V                 
 Iedree        1017 C443797-5  * Po                 604 Mi K4IV                
 Netsiazdinsh  1023 C463779-8  M Ri C2              904 Na M2III M1V           
 Chakrqil      1024 B636569-9    Ni O:1025          700 Na M3V                 
-Ianzhva       1025 B564955-B    Hi                 314 Na F8II M6V DM         
+Ianzhva       1025 B564955-B    Hi                 314 Na F8II M6V D          
 Crimson Beacon1029 B876723-A    Ag                 400 CA M4III               
 Carillon      1030 A766948-C  C Hi Cx              702 CA F2V                 
-Yellow Ocean  1031 A89A728-9    Wa                 904 CA F5V DM              
+Yellow Ocean  1031 A89A728-9    Wa                 904 CA F5V D               
 Satsva        1035 B00068A-9    As Na Ni           322 Na M9V                 
-Rajash        1036 B85A475-B    Ni Wa Lo           403 Na M8V DM              
+Rajash        1036 B85A475-B    Ni Wa Lo           403 Na M8V D               
 Ishnad        1037 C634520-6    Ni                 624 Na M7V                 
 Fiplkledensh  1104 A500ACA-D  Z In Na Va Hi        304 Zh G0V M0V             
 Braiebl       1109 X446000-0    Ba              F  024 Zh G5V                 
@@ -183,8 +183,8 @@ Cauldron      1133 A8A3726-C    Fl                 611 CA M1V
 Sanzhkria     1136 X735000-0    Ba                 002 Na M8V                 
 Melchizhdrenk 1139 C876599-7    Ag Ni              324 Na M3III               
 Reentschti    1206 A235767-F  Y O:1308             300 Zh M3V                 
-Dretl Chtaons 1208 CA8A357-B    Lo Ni Wa           722 Zh DM                  
-Iablstizenzde 1212 C48258A-7    Ni                 921 Zh F8V DM DM           
+Dretl Chtaons 1208 CA8A357-B    Lo Ni Wa           722 Zh D                   
+Iablstizenzde 1212 C48258A-7    Ni                 921 Zh F8V D D             
 Siafrtivivlsia1213 A320322-B  Z De Lo Po Ni        605 Zh F8V                 
 Edlavr        1218 A6A3A8A-F  * Fl Hi              604 Mi F2V M9V             
 Zhde Inesh    1222 X755000-0    Ba                 004 Na M3V                 
@@ -196,68 +196,68 @@ Zhistieiprnzh 1302 C312533-A    Ic Ni              412 Zh M7V
 Dliiepr Plenz 1303 E47579C-6    Ag C3              814 Zh G4V                 
 Rievrniprkl   1307 C000435-9    As Ni Lo           214 Zh M0V                 
 Viadl Rirnch  1308 A673989-B  Z In Hi Cp           405 Zh F8V G1V             
-Zditsatlans   1310 B545421-B    Ni Lo              200 Zh M5V DG              
-Tsalchie      1312 C4019CA-B    Ic Hi Na Va In     103 Zh F4V DM              
+Zditsatlans   1310 B545421-B    Ni Lo              200 Zh M5V D               
+Tsalchie      1312 C4019CA-B    Ic Hi Na Va In     103 Zh F4V D               
 Jianchonts    1313 B300541-D  Z Va Ni              620 Zh M7V                 
-Stitl         1319 E370237-6    De Lo Ni           214 Mi G1V DM DM           
+Stitl         1319 E370237-6    De Lo Ni           214 Mi G1V D D             
 Iedrav        1320 C310234-9  * Ni Lo              700 Mi M2V                 
 Vinzhe        1322 E6417CE-6    Po              A  813 Na M9V                 
 Dim Rock      1330 B7A4776-A  C Fl              A  802 CA K7V                 
 Sokr Jakkia   1338 E54846A-6    Ni Lo O:1438       624 Na G4V                 
 Pilfiech      1401 D79A851-9    Wa                 223 Zh F4IV                
 Jerzrtchil    1402 B57398B-B    In Hi              213 Zh F0V G1V             
-Zhiefnach     1404 X671000-0    Ba An           F  013 Zh M0V DM              
-Vrikl Zhosiezh1405 A4876BB-D  Z Ag Ni              405 Zh M9V DM              
+Zhiefnach     1404 X671000-0    Ba An           F  013 Zh M0V D               
+Vrikl Zhosiezh1405 A4876BB-D  Z Ag Ni              405 Zh M9V D               
 Stiech Ienj   1406 B57246B-9    Ni Lo O:1308       510 Zh M9V                 
 Zhdabl        1410 C1209B9-B  Z De Hi In Na Po     114 Zh G9V                 
 Ieviabliefrzh 1411 B457478-A    Ni Lo              924 Zh F2V                 
-Ezae          1417 A120988-F  * Hi De Po In Na     204 Mi M2V DK              
-Flabretlanch  1418 B998799-9  * Ag                 122 Mi F4V DM              
+Ezae          1417 A120988-F  * Hi De Po In Na     204 Mi M2V D               
+Flabretlanch  1418 B998799-9  * Ag                 122 Mi F4V D               
 Zdonzh        1420 D260638-5    De Ni              104 Mi K3V                 
-Eov Stiavr    1421 C945755-9  M Ag                 402 Na DF                  
+Eov Stiavr    1421 C945755-9  M Ag                 402 Na D                   
 Denshnef      1423 X581000-0    Ba                 003 Na F6V                 
 Ezpianzchtiepraie'  1426 B635245-9    Lo Ni              802 Cc M9V                 
-Merikrer      1431 X402000-0    Ba Ic Va           002 Na F0V DM              
+Merikrer      1431 X402000-0    Ba Ic Va           002 Na F0V D               
 Ravlda        1435 C698234-7    Lo Ni              100 Na F9IV                
 Brinzhianzh   1437 B867689-A    Ag Ni Ri An        201 Iz K4V                 
 Jonjivr       1438 AAD5254-E  Z Lo Ni Rs Cp        604 Iz G2V                 
 Flienshoch    1504 C65668D-6    Ag Ni              712 Zh G2V                 
-Zdiadr Zhezh  1506 A538999-D    Hi                 710 Zh G3IV DM             
-Vritsavr      1512 B768367-9  Z Lo Ni O:1410       800 Zh F8V DM              
-Dia           1514 B100687-A  * Va Na Ni           814 Mi M2V DM              
+Zdiadr Zhezh  1506 A538999-D    Hi                 710 Zh G3IV D              
+Vritsavr      1512 B768367-9  Z Lo Ni O:1410       800 Zh F8V D               
+Dia           1514 B100687-A  * Va Na Ni           814 Mi M2V D               
 Ietietl       1519 A677988-D    Hi In              513 Mi F0V                 
-Atlieblanch   1521 A652356-B  * Lo Ni Po           223 Mc F3V DM              
-Savrflia      1522 X522000-0    Ba Po              004 Na K8V DM              
+Atlieblanch   1521 A652356-B  * Lo Ni Po           223 Mc F3V D               
+Savrflia      1522 X522000-0    Ba Po              004 Na K8V D               
 Doklvar       1525 X865000-0    Ba                 014 Na G0II                
 Dianzh Diatl  1527 A8679A8-C    Hi                 420 Cc F6V                 
-Forge         1531 C10066D-7  M Na Ni Va O:1631 A  120 Na A3IV G9V DM DM      
+Forge         1531 C10066D-7  M Na Ni Va O:1631 A  120 Na A3IV G9V D D        
 Sesh          1532 X100000-0    Ba Va              021 Na M8V                 
 Drianshstitl  1537 B561789-9    Ri                 603 Iz K7V                 
 Fretstlapl    1538 B2529CB-C    Hi Po              703 Iz M7V M9V             
 Blier'lezh    1605 A589511-C  Z Ni                 702 Zh F6V                 
-Yiapl         1612 A678937-F  * Hi In              412 Mi F4V DM              
+Yiapl         1612 A678937-F  * Hi In              412 Mi F4V D               
 Nabrienj      1613 A223636-C    Na Ni Po           823 Mi M7V                 
 Idri          1614 C5A2334-A  * Fl Lo Ni           404 Mi M9V                 
-Dienzhishinch 1615 A452A87-F  * Hi Po Cx           402 Mi F7V DM              
-Adrqriaz      1621 C000698-7    As Ni Na           625 Na G0V DM              
+Dienzhishinch 1615 A452A87-F  * Hi Po Cx           402 Mi F7V D               
+Adrqriaz      1621 C000698-7    As Ni Na           625 Na G0V D               
 Shtoeb Onsh   1625 X8A8000-0    Ba Fl              000 Na M7V                 
-Zezhdishketl  1630 B311510-B  M Ic Ni              211 Ic M8V DM              
+Zezhdishketl  1630 B311510-B  M Ic Ni              211 Ic M8V D              
 Hammer        1631 B5527AD-9  M Po              A  814 Na M3II K5V            
 Yojidrishtats 1632 X200000-0    Ba Va              000 Na M9V                 
-Zdantsplitskliepl   1636 B869582-B  I Ni                 220 Iz M9V DM              
+Zdantsplitskliepl   1636 B869582-B  I Ni                 220 Iz M9V D               
 Sejchiet      1639 A586AC8-E  Z Hi D0              925 Iz F1V                 
 Stovozh Friezh1709 C554576-9    Ag Ni              413 Zh F4V                 
 Paapadliek    1710 CACA210-B    Ni Lo Fl           402 Zh M0V                 
-Ialensh       1711 X574000-0    Ba              F  010 Zh G2V DM              
-Chabl         1714 A795538-D  * Ag Ni              512 Mi DF DM               
-Zhieyiez      1719 A100338-B    Lo Ni Va           702 Mi K1V DM              
+Ialensh       1711 X574000-0    Ba              F  010 Zh G2V D               
+Chabl         1714 A795538-D  * Ag Ni              512 Mi D D                 
+Zhieyiez      1719 A100338-B    Lo Ni Va           702 Mi K1V D               
 Shtiprashint  1720 C200388-8    Lo Ni Va           110 Mi K5V M7V             
-Yuss          1725 X564000-0    Ba                 003 Na DF                  
-Kakariki      1726 D463650-7    Ni Ri D2           201 Na G4V DM DM           
+Yuss          1725 X564000-0    Ba                 003 Na D                   
+Kakariki      1726 D463650-7    Ni Ri D2           201 Na G4V D D             
 Fafrekolefransh 1731 X000000-0    As Ba              040 Na M5III               
 Zhdamonzhdranj1735 C100363-9    Lo Ni Va O:1738    350 Iz K2II                
-Chedraz       1738 B7678C9-8  I                    920 Iz K9III DM DM         
-Noche         1740 B241595-B  X Ni Po              830 Iz G1V DM              
+Chedraz       1738 B7678C9-8  I                    920 Iz K9III D D           
+Noche         1740 B241595-B  X Ni Po              830 Iz G1V D               
 Veriapr       1805 A304477-B    Ic Ni Va Lo        503 Zh M6III G3V           
 Sobrechvri    1809 A402274-D  Z Ic Ni Va Lo        500 Zh M1V                 
 Ozhavlazefr   1812 D576164-A    Lo Ni O:1615       204 Mi G8V                 
@@ -265,62 +265,62 @@ Ripejekl      1813 A345698-8    Ag Ni              700 Mi F9IV M7V
 Peviade       1815 B00089A-B    As Na              912 Mi K3V                 
 Chaabazh      1816 B120488-D    De Ni Po Lo        413 Mi M3V                 
 Drirebradr    1820 B335788-8                       111 Mi M5V                 
-Mivlzhits     1823 XAE9000-0    Ba                 010 Na DK                  
-Stelsodr      1830 X463521-3    Ni C7              223 Na M2V DF              
+Mivlzhits     1823 XAE9000-0    Ba                 010 Na D                   
+Stelsodr      1830 X463521-3    Ni C7              223 Na M2V D               
 Zdansiyner    1831 X799000-0    Ba              R  001 Na F7V                 
 Tliebrenzh    1832 A97A78A-C  I Wa                 410 Ic K0V                 
 Brozh         1838 C000516-B    As Ni              140 Iz M3V                 
-Yienchbrej    1902 C651559-9    Ni Po           U  913 Zh K0V DM              
+Yienchbrej    1902 C651559-9    Ni Po           U  913 Zh K0V D               
 Shishto'dridl 1903 B4357F8-7                       914 Zh A0IV G5V            
 Dizedivr To   1908 B634334-8    Lo Ni              712 Zh K9V                 
 Proza Zdiafl  1909 B634522-9    Ni                 203 Zh M0V                 
 Cochints Kant 1910 D655356-8    Lo Ni              200 Zh F4V                 
 Iachonz       1913 B888676-A  Z Ag Ni Ri           303 Zh K0V                 
-Zhazhanzh     1916 A665437-B  * Ni Lo              810 Mi F6V DM              
-Shtiachabr    1917 A594435-E  * Ni Lo              103 Mi F0V DM              
+Zhazhanzh     1916 A665437-B  * Ni Lo              810 Mi F6V D               
+Shtiachabr    1917 A594435-E  * Ni Lo              103 Mi F0V D               
 Stiatlade     1918 D778698-5    Ag Ni              812 Mi F5IV                
 Storm         1922 A967777-C  M Ag Ri An           833 Na G2V                 
-Waikikamukau  1926 D243677-7    Ni Po              701 Na DF DM               
-Fiaf          1928 D8B7300-8    Lo Ni Fl           603 Na M8V DM              
+Waikikamukau  1926 D243677-7    Ni Po              701 Na D D                 
+Fiaf          1928 D8B7300-8    Lo Ni Fl           603 Na M8V D              
 Soyayt        1931 C687675-7  Q Ag Ni Ri           102 Dr F7V                 
 Tliavl Kich   2002 C659100-B    Lo Ni              900 Zh G3V                 
 Piadrliz      2004 B55A222-8    Lo Ni Wa           704 Zh G5IV                
 Shaeensh      2005 B661397-A    Lo Ni              501 Zh G5V                 
 Kizdalfa      2007 A433AC7-E  Z Hi Na Po Cp        324 Zh G3V                 
 Abrievie      2010 B99558A-A    Ag Ni              500 Zh F2V                 
-Sobropr       2011 C585865-8    Ri O:2211          711 Zh F0D                 
+Sobropr       2011 C585865-8    Ri O:2211          711 Zh F0V                 
 Liansh        2013 D87A164-A    Wa Lo Ni O:1615    104 Mi M1V                 
 Elfedlent     2016 DAA2064-A    Lo Ni Fl Rv 1615   813 Mi M0V                 
-Flekriabr     2023 C9A8532-8    Ni Fl              230 Na K1V DM              
-Kansh         2028 C8A5979-B  M Hi Fl              304 Na DF DM               
+Flekriabr     2023 C9A8532-8    Ni Fl              230 Na K1V D               
+Kansh         2028 C8A5979-B  M Hi Fl              304 Na D D                 
 Itsplanzhikar 2035 A358786-E  I Ag                 341 Iz F8V                 
-Qrannienzh    2040 C9AA589-C    Ni Fl              711 Iz G6V DM              
+Qrannienzh    2040 C9AA589-C    Ni Fl              711 Iz G6V D               
 Predrnzhcho   2101 A270789-C  Z De                 203 Zh M0III M8V           
 Mikliezh      2105 B322355-A  Z Lo Ni Po           603 Zh K4II M1V            
 Dloiach       2107 B100520-A    Ni Va              224 Zh F5V                 
 Drazna'chi    2108 A4387BC-B                       904 Zh F2IV                
 Zhdaenz       2110 A596423-9  Z Ni Lo              300 Zh M0V                 
 Dralievl      2114 D665164-A    Lo Ni O:1615       113 Mi M2V                 
-Jdieblansh    2116 A000337-F    As Lo Ni           714 Mi M1V DG              
-Beblazhie'    2117 D000588-9    As Ni              614 Mi G7V DM              
+Jdieblansh    2116 A000337-F    As Lo Ni           714 Mi M1V D               
+Beblazhie'    2117 D000588-9    As Ni              614 Mi G7V D               
 Ovdash        2121 E849655-7    Ni                 601 Na F4V                 
-Ebria         2124 D746976-9    Hi In              402 Na F0V DM              
+Ebria         2124 D746976-9    Hi In              402 Na F0V D               
 Ilosha        2125 E65469C-3    Ag Ni              402 Na G6V                 
 Mukir         2126 D210421-7    Ni Lo              335 Na M4V                 
 Imazhianztsied2131 X436000-0    Ba                 030 Na M5V                 
 Qrazhazhjal   2137 A984AC9-E  X Hi                 222 Iz M3V                 
-Eleshtepri    2138 E478537-7    Ag Ni              151 Iz F0V DM              
+Eleshtepri    2138 E478537-7    Ag Ni              151 Iz F0V D               
 Anchli        2140 A352989-D  Y Hi Po An C0        731 Iz F5V                 
 Bianzh        2202 B8A6411-B    Fl Ni Lo           315 Zh M0V M6V             
 Ninzh         2211 B51357A-B  Z Ic Ni              402 Zh M9II M9V            
-Finzhchtanz   2213 B371561-8    Ni O:2314          714 Zh M2V DM              
+Finzhchtanz   2213 B371561-8    Ni O:2314          714 Zh M2V D               
 Bledradl      2214 D647164-A    Lo Ni O:1615       123 Mi M3V                 
 Fleqliaajafriepla   2318 B546438-6  * Ni Lo D1           501 Mi F2IV                
-Shte'drabliech2221 X250644-1    De Ni Po           500 Na F1V DM DM           
-Sakigu        2224 B000576-A    As Ni              630 Na DM                  
+Shte'drabliech2221 X250644-1    De Ni Po           500 Na F1V D D             
+Sakigu        2224 B000576-A    As Ni              630 Na D                   
 Jonterienzh   2232 X8B3000-0    Ba Fl              010 Na K3V M7V             
-Leyins        2233 X000000-0    As Ba              000 Na M6V M2V             
-Shtansh       2239 E89756B-3    Ag Ni O:2140    A  220 Iz M9III DM DM         
+Leyins        2233 X000000-0    As Ba              000 Na M2V M6V             
+Shtansh       2239 E89756B-3    Ag Ni O:2140    A  220 Iz M9III D D           
 Qrifoplsidl   2302 B694536-8    Ag Ni C0           703 Zh M1V                 
 Dlezvetl      2304 C684688-8    Ag Ni Ri D8     U  304 Zh M2V M5V             
 Jdaiebr       2305 E8855A8-6    Ag Ni              221 Zh K9V                 
@@ -328,13 +328,13 @@ Kroshzi       2306 A000585-E    As Ni              711 Zh M3V
 Itlzhdiflaz   2311 E88A310-4    Lo Ni Wa D2        420 Zh F3V                 
 Palstimrdl    2314 A442575-9  Z Po Ni              423 Zh G8V M1V             
 Chivedial     2219 D559A87-5    Hi C2              303 Mi F8IV                
-Kishka        2326 D555246-3    Lo Ni              320 Na K2V DM              
+Kishka        2326 D555246-3    Lo Ni              320 Na K2V D               
 Tiqa          2328 E776777-3    Ag                 811 Na K5V                 
-Edjinsja      2329 X785464-2    Ni Lo O:2330       403 Na F1V DM              
+Edjinsja      2329 X785464-2    Ni Lo O:2330       403 Na F1V D               
 She'qil       2330 C9C9201-9    Lo Ni Fl           503 Na M6V                 
-Zhieotlizhikl 2332 X471000-0    Ba                 000 Na M6V DM              
+Zhieotlizhikl 2332 X471000-0    Ba                 000 Na M6V D               
 Frikriyip     2334 E430210-8  Z De Lo Ni Po Re  A  151 Na F0III M8V           
-Zhdits Zdats  2402 A9B49AD-E    Fl Hi              504 Zh G1V DM              
+Zhdits Zdats  2402 A9B49AD-E    Fl Hi              504 Zh G1V D               
 Eshedrtlial   2407 C514836-7    Ic                 204 Zh K2III               
 Zhdiazh       2410 B130735-D    De Na Po           524 Zh F5V M5V             
 Paklshtepl    2413 A429400-A    Lo Ni              222 Zh M3V                 
@@ -348,57 +348,57 @@ Shteelov      2508 B559754-7  Z                    713 Zh F5II
 Priebldrivl   2509 C427358-9    Lo Ni              204 Zh G5IV                
 Soliatlrizh   2512 D320420-6    De Ni Po Lo     U  420 Zh M1V                 
 Qro'vepl      2516 B7C1778-A  Z Fl                 104 Zh F7V                 
-Ech           2519 C4547AB-9  M Ag                 520 Na DF DM               
+Ech           2519 C4547AB-9  M Ag                 520 Na D D                 
 Arcana        2523 B8775B3-C  A Ag Ni An        R  535 AU F7V                 
 Dushegadaar   2531 A879796-B  X                    716 Na M2V                 
-Eblplons      2532 C5223A6-8    Lo Ni Po           594 Na G6V DM              
-Vlados        2535 E500100-0    Lo Ni Va           370 Na DM                  
+Eblplons      2532 C5223A6-8    Lo Ni Po           594 Na G6V D               
+Vlados        2535 E500100-0    Lo Ni Va           370 Na D                   
 Brianchvrench 2537 C855988-8    Hi              R  938 Na F6V M4V             
-Tlivl Lafr    2601 A5459BB-D    Hi In              804 Zh M0V K8V             
+Tlivl Lafr    2601 A5459BB-D    Hi In              804 Zh K8V M0V             
 Echvech Iebrpr2602 C415737-7    Ic                 704 Zh K5V M5V             
 Salafned      2603 D67668A-5    Ni Ag              322 Zh F5IV G0V            
 Iabrinch      2605 B000552-B    As Ni              713 Zh G1V M8V             
 Leepzhishtie  2610 A775AA9-E  Y Hi In              711 Zh G1V                 
 Dlidl         2612 C000344-9    As Lo Ni           410 Zh K0V                 
-Zdoflqriaqr   2615 C655559-8    Ag Ni              100 Zh DF                  
-Vamtliaz      2617 B426652-B  Z Ni                 900 Zh F4V DM              
+Zdoflqriaqr   2615 C655559-8    Ag Ni              100 Zh D                   
+Vamtliaz      2617 B426652-B  Z Ni                 900 Zh F4V D               
 Utu           2620 A5689BB-C  A Hi Cx              410 AU G1V                 
-Kia           2623 A35296B-C  A Hi Po O:2620       102 AU DF                  
-Qlate         2630 C65A400-A    Ni Lo Wa           304 Na DF DM               
+Kia           2623 A35296B-C  A Hi Po O:2620       102 AU D                   
+Qlate         2630 C65A400-A    Ni Lo Wa           304 Na D D                 
 Greytown      2633 C447441-7    Lo Ni              950 Gs G7V                 
 Jdreie'       2703 B7059A9-C    Hi In Va Ic Rn     703 Zh K0V                 
-Nachmetl      2706 A6B7346-D  Z Lo Ni Fl           623 Zh M6V M0V             
+Nachmetl      2706 A6B7346-D  Z Lo Ni Fl           623 Zh M0V M6V             
 Yiazhdoql     2710 B5648AD-A                       800 Zh G6V                 
-Itlfeklkrekl  2714 A988898-E  Z Ri Cp              304 Zh DF DM               
-Jidrbliam     2716 D120651-A    De Na Ni Po        110 Zh M3V DM              
-Ssenuiku      2719 B4937X4-A  P                    703 Dr G8V DM              
+Itlfeklkrekl  2714 A988898-E  Z Ri Cp              304 Zh D D                 
+Jidrbliam     2716 D120651-A    De Na Ni Po        110 Zh M3V D               
+Ssenuiku      2719 B4937X4-A  P                    703 Dr G8V D               
 Dustbowl      2725 CAF16B0-C  A Ni Pr           R  324 AU G8V                 
 Umder         2727 X354603-0    Ag Ni              702 Na F9V                 
 Khuggi        2728 B301758-9  M Ic Na Va           121 SC M5V                 
-Bravl         2730 D7B49EF-9    Fl Hi              203 Na DG DM               
-Caveat        2733 C7A3645-9    Fl Ni              592 Gs M2III DF            
+Bravl         2730 D7B49EF-9    Fl Hi              203 Na D D                 
+Caveat        2733 C7A3645-9    Fl Ni              592 Gs M2III D             
 Glenaura      2734 B757503-B  M Ag Ni              714 Gs G5III               
 Kusiahatai    2735 A575737-D  J Ag                 936 Gs K1V                 
 Iqlneshav     2738 E210654-9    Na Ni              158 Na A8IV                
 Shiqrch       2801 A86A787-E  Z Wa Ri Cp           714 Zh K2V M8V             
 Shaz Ziefr    2803 B222688-B    Ni Na Po           923 Zh M5III               
 Zezya         2806 E875631-5    Ni Ag              300 Zh K6V                 
-Zhdi'apl      2812 E573432-3    Ni Lo              603 Zh F1V DM              
+Zhdi'apl      2812 E573432-3    Ni Lo              603 Zh F1V D               
 Pafltezhdr    2814 C333330-B    Lo Ni Po           114 Zh G0V                 
 Omzhea'iazh   2815 C676433-5    Ni Lo              500 Zh F0V                 
 Bepl          2817 C5848BF-4    C2                 700 Zh F0V                 
 Qapriez       2819 B66A888-B  Z Ri Wa C8           304 Zh F7V                 
-Crusade       2823 C5577BC-A  A Ag                 102 AU M0V DM              
+Crusade       2823 C5577BC-A  A Ag                 102 AU M0V D              
 Thalamus      2825 A42041B-B  A De Lo Ni Po        511 AU M3V                 
 Duneed        2832 A000744-C  J As Na              370 Gs F6II                
 Chejieb       2834 B400783-B    Na Va An           262 Gs M4III               
 Shining Face  2836 D5657DI-A    Ag              A  359 Na G8V                 
-Azhpokl Tlil  2904 B580679-7    Ni Ri De           814 Zh M9V M0V             
-Abaieplesh    2905 A5609BD-E  Z Hi De              722 Zh K5V K3V             
-Riefshtep     2912 A5279A7-D  Z Hi In              112 Zh G3V DM              
+Azhpokl Tlil  2904 B580679-7    Ni Ri De           814 Zh M0V M9V             
+Abaieplesh    2905 A5609BD-E  Z Hi De              722 Zh K3V K5V             
+Riefshtep     2912 A5279A7-D  Z Hi In              112 Zh G3V D               
 Kienzhqlied   2915 X8B0000-0    Ba De           F  001 Zh A7IV M9V            
 Fenchzhe      2919 C000767-7    As Na O:2819       512 Zh M4V                 
-Safcolia      2921 A98A7BB-C  A Wa                 405 AU DK DM DM            
+Safcolia      2921 A98A7BB-C  A Wa                 405 AU D D D               
 Ginkhu        2928 D4839AA-7    Hi D8              222 SC F5V                 
 Iareflonzal   2933 B110757-B    Na C2              871 Gs M4III M6V           
 Odreitsvoz    2934 B573474-9    Lo Ni           A  793 Gs G7III               
@@ -406,41 +406,41 @@ Zhe Niepl     3001 C234200-B    Lo Ni              724 Zh F5V
 Brozia'klie   3003 B635233-B    Lo Ni              203 Zh F7V                 
 Chebredrpliat 3006 C63A5D6-9    Wa Ni              202 Zh F3V                 
 Klichints     3008 D410732-8    Na                 214 Zh K5V M8V             
-Blentstadl    3011 D779723-7                       621 Zh DF                  
+Blentstadl    3011 D779723-7                       621 Zh D                   
 Chatipqi'itler3013 E351336-3    Lo Ni Po           910 Zh F7V                 
 Bajchaplfrabl 3015 C40276A-9    Ic Na Va O:2714    525 Zh F2V                 
-Iiash         3022 X676000-0    Ba              R  034 SC F1V DM              
+Iiash         3022 X676000-0    Ba              R  034 SC F1V D               
 Sukia         3024 C6887A9-3    Ag                 120 SC K2III M6V           
 Kemkhil       3025 E546344-5    Lo Ni              805 SC G8V                 
-Torgol        3026 C533442-9  M Lo Ni Po           504 SC DF                  
-Avator        3028 D203575-9    Ic Ni Va           323 Na M3V M0V             
+Torgol        3026 C533442-9  M Lo Ni Po           504 SC D                   
+Avator        3028 D203575-9    Ic Ni Va           323 Na M0V M3V             
 Ancona        3032 B566876-C  M Ri                 615 Gs K2V                 
-Yadrishipl    3035 C210432-A    Lo Ni              713 Na M5V K9V             
+Yadrishipl    3035 C210432-A    Lo Ni              713 Na K9V M5V             
 Chtiedl       3101 C794796-6    Ag C6              202 Zh G7V                 
 Ieezhdanzh    3103 D444400-3    Ni Lo              921 Zh M0V                 
 Qlrqlnis      3107 B478435-B    Ni Lo C3           900 Zh A9V                 
 Vrdriapr Blenj3108 A00047B-E  Z Ni As Lo           524 Zh M8III               
 Zdich         3111 B433678-9    Na Ni Po           114 Zh M5V                 
-Otedrel       3112 X798000-0    Ba              F  010 Zh DF DM               
-Elshienja     3113 C57568A-5    Ag Ni              900 Zh F3V DM DM           
+Otedrel       3112 X798000-0    Ba              F  010 Zh D D                 
+Elshienja     3113 C57568A-5    Ag Ni              900 Zh F3V D D             
 Prokefriabr   3114 E4345A7-8    Ni                 503 Zh A7V                 
-Tlish         3119 B464552-8  Z Ag Ni              325 Zh DF                  
+Tlish         3119 B464552-8  Z Ag Ni              325 Zh D                   
 Kiefer        3122 A663564-C  M Ni O:3124          622 SC K9V                 
-Kiirkhiim     3124 B668430-B  M Lo Ni              423 SC DF DM               
-Kons          3125 B684578-9  M Ag Ni              323 SC DF                  
+Kiirkhiim     3124 B668430-B  M Lo Ni              423 SC D D                 
+Kons          3125 B684578-9  M Ag Ni              323 SC D                   
 Flieporshe    3126 E78896B-6    Hi O:3026          101 SC K6V                 
-Fliebrtsel    3135 X8C2457-9    Fl Ni Lo        F  402 Zh DF DM               
+Fliebrtsel    3135 X8C2457-9    Fl Ni Lo        F  402 Zh D D                 
 Abrzhdedl     3137 XA5A000-0    Ba Wa           F  002 Zh M7III               
 Dlarlbesh     3202 B53555A-A    Ni                 414 Zh M1V                 
 Drzhishliebl  3204 A351422-E    Ni Po Lo           804 Zh M2V                 
 Epriefinch    3209 A575A7B-B  X Hi In              722 Zh M2V                 
-Adrdochdachia 3211 B767557-A    Ag Ni              501 Zh DM                  
+Adrdochdachia 3211 B767557-A    Ag Ni              501 Zh D                   
 Edshanjo      3217 X656651-2    Ag Ni           F  802 Zh F1V                 
-Afroqnats     3228 C8776AE-C    Ag Ni              903 Na DF                  
-Zdaefia       3229 X978000-0    Ba                 032 Na DF DM               
+Afroqnats     3228 C8776AE-C    Ag Ni              903 Na D                   
+Zdaefia       3229 X978000-0    Ba                 032 Na D D                 
 Arikrfekr     3235 X200012-A    Lo Ni Va        F  902 Zh M7III               
-Jeshiel       3237 X8A0830-8    De              F  403 Zh DF DM               
-Rodebr Rifia  3239 X368899-E    Ri C6           F  310 Zh F7V DM              
+Jeshiel       3237 X8A0830-8    De              F  403 Zh D D                 
+Rodebr Rifia  3239 X368899-E    Ri C6           F  310 Zh F7V D               
 #Zh Zhodani Consulate
 #Tl Talpaku Communality
 #Tc Talpaku Communality Client State


### PR DESCRIPTION
Clean up stellar data in M1105 Yiklerzdanzh.

Zeroth, any dwarfs with a spectral class (`DM`, `DK`, `DG`, etc) have their spectral classes dropped.
First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is _swapped_ into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).