### PR TITLE
Fix stellar data in Undeveloped Sectors, round 3

### DIFF
--- a/res/Sectors/M1105/Aerenfors.sec
+++ b/res/Sectors/M1105/Aerenfors.sec
@@ -23,41 +23,41 @@ Aerenfors
 #--------1---------2---------3---------4---------5---------6---
 #PlanetName   Loc. UPP Code   B   Notes         Z  PBG Al LRX *
 #----------   ---- ---------  - --------------- -  --- -- --- -
-Iashplie      0701 B658452-C  Z Ni                 917 Zh     K9V M0D 
+Iashplie      0701 B658452-C  Z Ni                 917 Zh     K9V M0V
 Kajvreensh    1001 B987486-7  Z Ni              U  705 Zh     G9V 
-Jieaz         1201 A69A89A-9  Z Wa                 504 Zh     F5V M0D 
+Jieaz         1201 A69A89A-9  Z Wa                 504 Zh     F5V M0V
 Klrzhdeql     1301 D446000-0  Z Ba Lo Ni           002 Zh     F2V 
-Bebrlifl      1601 C300526-B    Ni Va              303 Zh     F5V M4D 
-Iabaiabl      2001 C783563-8  Z Ag Ni              310 Zh     F4V M1D 
+Bebrlifl      1601 C300526-B    Ni Va              303 Zh     F5V M4V
+Iabaiabl      2001 C783563-8  Z Ag Ni              310 Zh     F4V M1V
 Driaplie      2401 C462449-8    Ni                 803 Zh     F3V 
-Klietlensebr  2601 E311000-0    Ba Ic Lo Ni        012 Zh     F5V M2D 
+Klietlensebr  2601 E311000-0    Ba Ic Lo Ni        012 Zh     F5V M2V
 Zhienshpiedr  2701 B2007A9-9  Z Na Va              114 Zh     M0V 
 Sheziq        2901 D334753-7                       301 Zh     A5V 
-Rnsho         3001 C220451-B    De Ni Po           712 Zh     M0V M4D 
+Rnsho         3001 C220451-B    De Ni Po           712 Zh     M0V M4V
 Dredro        0202 A300420-B  Z Ni Va              410 Zh     M0V 
 Chatljafo     0302 C5528A8-6    Po                 500 Zh     F4V 
 Zhdiabeplia   0402 E100589-9    Ni Va              902 Zh     K8V 
 Iei           0602 B63A446-B    Ni Wa              301 Zh     M3V 
 Bafrpalenekl  0802 B3378DD-9  Z                    523 Zh     F0V 
-Adlzhonsh     1002 E546573-5    Ag Ni              700 Zh     F2V M2D 
+Adlzhonsh     1002 E546573-5    Ag Ni              700 Zh     F2V M2V
 Chebchienj    1102 C644446-5    Ni                 134 Zh     F4V M6V 
-Tleflchefr    1402 D6B0000-0    Ba De Lo Ni        005 Zh     F4V M4D 
+Tleflchefr    1402 D6B0000-0    Ba De Lo Ni        005 Zh     F4V M4V
 Draqtazdal    1602 C575973-A    Hi In              921 Zh     F4V 
-Stedriazh     1702 B460443-9    De Ni           U  803 Zh     F6V M7D 
-Vlebrrebr     1902 B9A5455-8  Z Fl Ni              904 Zh     M4V M1D 
+Stedriazh     1702 B460443-9    De Ni           U  803 Zh     F6V M7V
+Vlebrrebr     1902 B9A5455-8  Z Fl Ni              904 Zh     M4V M1V
 Kaekrni'a     2002 C989775-4    Ri                 411 Zh     F9V 
 Konchchozh    2202 B464566-C    Ag Ni              501 Zh     F3V 
-Otsche        2402 E7689A7-3    Hi In           U  615 Zh     M4V M5D 
+Otsche        2402 E7689A7-3    Hi In           U  615 Zh     M4V M5V
 E'zhdets      2502 A230530-E  Z De Ni Po           800 Zh     M4V 
 Sariainjfip   2802 C200573-7    Ni Va              703 Zh     G2V 
 Zda'fliak     2902 B512765-7    Ic Na              700 Zh     F0V 
 Zhdiezhdiabr  3002 C555564-8    Ag Ni              611 Zh     K0V 
-Otlditlifr    3102 E85A556-8    Ni Wa              905 Zh     F0V M2D 
-Dralflo       0203 A788552-9  Z Ag Ni              106 Zh     F6V M8D 
+Otlditlifr    3102 E85A556-8    Ni Wa              905 Zh     F0V M2V
+Dralflo       0203 A788552-9  Z Ag Ni              106 Zh     F6V M8V
 Sa'ia         0303 C323000-0    Ba Lo Ni Po        000 Zh     K6V 
 Atltla        0403 B55359E-9  Z Ag Ni Po           500 Zh     F6V 
 Vranzhi       0603 E738000-0    Ba Lo Ni           003 Zh     M0V 
-Shanshfraa'   1203 C3749BF-6  Z Hi In              614 Zh     F7V M3D 
+Shanshfraa'   1203 C3749BF-6  Z Hi In              614 Zh     F7V M3V
 Chtelcha      1303 C626557-7    Ni                 505 Zh     M3V M7V 
 Ziezhev       1403 C79A520-B    Ni Wa              703 Zh     F5V 
 Ezhifliats    1603 C545475-5    Ni                 802 Zh     M8V 
@@ -66,26 +66,26 @@ Sazhr         2003 C571544-5    Ni                 213 Zh     F1V
 Pokremie'     2103 C43448B-7    Ni                 100 Zh     M8V 
 Qrnsieprb     2303 B3539EJ-A  Z Hi In Po           403 Zh     M6V 
 Pliklienzedl  2503 A61059A-D    Ni                 800 Zh     A0V 
-Noprien       2703 C350734-7    De Po              314 Zh     G9V M6D 
+Noprien       2703 C350734-7    De Po              314 Zh     G9V M6V
 Elfienj       3003 C858412-7    Ni                 702 Zh     F6V 
-Vapra         3103 D4638CB-7                       103 Zh     F9V M5D 
+Vapra         3103 D4638CB-7                       103 Zh     F9V M5V
 Briaflnech    0104 D995456-8    Ni                 813 Zh     F1V 
-Itljienzh     0304 E556422-2    Ni                 704 Zh     F5V M0D 
+Itljienzh     0304 E556422-2    Ni                 704 Zh     F5V M0V
 Pefrenjvench  1004 D756402-8  Z Ni                 502 Zh     F9V 
 Iadrecha'e    1204 C531000-0    Ba Lo Ni Po        003 Zh     G0V 
 Zhdedrov      1304 C67A876-A    Wa                 505 Zh     F7V M6V 
 Abldriazhste  1604 C26059B-6    De Ni              811 Zh     F6V 
 Zdiviepr      1804 B200420-D    Ni Va              400 Zh     G6V 
 Fanchshtiq    1904 B53179B-8    Na Po           U  602 Zh     K5V 
-Fanzhat       2004 B6A2740-B  Z Fl                 803 Zh     M2V M5D 
+Fanzhat       2004 B6A2740-B  Z Fl                 803 Zh     M2V M5V
 Tleche        2304 A410731-B  Z Na                 604 Zh     F7V 
-Nittlo        2404 C877667-7    Ag Ni              403 Zh     F9V M7D 
+Nittlo        2404 C877667-7    Ag Ni              403 Zh     F9V M7V
 Tletsiet      2604 C97A463-6    Ni Wa              700 Zh     M7V 
-Enzhiazhi     2704 C000443-C    As Ni              723 Zh     K5V M0D 
-Zhaetla       2804 C9A4000-0    Ba Fl Lo Ni        003 Zh     M7V M4V M7D 
+Enzhiazhi     2704 C000443-C    As Ni              723 Zh     K5V M0V
+Zhaetla       2804 C9A4000-0    Ba Fl Lo Ni        003 Zh     M7V M4V M7V
 Enzhbria'     2904 C331410-8    Ni Po              403 Zh     K9V 
 Zdiejste'pri  3104 B65A589-A    Ni Wa              201 Zh     F4V 
-Jiazpezhdekl  0105 C000740-8    As Na              300 Zh     M0V M6D 
+Jiazpezhdekl  0105 C000740-8    As Na              300 Zh     M0V M6V
 Tlitllitle    0505 A451854-D    Po                 604 Zh     F8V 
 Jianzhe       0605 B736477-7    Ni                 414 Zh     G0V 
 Yenzhiad      1005 B512531-9  Z Ic Ni              314 Zh     F7V 
@@ -95,11 +95,11 @@ Yebtsa        1605 D789532-8  Z Ni                 402 Zh     F7V
 Iltanzh       1805 B769669-9    Ni Ri              900 Zh     F6V 
 Ieztlaflie    2005 B338547-D    Ni                 323 Zh     K2V 
 Jeminte       2505 C64A423-B    Ni Wa              604 Zh     K2V 
-Finchbians    2805 B430787-A    De Na Po           815 Zh     A6V M4D 
+Finchbians    2805 B430787-A    De Na Po           815 Zh     A6V M4V
 Zhirfepl      3105 C410510-B    Ni                 100 Zh     K6V 
 Fakpleqleedl  3205 B402663-C    Ic Na Ni Va        203 Zh     F5III 
 Ianlans       0606 B663510-7  Z Ag Ni              601 Zh     F4V 
-Vliachifr     0706 B9B4427-8  Z Fl Ni              608 Zh     M1V M2D 
+Vliachifr     0706 B9B4427-8  Z Fl Ni              608 Zh     M1V M2V
 Chtepient     0906 A667496-B  Z Ni                 304 Zh     F5V 
 Donjelepr     1006 C4438B8-7    Po                 914 Zh     G0V 
 Rebla         1206 C555648-6  Z Ag Ni              713 Zh     F4V 
@@ -111,29 +111,29 @@ Kliedlieso    1806 B110400-D  Z Ni                 112 Zh     M2V
 Bonchtashie   1906 E572000-0    Ba Lo Ni           002 Zh     F2V 
 Fibliedrfo    2006 D535000-0    Ba Lo Ni           001 Zh     M0V 
 Intachzhez    2106 C48397B-B    Hi In              823 Zh     G4V 
-Rizstiedl     2306 C220454-7    De Ni Po           500 Zh     K4IV K6D 
+Rizstiedl     2306 C220454-7    De Ni Po           500 Zh     K4IV K6V
 Ietlozre      2506 E754478-5    Ni                 102 Zh     F6V 
 Jecho         2606 B9A288A-B  Z Fl                 103 Zh     F5V 
-Chtiaznache   2706 C462987-6    Hi In           U  315 Zh     F3V M1D 
+Chtiaznache   2706 C462987-6    Hi In           U  315 Zh     F3V M1V
 Mavrchtinzh   2906 B510522-8  Z Ni                 403 Zh     A6IV 
 Jdadrench     3006 C896410-8    Ni                 704 Zh     K8V 
 Drieche       0307 C776000-0    Ba Lo Ni           001 Zh     F4V 
 Tsafreiefl    0707 C7638DG-3    Ri              U  523 Zh     F7V 
-Anshplodr     0907 D403000-0  Z Ba Ic Lo Ni Va     000 Zh     M3V M7D 
+Anshplodr     0907 D403000-0  Z Ba Ic Lo Ni Va     000 Zh     M3V M7V
 Lietlra       1107 C691553-A    Ni                 202 Zh     G0V 
 Drrfe         1707 D376400-9    Ni                 110 Zh     F5V 
 Pedle         1807 C303478-7    Ic Ni Va           101 Zh     M2V 
 Dlrvreprafl   2007 C510420-8    Ni              U  604 Zh     M3V 
 Fladle        2107 C659420-5  Z Ni                 100 Zh     F0V 
 Noibriefla    2307 E639458-A    Ni                 614 Zh     G7V 
-Jdevlkofr     2507 A24789B-A                       310 Zh     F5V M1D 
+Jdevlkofr     2507 A24789B-A                       310 Zh     F5V M1V
 Iadra         3107 B67157B-6  Z Ni                 103 Zh     F8V 
-Eddents       0208 C8A9565-8    Fl Ni              402 Zh     M5V M5D 
-Chabe         0508 C3427A9-5    Po                 609 Zh     K5V F7V M1D 
+Eddents       0208 C8A9565-8    Fl Ni              402 Zh     M5V M5V
+Chabe         0508 C3427A9-5    Po                 609 Zh     K5V F7V M1V
 A'via         0608 D8B3000-0    Ba Fl Lo Ni     U  004 Zh     M7V 
 Stetsie       0908 A000769-B  Z As Na              202 Zh     K5III 
-Naiakr        1208 C855414-8    Ni                 602 Zh     F0V M6D 
-Ikrshanzhpoz  1708 E8C5000-0    Ba Fl Lo Ni        023 Zh     K7V M1D 
+Naiakr        1208 C855414-8    Ni                 602 Zh     F0V M6V
+Ikrshanzhpoz  1708 E8C5000-0    Ba Fl Lo Ni        023 Zh     K7V M1V
 Onjianchia    2108 D6876A7-2    Ag Ni              104 Zh     F0V 
 Echensh       2708 D565451-8  Z Ni                 411 Zh     F1V 
 Plazhfri      2908 A9C8666-A  Y Fl Ni              501 Zh     K3V 
@@ -148,49 +148,49 @@ Tlefeme       1709 C0008BA-B    As Na              303 Zh     K7V
 Shtatldots    2509 X847000-0    Ba Lo Ni        F  011 Zh     F9V 
 Kolibriasits  2609 C431443-7    Ni Po              512 Zh     M3V 
 Eplezarzienj  2909 C331877-9    Na Po              110 Zh     F6V 
-Vieievr       3209 B472546-9    Ni              U  203 Zh     F0V M1D 
-Plodrchia'    0510 C584452-A    Ni                 405 Zh     F9V M1D 
-Irzhjde'      0610 B5A09B8-D  Z De Hi In        U  702 Zh     F8V M5D 
-Eefchtia      0710 B300635-8    Na Ni Va           625 Zh     G3V M0D 
-Pienzblent    1210 D585464-4  Z Ni              U  208 Zh     K8V M5D 
-Anitlte       1310 C774000-0    Ba Lo Ni           013 Zh     G1V M3D 
+Vieievr       3209 B472546-9    Ni              U  203 Zh     F0V M1V
+Plodrchia'    0510 C584452-A    Ni                 405 Zh     F9V M1V
+Irzhjde'      0610 B5A09B8-D  Z De Hi In        U  702 Zh     F8V M5V
+Eefchtia      0710 B300635-8    Na Ni Va           625 Zh     G3V M0V
+Pienzblent    1210 D585464-4  Z Ni              U  208 Zh     K8V M5V
+Anitlte       1310 C774000-0    Ba Lo Ni           013 Zh     G1V M3V
 Oievrdaql     1410 D511000-0    Ba Ic Lo Ni        002 Zh     K8V 
-Obrijeefr     1610 C300402-7    Ni Va              306 Zh     M7V M7D 
+Obrijeefr     1610 C300402-7    Ni Va              306 Zh     M7V M7V
 Sibliaflianj  1710 C502000-0    Ba Ic Lo Ni Va     003 Zh     M1V 
 Savrjezhopr   1910 D150497-5  Z De Ni Po           803 Zh     F1V 
-Oatlplekr     2110 D311424-7    Ic Ni              918 Zh     F7V M5D 
+Oatlplekr     2110 D311424-7    Ic Ni              918 Zh     F7V M5V
 Atpie         2210 X6558A6-0                    F  713 Zh     F2V 
-Eiaa          2410 C433432-7    Ni Po              420 Zh     M8III M3D 
-Ribliblidlie  2510 C1009BD-9  Z Hi Na Va           710 Zh     F7D M5D 
-Iansjeqplibl  3210 C534433-6    Ni                 704 Zh     G1V M4D M6D 
+Eiaa          2410 C433432-7    Ni Po              420 Zh     M8III M3V
+Ribliblidlie  2510 C1009BD-9  Z Hi Na Va           710 Zh     F7D M5V
+Iansjeqplibl  3210 C534433-6    Ni                 704 Zh     G1V M4D M6V
 Krienjchtitl  0611 C266874-7    Ri                 302 Zh     M0V 
 Iebret        0911 C4357CD-6                       800 Zh     A8V 
 Qlizhstiadl   1211 C443652-A    Ag Ni Po           702 Zh     F5V 
 Shianjrel     1411 B4839A6-B  Z Hi In              214 Zh     F5V 
-Iblzhiaent    1611 D669436-5    Ni                 904 Zh     F0V M4D 
-Lie'praetl    1711 B552634-9  Z Ni Po              214 Zh     G2V M7D 
+Iblzhiaent    1611 D669436-5    Ni                 904 Zh     F0V M4V
+Lie'praetl    1711 B552634-9  Z Ni Po              214 Zh     G2V M7V
 Ietlzhetl     1811 C597000-0    Ba Lo Ni           010 Zh     F8V 
 Iansansia     2111 C955486-5    Ni                 304 Zh     F0V 
 Eklstej       2411 C669666-6    Ni Ri              901 Zh     F1V 
 Ansetsplobl   2511 E584423-2    Ni                 703 Zh     F1V 
 Vriaqrtiakl   3011 C573552-9  Z Ag Ni              722 Zh     F3V 
-Inedrchech    0312 E444000-0    Ba Lo Ni           002 Zh     F1V M2D 
-Ocha'piach    0712 C695636-7  Z Ag Ni              200 Zh     F5V M0D 
+Inedrchech    0312 E444000-0    Ba Lo Ni           002 Zh     F1V M2V
+Ocha'piach    0712 C695636-7  Z Ag Ni              200 Zh     F5V M0V
 Ealie         0812 C652723-7    Po                 902 Zh     F7V 
-Ifrt          1012 BAD9598-A    Fl Ni              504 Zh     M7V M8D 
+Ifrt          1012 BAD9598-A    Fl Ni              504 Zh     M7V M8V
 A'vetsniaia   1712 B447432-7    Ni                 612 Zh     F9V 
 Efda'         2212 E230403-6    De Ni Po           933 Zh     G3V 
 Lezze         2312 E235000-0    Ba Lo Ni           004 Zh     F1V 
 Fradldrepire  2412 B539558-C    Ni                 600 Zh     M7V 
 Ieprote       2812 A335444-D  Z Ni                 202 Zh     G9V 
-Jdeklchiqr    3012 C664410-6    Ni                 904 Zh     F7V M7D 
-Inzhiachier   3112 C624475-8    Ni                 900 Zh     K5V M3D 
+Jdeklchiqr    3012 C664410-6    Ni                 904 Zh     F7V M7V
+Inzhiachier   3112 C624475-8    Ni                 900 Zh     K5V M3V
 Ababl         0113 E000563-8    As Ni              422 Zh     F1II 
 Prablvrdl     0213 A30079D-E    Na Va              603 Zh     K1V 
 Brafmienj     0313 C234467-A    Ni                 101 Zh     F5V 
 Zdenjjiljiep  0513 C436425-8  Z Ni                 202 Zh     M7V 
 Jdielriash    0613 C572654-9  Z Ni                 801 Zh     F1V 
-Stidrzdepr    1113 C483675-7    Ag Ni Ri           723 Zh     F4V M0D 
+Stidrzdepr    1113 C483675-7    Ag Ni Ri           723 Zh     F4V M0V
 Inchbantsdrl  1213 X6A0000-0    Ba De Lo Ni     F  000 Zh     F9IV 
 Ilchantsvans  1313 E78A872-5    Ri Wa              101 Zh     F1V 
 Ielrieyotl    1913 C769420-5  Z Ni                 123 Zh     F9V 
@@ -198,132 +198,132 @@ Aem           2113 A244500-B  Y Ag Ni              814 Zh     F9V
 Eeze          2213 B542412-6  Z Ni Po              301 Zh     F9V 
 Tariatiapl    2513 C535543-6    Ni                 314 Zh     G7IV M4V 
 Iarozhich     2913 D7859DF-5  Z Hi In           U  623 Zh     F7V 
-Aidr          0314 C546000-0    Ba Lo Ni           014 Zh     F4V K1D 
+Aidr          0314 C546000-0    Ba Lo Ni           014 Zh     F4V K1V
 Fiablpoch     0714 B110684-D  Z Na Ni              113 Zh     F1V 
-Anzeb         1214 B401661-A  Z Ic Na Ni Va        302 Zh     M6V M5D 
+Anzeb         1214 B401661-A  Z Ic Na Ni Va        302 Zh     M6V M5V
 Aplenstla'    1714 C100427-9    Ni Va              613 Zh     K1V 
 Siro          1814 E333000-0    Ba Lo Ni Po        000 Zh     A8V 
 Azobatlen     1914 C130642-8    De Na Ni Po        802 Zh     M3V 
 Zdia'ipia     2014 D585544-3    Ag Ni              104 Zh     G5V 
-Praklzhets    2114 C8A4000-0    Ba Fl Lo Ni        005 Zh     G3V M0D 
-Ste'enz       3214 C889485-8    Ni                 302 Zh     F9V M2D 
-Zhdeflmitsop  0215 C635000-0  Z Ba Lo Ni           023 Zh     M6V M4D 
-Abfladiesh    0315 D689698-2    Ni Ri              307 Zh     M8V M0D 
-Zhdifrzher    1115 C595588-6    Ag Ni              103 Zh     F6V M0D 
-Naklzifen     1615 E310000-0    Ba Lo Ni           014 Zh     G4V M3D 
+Praklzhets    2114 C8A4000-0    Ba Fl Lo Ni        005 Zh     G3V M0V
+Ste'enz       3214 C889485-8    Ni                 302 Zh     F9V M2V
+Zhdeflmitsop  0215 C635000-0  Z Ba Lo Ni           023 Zh     M6V M4V
+Abfladiesh    0315 D689698-2    Ni Ri              307 Zh     M8V M0V
+Zhdifrzher    1115 C595588-6    Ag Ni              103 Zh     F6V M0V
+Naklzifen     1615 E310000-0    Ba Lo Ni           014 Zh     G4V M3V
 Chifipryitl   1815 C988542-6  Z Ag Ni              902 Zh     F5V 
-Aivansh       2115 C475430-8    Ni                 302 Zh     F2V M3D 
+Aivansh       2115 C475430-8    Ni                 302 Zh     F2V M3V
 Zdiazvriv     2215 E639963-A    Hi In              422 Zh     F8V 
 Avezh         2715 C448562-7    Ag Ni              423 Zh     F4V 
-Milaitliets   2915 C593000-0    Ba Lo Ni           004 Zh     K6V M3D 
+Milaitliets   2915 C593000-0    Ba Lo Ni           004 Zh     K6V M3V
 Fra'i         3015 A876773-B  Z Ag                 601 Zh     M8V 
-Enzdaa        0416 CAD6968-A    Fl Hi In           204 Zh     G9V M8D 
+Enzdaa        0416 CAD6968-A    Fl Hi In           204 Zh     G9V M8V
 Ieeodlyipr    0616 A797766-C  Z Ag                 403 Zh     F7V 
-Zhdialitl     1116 C888554-6  Z Ag Ni              802 Zh     G0V M1D 
-Qrisheiae     2016 E638452-7    Ni                 406 Zh     M1V M0D 
-Itzhinshnia   2116 A362521-C  Z Ni                 724 Zh     F5V M7D 
+Zhdialitl     1116 C888554-6  Z Ag Ni              802 Zh     G0V M1V
+Qrisheiae     2016 E638452-7    Ni                 406 Zh     M1V M0V
+Itzhinshnia   2116 A362521-C  Z Ni                 724 Zh     F5V M7V
 Chtili        2416 B100887-C    Na Va           U  900 Zh     G1V 
-Idriedriie    2916 B300847-A  Z Na Va              206 Zh     F4D M1D 
+Idriedriie    2916 B300847-A  Z Na Va              206 Zh     F4D M1V
 Eshibr        3216 C110462-B    Ni                 401 Zh     F5V 
 Aqltsizh      0117 C9B5000-0  Z Ba Fl Lo Ni        004 Zh     M1V 
 Iaa           0417 C585625-8  Z Ag Ni              714 Zh     F5V M4V 
 Elzdibl       0917 C575678-5    Ag Ni              631 Zh     K5V 
-Eljetl        1117 B442532-B    Ni Po           U  303 Zh     F1V M7D 
+Eljetl        1117 B442532-B    Ni Po           U  303 Zh     F1V M7V
 Zdilrtlchiaj  1517 E242666-5    Ni Po              503 Zh     G7V 
 I'iezh        1617 E454400-7    Ni                 703 Zh     F1V 
 Vlonsiaiaj    1717 B355478-A  Z Ni                 721 Zh     F6V 
-E'aie         1817 D7C1000-0    Ba Fl Lo Ni        002 Zh     M5V M8D 
-Iebrplajez    2117 B977467-A  Z Ni                 103 Zh     M6V M8D 
-Chikiaqiavr   3017 C325421-9    Ni                 326 Zh     F5V M5D 
+E'aie         1817 D7C1000-0    Ba Fl Lo Ni        002 Zh     M5V M8V
+Iebrplajez    2117 B977467-A  Z Ni                 103 Zh     M6V M8V
+Chikiaqiavr   3017 C325421-9    Ni                 326 Zh     F5V M5V
 Zattiente     3217 CAF7A89-C    Fl Hi In           522 Zh     F0V 
-Ao            0118 C88A644-7    Ni Ri Wa        U  305 Zh     F5V M0D 
-Efrdiek       0218 C883677-3    Ag Ni Ri           915 Zh     K9V M0D 
-Adrdiafbriad  0418 E9A4000-0    Ba Fl Lo Ni        015 Zh     G3V M5D 
+Ao            0118 C88A644-7    Ni Ri Wa        U  305 Zh     F5V M0V
+Efrdiek       0218 C883677-3    Ag Ni Ri           915 Zh     K9V M0V
+Adrdiafbriad  0418 E9A4000-0    Ba Fl Lo Ni        015 Zh     G3V M5V
 Krelashit     0518 B200444-D    Ni Va              124 Zh     G1V 
-Ni'enz        0618 C64A878-5  Z Wa                 304 Zh     G7V M3D 
-Ilashdriavr   0718 E200ABC-8    Hi Na Va           700 Zh     F7D 
+Ni'enz        0618 C64A878-5  Z Wa                 304 Zh     G7V M3V
+Ilashdriavr   0718 E200ABC-8    Hi Na Va           700 Zh     F7V
 Iial          1118 E5009CF-7    Hi Na Va           215 Zh     F2V 
-Praiebrip     1418 B211430-A  Z Ic Ni              313 Zh     F3V M4D 
-Iaikl         1718 B9768BD-A  Z                    116 Zh     F7V M5D 
-Iaanchzdiedl  2518 E424442-7    Ni                 813 Zh     G3V M6D 
-Itlad         2618 C6A5486-9  Z Fl Ni              701 Zh     F9V M4D 
+Praiebrip     1418 B211430-A  Z Ic Ni              313 Zh     F3V M4V
+Iaikl         1718 B9768BD-A  Z                    116 Zh     F7V M5V
+Iaanchzdiedl  2518 E424442-7    Ni                 813 Zh     G3V M6V
+Itlad         2618 C6A5486-9  Z Fl Ni              701 Zh     F9V M4V
 Choflzdets    2818 C300545-A    Ni Va              104 Zh     M6V 
-Azhefzhdokl   2918 C555677-3    Ag Ni              702 Zh     F6V M3D 
-Iaieie        3118 B42547A-A  Z Ni                 101 Zh     M1V M5D 
+Azhefzhdokl   2918 C555677-3    Ag Ni              702 Zh     F6V M3V
+Iaieie        3118 B42547A-A  Z Ni                 101 Zh     M1V M5V
 Brieplrni     0319 E100450-7    Ni Va              401 Zh     F4V 
-Shirkablniap  0419 E303410-8    Ic Ni Va           700 Zh     M0V M0D 
+Shirkablniap  0419 E303410-8    Ic Ni Va           700 Zh     M0V M0V
 Chierfl       0619 C648553-8  Z Ag Ni              413 Zh     F6V F6V 
 Jaflatl       0719 D140000-0  Z Ba De Lo Ni Po     003 Zh     F5V 
-Eientdliar    1119 E364424-4    Ni              U  803 Zh     F4V M0D 
+Eientdliar    1119 E364424-4    Ni              U  803 Zh     F4V M0V
 Kleliashfefr  1319 C756996-A    Hi In              200 Zh     F4V 
-Ii            1519 C9D6666-8    Fl Ni              425 Zh     M4V M2D 
+Ii            1519 C9D6666-8    Fl Ni              425 Zh     M4V M2V
 Siarpledr     2019 C410545-8  Z Ni                 102 Zh     K0V 
 Iklzhdel      2119 C888416-8    Ni                 504 Zh     F0V 
 Shtateienj    2219 C5577B9-8    Ag                 211 Zh     F2V 
-Platliash     2419 B454540-C    Ag Ni              801 Zh     F5V M3D 
+Platliash     2419 B454540-C    Ag Ni              801 Zh     F5V M3V
 Zheblal       2719 B865455-7    Ni                 203 Zh     F0V 
 Yiefrablatl   2819 C765615-8  Z Ag Ni              902 Zh     M4V 
-Bliavzhats    3019 C563448-6    Ni                 516 Zh     F2V M2D 
+Bliavzhats    3019 C563448-6    Ni                 516 Zh     F2V M2V
 Yoni          0620 A474467-C    Ni                 404 Zh     F8V 
 Ieapratl      0720 C100000-0  Z Ba Lo Ni Va        008 Zh     M2V M7V M0V 
-Viezdiernol   0820 C000798-B  Z As Na              400 Zh     M2V M4D 
+Viezdiernol   0820 C000798-B  Z As Na              400 Zh     M2V M4V
 Etlplibrfaf   1220 A464435-E    Ni                 104 Zh     G7V 
-Prianaf       1520 XA99000-0    Ba Lo Ni        F  003 Zh     F3V M7D 
-Eziait        1920 B538755-9                    U  213 Zh     M5III M8D 
-Eshtiatle     2220 D434433-7    Ni                 207 Zh     M4V M1D 
+Prianaf       1520 XA99000-0    Ba Lo Ni        F  003 Zh     F3V M7V
+Eziait        1920 B538755-9                    U  213 Zh     M5III M8V
+Eshtiatle     2220 D434433-7    Ni                 207 Zh     M4V M1V
 Blietlitl     2520 E636000-0    Ba Lo Ni           005 Zh     M1V M3V 
 Edlstabr      2920 B83A444-9    Ni Wa              302 Zh     M2V 
 Ije           3020 B100423-A    Ni Va              603 Zh     M0V 
-Iechtif       0121 C514000-0    Ba Ic Lo Ni        004 Zh     F3IV M6D 
+Iechtif       0121 C514000-0    Ba Ic Lo Ni        004 Zh     F3IV M6V
 Dantsqronze   0321 B96A489-B  Z Ni Wa              502 Zh     F9V 
-Iavrr         0521 A549876-9  Z                    102 Zh     F6V M3D 
+Iavrr         0521 A549876-9  Z                    102 Zh     F6V M3V
 Shtiebla      0921 A421400-E  Z Ni Po              303 Zh     M8V 
 Achtieq       1121 E348000-0    Ba Lo Ni           003 Zh     M7V 
 Edlanjzhezh   1421 X528000-0    Ba Lo Ni        F  001 Zh     F7V 
-Blinjeia      1621 E545000-0    Ba Lo Ni        U  002 Zh     F8V M4D 
-Zhievlilia    1721 C33578B-7  Z                    602 Zh     F9V M4D 
-Zhdieredians  1921 A66747A-9    Ni                 510 Zh     K4V M1D 
+Blinjeia      1621 E545000-0    Ba Lo Ni        U  002 Zh     F8V M4V
+Zhievlilia    1721 C33578B-7  Z                    602 Zh     F9V M4V
+Zhdieredians  1921 A66747A-9    Ni                 510 Zh     K4V M1V
 Drakldli'     2221 A500440-D    Ni Va              412 Zh     F6V 
-Edrkrazh      2421 D665484-6  Z Ni                 404 Zh     G2V M5V M5D 
+Edrkrazh      2421 D665484-6  Z Ni                 404 Zh     G2V M5V M5V
 Driplshtol    2521 C564468-8    Ni                 805 Zh     G9V 
-Eal           2721 B526643-A    Ni                 225 Zh     M7V M4D 
+Eal           2721 B526643-A    Ni                 225 Zh     M7V M4V
 Zhdashensh    0222 B110644-C    Na Ni              113 Zh     M5V 
 Narrkizh      0722 A8B6430-A  Z Fl Ni              826 Zh     A9V M2V 
 Eplzhach      0822 D778000-0    Ba Lo Ni           010 Zh     F3V 
 A'jiafr       1222 C464522-A    Ag Ni              433 Zh     F5V 
-Chetliante    1622 C140442-A    De Ni Po           514 Zh     K3V M5D 
+Chetliante    1622 C140442-A    De Ni Po           514 Zh     K3V M5V
 Rinzhdieets   1722 E130423-8    De Ni Po           901 Zh     M6V 
 Jdishseeiavr  1822 B404898-8    Ic Va              404 Zh     F7V 
 Shiafliats    2022 C100585-9  Z Ni Va              504 Zh     M7V 
 Ekradr        2622 CAB98B8-9  Z Fl                 424 Zh     G2V 
 Ibltedr       0623 C55368A-7    Ag Ni Po           800 Zh     K9V 
-Iepldriantie  0723 A43356B-C    Ni Po              304 Zh     M5V M1D 
+Iepldriantie  0723 A43356B-C    Ni Po              304 Zh     M5V M1V
 Pejrnzielrfl  0923 E575000-0    Ba Lo Ni           003 Zh     F3V 
 Dranshia      1123 C615679-7    Ic Ni              515 Zh     M5V K2V 
 Antjaqr       1423 C4319AA-9  Z Hi In Na Po        604 Zh     K4V 
 Eyiiafr       1623 A150854-D  Z De Po              310 Zh     F9V 
 Flarebrvif    1723 C130498-C  Z De Ni Po           602 Zh     K5V 
 Iiatlsti'per  2023 A7569A9-E  Z Hi In              204 Zh     F1V 
-Biansdiiakl   2223 D405443-7    Ic Ni Va           305 Zh     M0V M7D 
+Biansdiiakl   2223 D405443-7    Ic Ni Va           305 Zh     M0V M7V
 Pitietl       2323 A86A631-A  Z Ni Wa              604 Zh     G3V 
 Ievrejdiedl   2723 C998976-7    Hi In              904 Zh     F1V 
-Enshviakr     0324 A562474-8  Z Ni                 105 Zh     F5V M4D 
+Enshviakr     0324 A562474-8  Z Ni                 105 Zh     F5V M4V
 Jdepre        0424 C150445-B  Z De Ni Po           634 Zh     G9V 
 Krrjiea       1024 C426400-7    Ni                 123 Zh     F1V 
 Iarjdallash   1124 C120744-9    De Na Po           304 Zh     K1V 
 Eepr          1724 C664734-3    Ag                 701 Zh     F2V 
-Etlinch       1824 CAD8769-8    Fl                 113 Zh     F3V M8D 
+Etlinch       1824 CAD8769-8    Fl                 113 Zh     F3V M8V
 Drovi'        2524 D681451-4    Ni                 812 Zh     F4V 
 Riemshiebr    2724 X553AED-2    Hi In Po        F  515 Zh     K0V 
 Entplens      3124 B222454-D  Z Ni Po              700 Zh     M7V 
 Nililvirzid   0125 C367400-A    Ni                 905 Zh     K0V 
-Eplyilchtar   0225 A642420-D    Ni Po              821 Zh     F6V M4D 
+Eplyilchtar   0225 A642420-D    Ni Po              821 Zh     F6V M4V
 Ibe           0825 C00047A-7    As Ni              310 Zh     M6V 
 Aprenzh       0925 C220457-C    De Ni Po           400 Zh     M4V 
-Idral         1025 C40255A-A    Ic Ni Va           700 Zh     M4V M2D 
+Idral         1025 C40255A-A    Ic Ni Va           700 Zh     M4V M2V
 Ieablfifr     1625 C646A86-A  Z Hi In              523 Zh     F7V 
-Ieasets       1725 A655552-B  Z Ag Ni              811 Zh     F6V M6D 
-Iashefezh     1925 C545567-6  Z Ag Ni              716 Zh     F4V M4D 
+Ieasets       1725 A655552-B  Z Ag Ni              811 Zh     F6V M6V
+Iashefezh     1925 C545567-6  Z Ag Ni              716 Zh     F4V M4V
 Chtienia      2225 E641000-0    Ba Lo Ni Po        003 Zh     F5V 
 Sedriepr      2325 C427000-0  Z Ba Lo Ni           001 Zh     M3II 
 Ieklpriatl    0126 B357532-C  Z Ag Ni              403 Zh     M4V 
@@ -331,60 +331,60 @@ Ebiafriash    0626 C646733-6    Ag                 722 Zh     F8V
 Verjianch     0926 D9A8402-8    Fl Ni              103 Zh     G5V 
 Ienchial      1226 E262443-3    Ni                 905 Zh     G7V 
 Inshchens     1426 C110586-9    Ni                 202 Zh     M0V 
-Shiatlatlti   1626 A340489-D    De Ni Po           802 Zh     F4V M4D 
+Shiatlatlti   1626 A340489-D    De Ni Po           802 Zh     F4V M4V
 Iedlaklkop    1926 X400000-0    Ba Lo Ni Va     F  003 Zh     M7V 
 Shtekliaizh   2126 C657ABE-8    Hi In              200 Zh     M3V 
-Droklieof     2726 E120587-9    De Ni Po        U  802 Zh     M8V M3D 
+Droklieof     2726 E120587-9    De Ni Po        U  802 Zh     M8V M3V
 Idlancheoe    3226 E321000-0    Ba Lo Ni Po        024 Zh     G0V 
 Ivoprej       0127 E778864-5                       704 Zh     G1V 
-Alebiatl      0227 C6529A8-A    Hi In Po           224 Zh     G9V M0D 
-Daplqrebl     0327 C35579A-5    Ag                 105 Zh     F2V M8D 
+Alebiatl      0227 C6529A8-A    Hi In Po           224 Zh     G9V M0V
+Daplqrebl     0327 C35579A-5    Ag                 105 Zh     F2V M8V
 Anjzdobri     0427 C7A5000-0  Z Ba Fl Lo Ni     U  021 Zh     F1V 
-Ashapchiedr   0727 C448500-8    Ag Ni              617 Zh     F3V M0D M7D 
+Ashapchiedr   0727 C448500-8    Ag Ni              617 Zh     F3V M0D M7V
 Ajapdriabl    0827 C426000-0    Ba Lo Ni           024 Zh     K9V 
-Ieltrrfrefle  1327 B7A1500-8  Z Fl Ni              704 Zh     G5V M2D 
+Ieltrrfrefle  1327 B7A1500-8  Z Fl Ni              704 Zh     G5V M2V
 Jetssob       1727 D5A2000-0    Ba Fl Lo Ni        011 Zh     M1V 
 Diekryadr     1927 E797000-0    Ba Lo Ni        U  000 Zh     F3V 
-Echriedr      2127 C788866-5    Ri                 126 Zh     F2V M7D 
-Echedr        2527 X79AA98-7    Hi In Wa        F  911 Zh     F9V M1D 
+Echriedr      2127 C788866-5    Ri                 126 Zh     F2V M7V
+Echedr        2527 X79AA98-7    Hi In Wa        F  911 Zh     F9V M1V
 Aprejef       2627 E110463-8    Ni                 115 Zh     F6V 
-Ifdaklzhiqr   2827 D000410-A  Z As Ni              202 Zh     M7V M6D 
+Ifdaklzhiqr   2827 D000410-A  Z As Ni              202 Zh     M7V M6V
 Siefreansh    2927 C437968-7  Z Hi In              501 Zh     F9V 
 Dadtatletl    3027 C542000-0    Ba Lo Ni Po        003 Zh     F7V 
 Shiejia       3227 C5A0000-0    Ba De Lo Ni        020 Zh     M6V 
-Atsyildrant   0328 B525466-9  Z Ni                 715 Zh     K2V M4D 
+Atsyildrant   0328 B525466-9  Z Ni                 715 Zh     K2V M4V
 Astifr        0928 C130453-B  Z De Ni Po           702 Zh     M3V 
-Jodrjdedr     1028 AA8A487-E    Ni Wa              502 Zh     F6V M2D 
+Jodrjdedr     1028 AA8A487-E    Ni Wa              502 Zh     F6V M2V
 Kilsae        1228 C886446-5    Ni                 200 Zh     F2V 
-Piziedbiabl   1428 C657440-6  Z Ni                 911 Zh     F3V M6D 
+Piziedbiabl   1428 C657440-6  Z Ni                 911 Zh     F3V M6V
 Shanze        1628 C130432-A    De Ni Po           723 Zh     K3V 
 Iarchrsh      1828 A334540-E  Z Ni                 904 Zh     M4V 
 Atlstapl      2228 BAB5752-A    Fl              U  403 Zh     M8V 
-Shtienzir     0229 D533000-0    Ba Lo Ni Po        002 Zh     M1V M2D 
+Shtienzir     0229 D533000-0    Ba Lo Ni Po        002 Zh     M1V M2V
 Able          1229 A6A2696-C  Z Fl Ni              404 Zh     M2V 
 Edianiaplev   1329 A443674-C    Ag Ni Po           812 Zh     F9V 
 Doprebljiepr  1729 E302000-0    Ba Ic Lo Ni Va     003 Zh     M1V M5V 
-Azhan         2029 C8B3000-0    Ba Fl Lo Ni        003 Zh     G7V M4D 
+Azhan         2029 C8B3000-0    Ba Fl Lo Ni        003 Zh     G7V M4V
 Epieblesh     2829 E8B1000-0    Ba Fl Lo Ni     U  003 Zh     M7V 
 I'staqi       3129 C664435-5    Ni                 314 Zh     F9V 
 Ielpladl      3229 C301557-A    Ic Ni Va        U  311 Zh     F7V 
-Jdiazhie      0130 C7B2987-A    Fl Hi In           405 Zh     F6V M3D 
-Ebriklribr    0230 C899987-A    Hi In              814 Zh     K3V M6D 
+Jdiazhie      0130 C7B2987-A    Fl Hi In           405 Zh     F6V M3V
+Ebriklribr    0230 C899987-A    Hi In              814 Zh     K3V M6V
 Chaprjedl     0330 E370477-8    De Ni           U  503 Zh     F2V 
 Tanieie       0530 B9B3400-A    Fl Ni              303 Zh     F8V 
-Ieshredl      0930 C784452-7    Ni                 105 Zh     F9V M8D 
-Dla'dlavr     1030 B491466-7    Ni                 933 Zh     F2V M0D 
+Ieshredl      0930 C784452-7    Ni                 105 Zh     F9V M8V
+Dla'dlavr     1030 B491466-7    Ni                 933 Zh     F2V M0V
 Tiaklri       1330 C302000-0    Ba Ic Lo Ni Va     002 Zh     M6II 
-Dreqishtla    1530 B464767-A    Ag Ri              501 Zh     G5V M6D 
+Dreqishtla    1530 B464767-A    Ag Ri              501 Zh     G5V M6V
 Jdontabea     2530 C110421-B  Z Ni                 503 Zh     G2V 
 Esanch        2630 B766766-A    Ag Ri              903 Zh     M4V 
-Blatlensh     0131 C373577-6  Z Ag Ni              207 Zh     F9V M5D 
+Blatlensh     0131 C373577-6  Z Ag Ni              207 Zh     F9V M5V
 Adobl         0831 D1008BD-9  Z Na Va              301 Zh     F5V 
-Enzipltir     1231 C435536-B    Ni                 204 Zh     M1V M0D 
-Intfra        1631 D73A420-7  Z Ni Wa           U  612 Zh     K5V M5D 
-Iero          1931 E223000-0    Ba Lo Ni Po     U  012 Zh     M6V M1D 
+Enzipltir     1231 C435536-B    Ni                 204 Zh     M1V M0V
+Intfra        1631 D73A420-7  Z Ni Wa           U  612 Zh     K5V M5V
+Iero          1931 E223000-0    Ba Lo Ni Po     U  012 Zh     M6V M1V
 Staqrdlach    2131 D7B3000-0    Ba Fl Lo Ni        020 Zh     G2II 
-Sinskobro     2431 C240465-A    De Ni Po           202 Zh     F4V M5D 
+Sinskobro     2431 C240465-A    De Ni Po           202 Zh     F4V M5V
 Nianzechensh  2931 C886878-6    Ri                 502 Zh     F5V 
 Enzhdriqr     3231 CAA2511-8    Fl Ni              822 Zh     M6V 
 Fliezant      0332 C235446-B    Ni                 700 Zh     M3V 
@@ -394,51 +394,51 @@ Driavbrotl    0832 B561766-6  Z Ri                 303 Zh     F9V M4D F9V
 Adlots        0932 D62A411-7    Ni Wa              503 Zh     M7V 
 Sievlapr      1132 B522467-8  Z Ni Po              723 Zh     F7IV 
 Iantsariaint  1232 E788466-5    Ni                 300 Zh     F2V 
-Vriadiant     1332 C97A411-8    Ni Wa              513 Zh     F9V M1D 
+Vriadiant     1332 C97A411-8    Ni Wa              513 Zh     F9V M1V
 Iajzhditl     1432 D565633-2    Ag Ni              302 Zh     F9V 
 Ieflaprdebl   1532 D9A4000-0    Ba Fl Lo Ni     U  002 Zh     M3V 
-Tlrklolinsoj  3232 B341523-A  Z Ni Po              204 Zh     M5V M1D 
-Aplpia        0233 D647774-6    Ag                 200 Zh     F0V M5D 
-Stieriebr     0433 C000422-8    As Ni              705 Zh     M4V M2D 
+Tlrklolinsoj  3232 B341523-A  Z Ni Po              204 Zh     M5V M1V
+Aplpia        0233 D647774-6    Ag                 200 Zh     F0V M5V
+Stieriebr     0433 C000422-8    As Ni              705 Zh     M4V M2V
 Klianschtie   0933 C445477-5    Ni                 801 Zh     F9V 
 Seklchted     1033 D72A765-8    Wa                 213 Zh     M1V 
-Chteqjedr     1933 C8A0678-9    De Ni              700 Zh     M0V M3D 
-Driebrjebr    2733 E444876-6                       412 Zh     F6V M4D 
-Aiaj          3133 B468579-7    Ag Ni              403 Zh     G0V M3D 
-Bebldiiets    0334 E9B4511-8    Fl Ni              416 Zh     G1V M7D 
+Chteqjedr     1933 C8A0678-9    De Ni              700 Zh     M0V M3V
+Driebrjebr    2733 E444876-6                       412 Zh     F6V M4V
+Aiaj          3133 B468579-7    Ag Ni              403 Zh     G0V M3V
+Bebldiiets    0334 E9B4511-8    Fl Ni              416 Zh     G1V M7V
 Ejianzh       0534 E888875-3    Ri                 512 Zh     K3V 
 Zelejtie      0634 B524422-B  Z Ni                 203 Zh     M5V 
-Eapldlestir   0734 C889779-4    Ri              U  812 Zh     F6V M6D 
-Sidrdiaie     0934 C577832-7                       435 Zh     F4V G7V M3D 
-Tabrzhitzdia  1134 C737484-6    Ni                 605 Zh     M0V M3D 
+Eapldlestir   0734 C889779-4    Ri              U  812 Zh     F6V M6V
+Sidrdiaie     0934 C577832-7                       435 Zh     F4V G7V M3V
+Tabrzhitzdia  1134 C737484-6    Ni                 605 Zh     M0V M3V
 Aipldlenj     1234 C673445-5    Ni                 903 Zh     F6V 
 Iatlar        1334 C758497-6    Ni                 611 Zh     F2V 
 Chtiplchtadl  1534 C996532-7    Ag Ni              104 Zh     F6V 
 Ekrniebia     1634 C876000-0  Z Ba Lo Ni           013 Zh     F8V 
 Iakiltakr     1734 B653556-A    Ag Ni Po           710 Zh     F2V 
-Jatsripl      2734 C211444-7  Z Ic Ni              604 Zh     M6V M1D 
+Jatsripl      2734 C211444-7  Z Ic Ni              604 Zh     M6V M1V
 Chtenjiatse   3034 C7A299B-9    Fl Hi In           905 Zh     F2V 
 Iklzhdevl     0135 C410886-A    Na                 504 Zh     F6V 
 Beshitia      0435 E946463-7    Ni                 612 Zh     F2V 
-Keqbie'       0535 C666647-7    Ag Ni Ri        U  304 Zh     F3V M2D 
+Keqbie'       0535 C666647-7    Ag Ni Ri        U  304 Zh     F3V M2V
 Patshel       0735 A311411-E  Z Ic Ni              903 Zh     A2IV 
-Zhdialiaianj  0935 D647975-8    Hi In              202 Zh     F9V M6D 
+Zhdialiaianj  0935 D647975-8    Hi In              202 Zh     F9V M6V
 Voshiapr      1035 E869547-4    Ni                 204 Zh     F5V 
-Vientanz      1735 B302675-8  Z Ic Na Ni Va        625 Zh     M8V M6D 
+Vientanz      1735 B302675-8  Z Ic Na Ni Va        625 Zh     M8V M6V
 Chtiflkat     1835 C8C8556-A    Fl Ni              104 Zh     M2V 
-Viadlbrints   2135 E7A2000-0    Ba Fl Lo Ni        003 Zh     M1V M2D 
+Viadlbrints   2135 E7A2000-0    Ba Fl Lo Ni        003 Zh     M1V M2V
 Dansinzdlaf   2835 BAC6465-9    Fl Ni              202 Zh     M5V 
 Zhedzarchebr  3135 B88A9BA-A  Z Hi In Wa           512 Zh     F0V 
 Zhdedipens    0136 C130422-A  Z De Ni Po        U  517 Zh     G8V M3V 
-Vekrier       0436 C537668-7    Ni                 500 Zh     M8V M6D 
-Apeshprent    0536 C77A410-A    Ni Wa              606 Zh     M8V M1D 
+Vekrier       0436 C537668-7    Ni                 500 Zh     M8V M6V
+Apeshprent    0536 C77A410-A    Ni Wa              606 Zh     M8V M1V
 Vrietlchajel  1336 D203000-0  Z Ba Ic Lo Ni Va     034 Zh     M2V M1V 
-Biarchalo     2136 C5358BG-7  Z                    416 Zh     F7V M2D 
-Avone         2236 C543000-0    Ba Lo Ni Po        014 Zh     K7V M4D 
-Ofraladetl    2536 C40296A-A    Hi Ic Na Va        405 Zh     F6V M4D 
-Ii            2636 E697000-0    Ba Lo Ni           002 Zh     F2V M4D 
+Biarchalo     2136 C5358BG-7  Z                    416 Zh     F7V M2V
+Avone         2236 C543000-0    Ba Lo Ni Po        014 Zh     K7V M4V
+Ofraladetl    2536 C40296A-A    Hi Ic Na Va        405 Zh     F6V M4V
+Ii            2636 E697000-0    Ba Lo Ni           002 Zh     F2V M4V
 Ratlkid       3136 C8B2000-0    Ba Fl Lo Ni        004 Zh     M4V 
-Jieqladzhdor  0237 C300434-9    Ni Va              606 Zh     M1V M7D 
+Jieqladzhdor  0237 C300434-9    Ni Va              606 Zh     M1V M7V
 Iadripl       0637 C858437-6    Ni                 404 Zh     G7V 
 Fida          0837 C598463-9    Ni                 502 Zh     G2V 
 Iade          1137 B410435-D    Ni                 904 Zh     G4V M8V 
@@ -447,44 +447,44 @@ Itlsinji'     1837 D9A5459-8    Fl Ni              911 Zh     G3V
 Piebflefatl   2037 E898553-7    Ag Ni              613 Zh     F0V 
 Jrqiaenzpiqr  2137 CAC4000-0    Ba Fl Lo Ni        001 Zh     M7V 
 Venzha        2337 B120467-C  Z De Ni Po           400 Zh     F2V 
-Fiense        2737 E664956-4    Hi In           U  723 Zh     F8V M0D 
+Fiense        2737 E664956-4    Hi In           U  723 Zh     F8V M0V
 Brievltliabl  0138 D664440-2  Z Ni                 200 Zh     F1V 
 Bieprvrapr    0238 A212551-E  Z Ic Ni              413 Zh     F9V 
 Ebranie       0338 C490669-8    De Ni              102 Zh     F1V 
 Ietliadryebr  0538 X375000-0    Ba Lo Ni        F  005 Zh     M0V 
-Ponshia       0638 C7B1000-0    Ba Fl Lo Ni        003 Zh     A0IV M2D M8V M8D 
-Fachdrent     1038 E459755-5                       402 Zh     K8V M8D 
-Jiejebr       1238 C997400-6    Ni                 816 Zh     G3V M6D 
+Ponshia       0638 C7B1000-0    Ba Fl Lo Ni        003 Zh     A0IV M2D M8V M8V
+Fachdrent     1038 E459755-5                       402 Zh     K8V M8V
+Jiejebr       1238 C997400-6    Ni                 816 Zh     G3V M6V
 Zaprienchiae  1338 C657888-5  Z                    710 Zh     F7V 
 Chifraklibre  1438 B9D1411-A  Z Fl Ni              802 Zh     F2V 
 Zhdanshianch  1838 A263585-C  Z Ag Ni              703 Zh     F1V 
-Stalpiel      2138 A857544-B    Ag Ni              203 Zh     F1V M8D 
+Stalpiel      2138 A857544-B    Ag Ni              203 Zh     F1V M8V
 Brezvenzhans  2238 C574423-5  Z Ni                 405 Zh     F6V 
 Estiblfiesh   2838 C15089B-9  Z De Po              413 Zh     F9V 
 Tlonsestivr   3038 E546955-6    Hi In              400 Zh     F3V 
 Jielblafchaj  3138 E400466-8    Ni Va              500 Zh     M1V 
 Itsipiazekr   0139 C7B6000-0  Z Ba Fl Lo Ni     U  007 Zh     M0V M8V 
-Plevlchiebr   0239 C728400-9    Ni                 502 Zh     M8V M7D 
+Plevlchiebr   0239 C728400-9    Ni                 502 Zh     M8V M7V
 Elpriva       0839 C110446-B    Ni                 224 Zh     F5V 
 Apla          0939 B647449-8  Z Ni                 923 Zh     F4V 
 Drechiaqenz   1039 B410462-A    Ni                 301 Zh     M2V 
 Iiashie       1139 C9D7620-6  Z Fl Ni              303 Zh     M5V 
 Nidrjdiliabr  1339 B659432-8    Ni                 903 Zh     F9V 
-Qlienzabl     1539 C97A8A7-5    Wa                 918 Zh     F9V M7D 
-Verdliakl     1739 C795577-5    Ag Ni              316 Zh     K2V M0D 
+Qlienzabl     1539 C97A8A7-5    Wa                 918 Zh     F9V M7V
+Verdliakl     1739 C795577-5    Ag Ni              316 Zh     K2V M0V
 Ieblidrdlib   2239 C778775-5    Ag                 603 Zh     F9V 
-Ilets         2439 C447452-7    Ni                 316 Zh     G1V M2D 
+Ilets         2439 C447452-7    Ni                 316 Zh     G1V M2V
 Estekl        3039 C220451-7    De Ni Po           924 Zh     G7III 
-Viervedranz   3139 C455442-6    Ni                 806 Zh     F9V M2D 
+Viervedranz   3139 C455442-6    Ni                 806 Zh     F9V M2V
 Ebra          0340 X54A9BA-5    Hi In Wa        F  723 Zh     F0V 
-Niepravr      0540 DA98000-0    Ba Lo Ni           013 Zh     F7V M3D 
-Zieblji       0640 C988898-3    Ri              U  811 Zh     F6V M0D 
-Iavrpiliepl   0740 D440420-7  Z De Ni Po           203 Zh     F4V M7D 
+Niepravr      0540 DA98000-0    Ba Lo Ni           013 Zh     F7V M3V
+Zieblji       0640 C988898-3    Ri              U  811 Zh     F6V M0V
+Iavrpiliepl   0740 D440420-7  Z De Ni Po           203 Zh     F4V M7V
 Zajinianj     0840 C615468-8  Z Ic Ni              803 Zh     G3V 
-Iejiaddevr    1140 C887ACB-C    Hi In              234 Zh     F1V M4D 
+Iejiaddevr    1140 C887ACB-C    Hi In              234 Zh     F1V M4V
 Ieazienzh     1740 B625658-7  Z Ni                 502 Zh     M7V M3V 
 Etievrianch   1940 E8877BG-2    Ag                 602 Zh     F1V 
-Eshvajel      2440 C527485-8    Ni                 701 Zh     G3V M2D 
+Eshvajel      2440 C527485-8    Ni                 701 Zh     G3V M2V
 Chansiklatli  2540 C576513-9    Ag Ni              801 Zh     M7V 
 Sierfiens     2840 A242479-B  Z Ni Po              900 Zh     K8V 
 Blitlchap     3140 A685479-A    Ni                 200 Zh     F0V 

--- a/res/Sectors/M1105/Gzaekfueg.sec
+++ b/res/Sectors/M1105/Gzaekfueg.sec
@@ -21,84 +21,84 @@ Gzaekfueg
 #--------1---------2---------3---------4---------5---------6---
 #PlanetName   Loc. UPP Code   B   Notes         Z  PBG Al LRX *
 #----------   ---- ---------  - --------------- -  --- -- --- -
-Kedanksek     0501 D79689C-3                       802 Ve     F6V M7D
+Kedanksek     0501 D79689C-3                       802 Ve     F6V M7V
 Ksikhsoloug   0601 AAD8625-B  G Fl Ni              300 Ve     K7V
 Gvaengfadz    0701 C412620-6    Ic Na Ni           510 Ve     F1V
 Douzaaeks     0801 E968475-6    Ni                 312 V5     F9V
 Urzokhurz     1101 C453456-A  G Ni Po              204 Va     G5V
 Kuzoevo       1201 E426978-8    Hi In              103 Va     F8V
-Faeksugh      1501 E300234-7    Lo Ni Va           823 VG     M8D M3D
+Faeksugh      1501 E300234-7    Lo Ni Va           823 VG     M8D M3V
 Dzekseghzaek  1601 A589310-7    Lo Ni              420 VG     F1V
-Taeurrael     1701 C989876-4                       914 VG     F9V M7D
+Taeurrael     1701 C989876-4                       914 VG     F9V M7V
 Gori          1901 B400269-7    Lo Ni Va           411 VG     M4V M6V
-Kfoeaengknen  2101 C578120-5    Lo Ni              618 VG     K3V M2D
-Daeakh        2801 E676610-1    Ag Ni              220 Va     F5V M3D
+Kfoeaengknen  2101 C578120-5    Lo Ni              618 VG     K3V M2V
+Daeakh        2801 E676610-1    Ag Ni              220 Va     F5V M3V
 Aekksakhazo   0102 C230211-7  G De Lo Ni Po        401 Ve     M0V
 Gotsaedz      0902 C1609CD-7  G De Hi In           302 V5     F7V
 Kurrouta      1002 D450673-4  G De Ni Po           302 V5     F0V
 Dhongvoudz    1402 C8B5554-8    Fl Ni              703 V5     K2V
 Kseka         1602 C521654-7    Na Ni Po           213 VG     F2V M3V
-Gougnuez      2102 C66A667-9  C Ni Ri Wa           205 VG     F4V M3D
+Gougnuez      2102 C66A667-9  C Ni Ri Wa           205 VG     F4V M3V
 Ozon          2302 B240978-D  C De Hi In Po        303 VG     G7V
-Kfelaelung    2402 B784856-9  G Ri                 308 VG     M0V M3D
+Kfelaelung    2402 B784856-9  G Ri                 308 VG     M0V M3V
 Aka           2802 C330A79-9  G De Hi In Na Po     801 Va     F2V
 Vuvikou       0603 A351438-D    Ni Po              405 V5     F6V
-Kfokfukdae    0703 C473303-8    Lo Ni              307 V5     G5V M8D
-Arzanngaer    1403 B200766-6  G Na Va              102 V5     M1V M4D
+Kfokfukdae    0703 C473303-8    Lo Ni              307 V5     G5V M8V
+Arzanngaer    1403 B200766-6  G Na Va              102 V5     M1V M4V
 Rekhoghoekh   1703 A659477-C  G Ni                 512 VG     G9V
 Tsuroeks      2203 C74A234-8    Lo Ni Wa           503 VG     F9V
 Ulegz         2503 D210400-8    Ni                 104 VG     K0V
-Ghatoets      2803 A566369-A    Lo Ni              912 Va     F6V M5D
+Ghatoets      2803 A566369-A    Lo Ni              912 Va     F6V M5V
 Aersaedh      3203 D9A6753-2    Fl                 923 Va     K0V
-Uengkikgi     0204 C00046A-8    As Ni              203 Ve     F3V M0D
+Uengkikgi     0204 C00046A-8    As Ni              203 Ve     F3V M0V
 Gnanukhsen    0404 E55A876-5  C Wa                 910 V5     F8V
 Arae          0504 C9768CC-7                       500 V5     F6V
-Saeghu        0704 C653446-8  C Ni Po              915 V5     M4V M4D
+Saeghu        0704 C653446-8  C Ni Po              915 V5     M4V M4V
 Thoeoks       1004 C77A230-5    Lo Ni Wa           121 V5     F6V
 Orzong        1504 B572210-A    Lo Ni              222 V5     F4V
 Kfukhsodz     1604 D321664-3    Na Ni Po           702 V5     M3V
 Orrggudhul    2804 C510586-8  G Ni                 104 Va     F3V
 Ekaez         2904 A120001-F  G De Lo Ni Po        800 Va     M0V
-Ksodaeourr    3004 C410664-6  C Na Ni              603 Va     G8V M6D
+Ksodaeourr    3004 C410664-6  C Na Ni              603 Va     G8V M6V
 Aghzizor      0105 E34559A-2    Ag Ni              900 Ve     M6V
 Llakirrg      0405 CA887AD-4    Ag                 211 V5     K3V
-Rreedzredh    0605 E5566BF-4  C Ag Ni              602 V5     F2V M4D
+Rreedzredh    0605 E5566BF-4  C Ag Ni              602 V5     F2V M4V
 Ksagaegigha   1405 E998102-3    Lo Ni              700 V5     F1V
-Ughaerrig     1605 D648677-2    Ag Ni              114 V5     F2V M2D
-Dhurrknakh    1805 E344556-9  C Ag Ni              224 V5     F4V M7D
-Foekha        1905 X97A542-1  C Ni Wa              933 V5     F8V M6D
+Ughaerrig     1605 D648677-2    Ag Ni              114 V5     F2V M2V
+Dhurrknakh    1805 E344556-9  C Ag Ni              224 V5     F4V M7V
+Foekha        1905 X97A542-1  C Ni Wa              933 V5     F8V M6V
 Voguukh       2205 A69777A-7  G Ag                 203 V5     F0V
 Naengorr      2605 B78A578-8  C Ni Wa              114 Va     G8V
 Odzkhuegodz   2805 C541875-3    Po                 514 Va     K5V
-Ikfu          3205 A758887-B  G                    115 Va     F3V M8D
-Gorsakhsang   0306 D1209CB-9    De Hi In Na Po     503 V5     F1V M5D M8D
+Ikfu          3205 A758887-B  G                    115 Va     F3V M8V
+Gorsakhsang   0306 D1209CB-9    De Hi In Na Po     503 V5     F1V M5D M8V
 Gvugvatsong   0506 C585446-5  C Ni                 115 V5     F7V
 Kongelvae     0706 C533552-A    Ni Po              503 V5     M1V
 Gzaekeng      1506 C56897A-7    Hi In              100 V5     G5V
 Kooung        1706 C558A78-B  H Hi In              910 V5     F4V
-Aengthaeg     1806 B41056A-7  G Ni                 804 V5     M5V M8D
+Aengthaeg     1806 B41056A-7  G Ni                 804 V5     M5V M8V
 Kfovodi       1906 C575231-6    Lo Ni              510 V5     F2V
 Kangzaeg      2006 A150378-C  G De Lo Ni Po        811 V5     F3V
 Aekdigh       2206 C346747-5  G Ag                 302 V5     F1V
-Khuaerrerr    2306 X567678-0  C Ag Ni              318 V5     F9V M2D
+Khuaerrerr    2306 X567678-0  C Ag Ni              318 V5     F9V M2V
 Fudhzaes      2606 C110324-C    Lo Ni              903 Va     M7V
 Knangan       2706 X432344-3  C Lo Ni Po           304 Va     M2V
 Gangollghaer  2806 B564001-A    Lo Ni              204 Va     F6V
-Nezueg        2906 D426104-9  C Lo Ni              412 Va     K0V M5D
-Atsngoerr     0407 X242510-0    Ni Po              722 V5     F2V F5V M7D
-Siedzthokh    0507 E849422-3    Ni                 116 V5     K9V M8D
-Irrorr        1107 E788555-4  C Ag Ni              206 V5     F4V M4D M0D
-Aekkoekhs     1407 D434643-6  C Ni                 402 V5     M2V M1D
+Nezueg        2906 D426104-9  C Lo Ni              412 Va     K0V M5V
+Atsngoerr     0407 X242510-0    Ni Po              722 V5     F2V F5V M7V
+Siedzthokh    0507 E849422-3    Ni                 116 V5     K9V M8V
+Irrorr        1107 E788555-4  C Ag Ni              206 V5     F4V M4D M0V
+Aekkoekhs     1407 D434643-6  C Ni                 402 V5     M2V M1V
 Rundzer       1607 B330874-9    De Na Po           914 V5     F4V
-Usgvourzodh   2207 D736749-3  C                    805 V5     M4V M4D
+Usgvourzodh   2207 D736749-3  C                    805 V5     M4V M4V
 Ouvo          2407 E435445-8    Ni                 100 V5     M5V
-Kuknarr       2507 D301203-5  C Ic Lo Ni Va        106 Va     F8V M2D
-Khaeaeng      3007 B737573-8    Ni                 718 VN     K9V M1D
+Kuknarr       2507 D301203-5  C Ic Lo Ni Va        106 Va     F8V M2V
+Khaeaeng      3007 B737573-8    Ni                 718 VN     K9V M1V
 Khullung      0108 C1007BA-A  G Na Va              601 Ve     F5V
-Totsoung      0608 D898640-0    Ag Ni              716 V5     F8V M4D
+Totsoung      0608 D898640-0    Ag Ni              716 V5     F8V M4V
 Nongdhangae   0708 D88A364-4  C Lo Ni Wa           200 V5     F8V
-Fukoksa       1108 C549898-2  C                    618 V5     G7V M3D
-Dzaeghaek     1308 CADA500-C  G Fl Ni Wa           514 V5     M0V M3D
+Fukoksa       1108 C549898-2  C                    618 V5     G7V M3V
+Dzaeghaek     1308 CADA500-C  G Fl Ni Wa           514 V5     M0V M3V
 Khaegze       2708 A7B1520-D  C Fl Ni              903 V5     M7V
 Garzuzaedz    3008 B948558-7  G Ag Ni              602 VN     F5V
 Zououz        0409 E510679-2    Na Ni              301 V5     M2V
@@ -111,91 +111,91 @@ Engekh        2509 E665202-7  C Lo Ni              402 V5     K9V
 Llusuerrg     2609 D647324-4  G Lo Ni              702 V5     F1V
 Errkfaekso    2709 E210002-2  C Lo Ni              90A V5     M7V M1D M8V
 Saeanglon     3009 D454421-4    Ni                 403 VN     M8V
-Ngarroel      3209 C610988-7    Hi Na              314 VN     F7V M5D
+Ngarroel      3209 C610988-7    Hi Na              314 VN     F7V M5V
 Ghongal       0210 C9C3244-3  C Fl Lo Ni           704 V5     M5V
 Kfodzours     0310 C469448-6    Ni                 315 V5     F5V
-Zursgaenoen   0410 E328344-6    Lo Ni              805 V5     G0V M8D
+Zursgaenoen   0410 E328344-6    Lo Ni              805 V5     G0V M8V
 Vaou          0710 C65548A-8    Ni                 604 V5     G7V
 Khongaets     0810 B868520-4    Ag Ni              700 V5     G1V
-Gorosaekhs    0910 B332120-8    Lo Ni Po           204 V5     M8V M1D
-Ghaung        1310 C779624-4  G Ni                 103 V5     F7V M5D
+Gorosaekhs    0910 B332120-8    Lo Ni Po           204 V5     M8V M1V
+Ghaung        1310 C779624-4  G Ni                 103 V5     F7V M5V
 Korsoghagorz  1410 C67A77B-7    Wa                 212 V5     F5V
 Akzudhtsaeo   2110 B334766-9                       523 V5     M2V
-Onungoghz     2210 C42289D-6    Na Po              115 V5     G7V M8D
+Onungoghz     2210 C42289D-6    Na Po              115 V5     G7V M8V
 Dzodzik       2310 D769536-5  H Ni                 203 V5     K8V
 Uegthaerr     2610 A868363-D  G Lo Ni              703 V5     F6V
 Llaeukharung  3010 A454976-B  G Hi In              601 VN     K3V
 Orruers       3110 CAC3779-2    Fl                 910 VN     M8V
 Anetssoz      0711 B255758-A  C Ag                 812 V5     F7V
-Ugvoerrdzal   0911 C79A876-8    Wa                 803 V5     F9V M3D
-Llekna        1311 E578344-3    Lo Ni              501 V5     F4V M1D
-Gnoksuekh     1811 E667000-5    Ba Lo Ni           603 V5     G1V M7D
+Ugvoerrdzal   0911 C79A876-8    Wa                 803 V5     F9V M3V
+Llekna        1311 E578344-3    Lo Ni              501 V5     F4V M1V
+Gnoksuekh     1811 E667000-5    Ba Lo Ni           603 V5     G1V M7V
 Tekha         1911 E759511-4  C Ni                 300 V5     F6V
 Raalerrzueng  2211 E31058C-7  C Ni                 704 V5     F8V
-Aenoen        2411 B8D4532-7  G Fl Ni              214 V5     G2V K9D
+Aenoen        2411 B8D4532-7  G Fl Ni              214 V5     G2V K9V
 Aenllath      2511 E100578-8    Ni Va              214 V5     M3III
 Luaghdzon     2711 C699745-3  G                    210 V5     M7V
 Orsok         3011 E448100-7  C Lo Ni              403 VN     F5V
 Oouson        1012 B436313-6  G Lo Ni              704 V5     M3V M6V
 Lloegva       1112 D621526-3  C Ni Po              124 V5     F1V
-Kurfoegkokna  1512 B371642-A  G Ni                 504 V5     K1V M5D
-Gazog         1712 C867403-8  C Ni                 503 V5     G0V M7D
+Kurfoegkokna  1512 B371642-A  G Ni                 504 V5     K1V M5V
+Gazog         1712 C867403-8  C Ni                 503 V5     G0V M7V
 Ooo           2012 B9479B6-9    Hi In              224 V5     F1V
 Ksoegagoul    2112 E224200-4  C Lo Ni              203 V5     K7V M8V
 Ueksu         2212 E304442-2  C Ic Ni Va           102 V5     K3V
 Aea           2412 CAB8689-9    Fl Ni              801 V5     F8V
 Tuoez         2512 C400562-7    Ni Va              603 V5     G8V M7V
-Ollaerzoerz   2612 EAD4678-1    Fl Ni              123 V5     K9V M0D
-Gzitsezoegh   3012 C554234-9    Lo Ni              106 VN     F9V M6D
+Ollaerzoerz   2612 EAD4678-1    Fl Ni              123 V5     K9V M0V
+Gzitsezoegh   3012 C554234-9    Lo Ni              106 VN     F9V M6V
 Gheguesae     3112 C456200-9    Lo Ni              200 VN     F9V
-Aaoeou        3212 C89A379-8    Lo Ni Wa           907 VN     K9V M7D M5D
-Guutsa        0913 C753101-4    Lo Ni Po           303 V5     F6V M2D
-Orsgeghoeze   1213 C9C1587-6  G Fl Ni              602 V5     M2V M6D
+Aaoeou        3212 C89A379-8    Lo Ni Wa           907 VN     K9V M7D M5V
+Guutsa        0913 C753101-4    Lo Ni Po           303 V5     F6V M2V
+Orsgeghoeze   1213 C9C1587-6  G Fl Ni              602 V5     M2V M6V
 Taoekh        1313 CAE9000-5  G Ba Fl Lo Ni        903 V5     M2V
 Dhillourr     1413 B110A7A-G    Hi Na              102 V5     F9V
 Faetsovuerrg  1513 C546641-4  G Ag Ni              613 V5     F6V M5V
 Gnaghaegz     1713 B4257BC-A  G                    302 V5     M5V
-Dzondhae      1913 C645514-6  C Ag Ni              300 V5     F7V M5D
+Dzondhae      1913 C645514-6  C Ag Ni              300 V5     F7V M5V
 Kaaekorr      2413 C370210-5  G De Lo Ni           701 V5     G6V
 Oeldounors    2513 A948667-9    Ag Ni              505 V5     F4V
 Utsaezu       2813 D546878-1  G                    803 Va     F8V
 Ouonoeng      0914 BA6A878-9  G Wa                 800 V5     F2V
-Arsghourrg    1214 B658976-A    Hi In              602 V5     M0V M5D
-Ghallkaegz    1914 B232111-B  G Lo Ni Po           604 V5     M4V M7D
-Gvioengoegh   2414 A884626-6  G Ag Ni              504 V5     F5V M0D
+Arsghourrg    1214 B658976-A    Hi In              602 V5     M0V M5V
+Ghallkaegz    1914 B232111-B  G Lo Ni Po           604 V5     M4V M7V
+Gvioengoegh   2414 A884626-6  G Ag Ni              504 V5     F5V M0V
 Enekhzul      2814 C110458-B  C Ni                 502 Va     M3V
 Llothurr      3014 C544477-8    Ni                 607 Va     F4V M2D F7V
 Ousagudha     1315 C350778-5    De Po              512 V5     F9V F3V
 Eredhok       1815 CAB5144-7  G Fl Lo Ni           322 V5     M3V
 Riegallonzak  1915 B460367-5  G De Lo Ni           914 V5     F7V
-Dakhsarrllo   2015 C857663-1  C Ag Ni              803 V5     F0V M3D
-Sokhzaenug    2115 C502876-7    Ic Na Va           903 V5     F9D
+Dakhsarrllo   2015 C857663-1  C Ag Ni              803 V5     F0V M3V
+Sokhzaenug    2115 C502876-7    Ic Na Va           903 V5     F9V
 Lefaez        2315 B54A344-B    Lo Ni Wa           206 V5     F7V M2V
 Tarrgoengouk  2515 B526578-B    Ni                 410 V5     A4V
 Khaellou      2715 B659302-8    Lo Ni              414 Va     K0V
-Gukazo        2815 X200568-0  C Ni Va              104 Va     K0V M0D
+Gukazo        2815 X200568-0  C Ni Va              104 Va     K0V M0V
 Duegoukhs     3015 C682777-7                       524 Va     F0V
 Uekhseng      3115 E110699-8    Na Ni              404 Va     M2V
-Rurvaeng      1116 D310510-4  C Ni                 807 V5     M7V M7D
-Aguekhaa      1616 B65157B-B  G Ni Po              801 V5     F6V M7D
+Rurvaeng      1116 D310510-4  C Ni                 807 V5     M7V M7V
+Aguekhaa      1616 B65157B-B  G Ni Po              801 V5     F6V M7V
 Urrgoen       2016 C43078A-7  H De Na Po           412 V5     F2IV
-Isarrorrgh    1217 E5749A5-5  C Hi In              621 V5     F5V M4D
+Isarrorrgh    1217 E5749A5-5  C Hi In              621 V5     F5V M4V
 Kenal         1317 C2006AD-9    Na Ni Va           500 V5     M6V M6V
 Saghangaedz   1817 C455535-9  G Ag Ni              304 V5     F1V
-Vusarrg       1917 C664244-6  C Lo Ni              416 V5     F5V M8D
+Vusarrg       1917 C664244-6  C Lo Ni              416 V5     F5V M8V
 Uesaen        2017 CAA7210-4  C Fl Lo Ni           212 V5     F1IV
-Khaegoth      2317 C210878-4    Na                 904 V5     F5V M7D
+Khaegoth      2317 C210878-4    Na                 904 V5     F5V M7V
 Ourrkazthodz  2517 C422434-B  G Ni Po              813 V5     M8V
 Uzouzllug     2617 C737342-8    Lo Ni              202 V5     M1V
-Ghaeontoeng   2817 C555651-6    Ag Ni              604 Va     G4V M6D
+Ghaeontoeng   2817 C555651-6    Ag Ni              604 Va     G4V M6V
 Oulraz        1218 D334205-6  C Lo Ni              400 V5     M1II G8V
-Angatholl     1618 E95A673-3    Ni Wa              204 V5     F5V M1D
-Onfan         2018 C344664-5    Ag Ni              903 V5     F0V M1D
+Angatholl     1618 E95A673-3    Ni Wa              204 V5     F5V M1V
+Onfan         2018 C344664-5    Ag Ni              903 V5     F0V M1V
 Lufighger     2218 B9D7610-4  C Fl Ni              902 V5     M3V
-Ouaeghuerrou  2818 A76A220-C  G Lo Ni Wa           402 Va     M5V M6D
+Ouaeghuerrou  2818 A76A220-C  G Lo Ni Wa           402 Va     M5V M6V
 Oho           3018 C100489-C  S Ni Va              103 Ga     M6II
 Ondshass      3118 C100886-5    Ri                 203 Ga     M7V
-Ateenar       3218 C567536-B  S De Ni Po           416 Ga     K9V M8V M3D
+Ateenar       3218 C567536-B  S De Ni Po           416 Ga     K9V M8V M3V
 Narzoerrag    1519 C6A3547-7    Fl Ni              100 V5     M4V
 Guenegh       1819 B738588-7    Ni                 713 V5     M8V
 Khuegingazu   2119 D759479-5    Ni                 813 V5     F0V
@@ -204,94 +204,94 @@ Kfullaerr     2819 D8B8210-6  C Fl Lo Ni           514 Va     M7V M7V
 Tihteteni     3019 D656468-4  S Ni                 120 Ga     F1V
 Vacstee       3119 D7A68DH-4  S                    920 Ga     M4III
 Laedaerrgh    1720 C578204-9  H Lo Ni              502 V5     F9V
-Ravoeaesue    1820 E7A2566-7  C Fl Ni              902 V5     M3V M2D
+Ravoeaesue    1820 E7A2566-7  C Fl Ni              902 V5     M3V M2V
 Uegaksa       2520 X767841-1    Ri                 604 V5     F3V
 Zogodhaeth    2820 B000478-A    As Ni              302 Va     M4V
 Naen          3020 C52235A-B    Lo Ni Po           302 Ga     K1V
-Eri           3120 D332235-9    Lo Ni Va           824 Ga     K4V M0D
+Eri           3120 D332235-9    Lo Ni Va           824 Ga     K4V M0V
 Saesoulou     1321 A44169A-B    Ni Po              700 V5     F2V
-Gvuengkakh    1721 B300575-9    Ni Va              616 V5     M5V M2D
+Gvuengkakh    1721 B300575-9    Ni Va              616 V5     M5V M2V
 Raeziueg      1821 D97A973-3  C Hi In Wa           500 V5     F5V
 Kazoughgzun   1921 E360448-5    De Ni              412 V5     F1V
 Enakh         2021 E200221-8  C Lo Ni Va           300 V5     F2IV
 Ngogae        2521 E2008AE-7    Na Va              214 V5     F8V
 Tsufuesak     2621 C5767AD-5  G Ag                 702 Va     K6V
 Gafaofdedit   3121 X8A3444-3    Fl Ni           R  921 Ga     M2V
-Endi          3221 C898477-A  S Ic Ni Va           812 Ga     F4V M5D
-Ounnon        0122 B87A976-9    Hi In Wa           602 Va     G7V M0D
+Endi          3221 C898477-A  S Ic Ni Va           812 Ga     F4V M5V
+Ounnon        0122 B87A976-9    Hi In Wa           602 Va     G7V M0V
 Ueruenggoer   1622 C8B29DB-8  C Fl Hi In           224 V5     F1V
-Arriraez      1722 E40055A-4  C Ni Va              901 V5     K1V M5D
+Arriraez      1722 E40055A-4  C Ni Va              901 V5     K1V M5V
 Rronak        1822 D573796-1  C Ag                 204 V5     K9V
 Losose        2222 B585778-7    Ag                 922 V5     F7V
-Gnaetaoerr    2322 C326533-9  G Ni                 206 V5     M7V M0D
+Gnaetaoerr    2322 C326533-9  G Ni                 206 V5     M7V M0V
 Llellagzkas   2622 B743672-8    Ag Ni Po           903 Va     F9V
 Agkuekhougz   1223 C250975-4    De Hi In Po        201 V5     M3V
 Dekhsuerrdou  1523 C586532-7    Ag Ni              311 V5     F7V
 Zungaenvor    1723 E584611-3  C Ag Ni              504 V5     F4V
 Anokang       1923 E312544-4  C Ic Ni              412 V5     G1V
-Khuenzakgorr  2023 C9A4874-5    Fl                 613 V5     F5V M0D
+Khuenzakgorr  2023 C9A4874-5    Fl                 613 V5     F5V M0V
 Kagzvaeth     2223 C260754-7    De Ri              910 V5     F0V
 Suzaoen       2323 A200202-B  G Lo Ni Va           313 V5     M1V M0V
 Onotuez       2623 D361424-3  C Ni                 214 Va     F3V
 Vadou         3023 BAA4132-C  S Fl Lo Ni           902 Ga     K5V M6V
-Thaaelgzars   1224 D370621-2  C De Ni              614 V5     F3V M7D
+Thaaelgzars   1224 D370621-2  C De Ni              614 V5     F3V M7V
 Guekuoe       1724 E000677-4  C As Na Ni           900 V5     M2III
 Zuekhfo       1824 E87977A-7  C                    400 V5     F7V
-Gnurskfonan   2024 A425120-A  C Lo Ni              512 V5     M6V M5D
+Gnurskfonan   2024 A425120-A  C Lo Ni              512 V5     M6V M5V
 Kusath        2124 D575976-3  G Hi In              501 V5     F0V
-Zuzaekhuegh   2424 E9C7487-8  C Fl Ni              713 V5     F1V M2D
+Zuzaekhuegh   2424 E9C7487-8  C Fl Ni              713 V5     F1V M2V
 Gvagfuerue    2624 C88A677-7    Ni Wa              410 Va     F1V
 Gisghoel      2724 B320532-9    De Ni Po           403 Va     K1V
 Bebidid       2824 B641664-A  S Ni Po              202 Ga     K0V
 Oyees         3124 B310411-A  M Fl Ni              204 Ga     F9V G7V
 Kharsgugz     1225 C566675-7    Ag Ni              300 V5     F3V
-Kaltour       1325 XAD5A7B-4    Fl Hi In           102 V5     F4V M6D
+Kaltour       1325 XAD5A7B-4    Fl Hi In           102 V5     F4V M6V
 Doudzo        1425 E5699DH-5    Hi In              300 V5     K5V
 Lloukaeukhs   1825 C150675-4    De Ni Po           914 V5     G0V
-Koerrruell    1925 E785620-2  C Ag Ni              126 V5     F9V M2D
-Llaedhue      2025 A4638DB-6  G                    512 V5     F8V M5D
+Koerrruell    1925 E785620-2  C Ag Ni              126 V5     F9V M2V
+Llaedhue      2025 A4638DB-6  G                    512 V5     F8V M5V
 Aurro         2125 C541440-4    Ni Po              500 V5     K9V
 Founuer       2325 A000331-C  C As Lo Ni           900 V5     M7V
-Oesodhakhs    2425 B72A67A-8    Ni Wa              903 V5     K7V M3D
+Oesodhakhs    2425 B72A67A-8    Ni Wa              903 V5     K7V M3V
 Iornes        2825 A554599-A    Ag Ni              402 Ga     K5V
 Oureslot      2925 A4666A8-A  B Na Ni              710 Ga     F9V
 Cifo          3025 B237464-A  A Ni Po              802 Ga     M6V
 Atha          3225 B69788B-A  S Ic Na Va           800 Ga     K0V
 Koeenaerkoe   1326 C7879CA-7    Hi In              312 V5     F7V
-Faethkhueg    1426 E68A559-3    Ni Wa              117 V5     F9V M4D
+Faethkhueg    1426 E68A559-3    Ni Wa              117 V5     F9V M4V
 Vuenengouz    1526 E585789-4  C Ag                 207 V5     F7V M1D F6V
 Gogvoeroghz   2126 D757466-6    Ni                 924 V5     F1V
 Gazoun        2326 D340975-6    De Hi In Po        400 V5     F1V
-Kazzoukal     2426 BAC7746-9    Fl                 802 V5     K3V M1D
-Yeregh        2826 A4468CD-A                       613 Ga     F5V M5D
-Sheod         2926 B590533-7  B Ag Ni              101 Ga     G5V M0D
-Ante          3026 B23148B-B  S Fl Ni              804 Ga     M1V M2D
-Irsifta       3126 X548530-0    Ni              R  610 Ga     F0V M0D
-Vegis         3226 E366696-8    As Na Ni           203 Ga     G5V M7D
+Kazzoukal     2426 BAC7746-9    Fl                 802 V5     K3V M1V
+Yeregh        2826 A4468CD-A                       613 Ga     F5V M5V
+Sheod         2926 B590533-7  B Ag Ni              101 Ga     G5V M0V
+Ante          3026 B23148B-B  S Fl Ni              804 Ga     M1V M2V
+Irsifta       3126 X548530-0    Ni              R  610 Ga     F0V M0V
+Vegis         3226 E366696-8    As Na Ni           203 Ga     G5V M7V
 Gheae         0727 B304211-7  C Ic Lo Ni Va        300 Va     M8V
 Seuo          1827 B79A545-B  G Ni Wa              601 V5     F2V
 Soru          2227 C327A75-D  C Hi In              304 V5     F4V
 Eu            2727 D436896-5  S                    200 Ga     F2V
-Gantoyoi      2927 E563310-8    Lo Ni              602 Ga     F8V M0D
+Gantoyoi      2927 E563310-8    Lo Ni              602 Ga     F8V M0V
 Laniht        3027 C210338-7    Lo Ni Wa           101 Ga     A0IV
 Thire         3227 C535733-4  M Ag                 724 Ga     F4V
-Voukhsedz     0428 C44468A-6  G Ag Ni              516 Va     K9V M7D
+Voukhsedz     0428 C44468A-6  G Ag Ni              516 Va     K9V M7V
 Foekhorr      1428 E988584-4  C Ag Ni              302 V5     K6V
-Ghueuedhars   1628 E250355-4    De Lo Ni Po        101 V5     K5V M6D
+Ghueuedhars   1628 E250355-4    De Lo Ni Po        101 V5     K5V M6V
 Foenrars      1828 C646240-2  G Lo Ni              922 V5     F4V
 Adharen       1928 C210699-6  G Na Ni              304 V5     F2V
-Knueraerrun   2128 D100777-3    Na Va              118 V5     M4V M1D F9V M4D
+Knueraerrun   2128 D100777-3    Na Va              118 V5     M4V M1D F9V M4V
 Ongnonggors   2428 E98A495-5  C Ni Wa              101 V5     F9V
 Orraerz       2528 C946556-A    Ag Ni              804 V5     F6V
 Asoitad       2728 D986323-2    Lo Ni              500 Ga     F4V
 Wigho         2828 D689696-6  S Ag Ni Ri           222 Ga     F1V
 Nefteanethe   3028 D626110-6    Lo Ni              217 Ga     F3V F0V
-Koenaers      0529 C324757-5  G                    500 Va     F2V M8D
-Neguegh       1329 C257444-8    Ni                 322 V5     F1V M6D
+Koenaers      0529 C324757-5  G                    500 Va     F2V M8V
+Neguegh       1329 C257444-8    Ni                 322 V5     F1V M6V
 Oghtullourro  2129 C000783-8    Ag                 302 V5     M6V
 Urrgueursar   2229 C524533-8  C As Ni              903 V5     M4V K8V
 Dhanvuerr     2329 D30047C-8    Ni                 804 V5     M4V
-Rozuth        2429 C252435-6    Ni Va              713 V5     F1V M4D
+Rozuth        2429 C252435-6    Ni Va              713 V5     F1V M4V
 Aro           2629 BA8A200-A  G Lo Ni Po           812 Va     F2V
 Londveron     2829 C452005-7    Lo Ni Wa           403 Ga     F1V
 Onge          3029 C444410-B  M Ni                 404 Ga     F7V
@@ -300,10 +300,10 @@ Ithaengkfogh  1630 B342204-9    Lo Ni Po           813 V5     M4V
 Oudod         2830 E6A0541-7    Ni                 924 Ga     M8V
 Gzaedhkirrg   1131 X6A0725-0  C De                 924 Va     M8V
 Dzekevaeng    1531 C773644-7    Ag Ni              710 V5     F4V
-Aekknegh      1731 B454401-8  G Ni                 106 V5     M8V M4D
-Ezorzeng      2031 B421899-7    Na Po              307 V5     M3V M6D
+Aekknegh      1731 B454401-8  G Ni                 106 V5     M8V M4V
+Ezorzeng      2031 B421899-7    Na Po              307 V5     M3V M6V
 Ougaghzoegz   2131 C470120-5  G De Lo Ni           702 V5     K4V
-Oaeough       2231 B552431-9  G Ni Po              310 V5     F1V M4D
+Oaeough       2231 B552431-9  G Ni Po              310 V5     F1V M4V
 Ogira         2331 C655535-6    Ag Ni              410 V5     M2V
 Esfenrast     2931 D1008B9-4  S                    502 Ga     M5V
 Eri           3231 B435421-B  M Fl Ni              705 Ga     G2V
@@ -311,29 +311,29 @@ Dalzudoe      1332 E435445-6  C Ni                 705 V5     G2V
 Gzazoevaellu  1632 C300445-7  H Ni Va              218 V5     A1III K9V
 Vrirhlanz     1635 B657721-7    Ag Ga              314 Na     G4V
 Kaengtsekou   1732 E453898-5  C Po                 300 V5     F7V
-Aeurr         2032 E453888-6  C Po                 204 V5     F0V M4D
+Aeurr         2032 E453888-6  C Po                 204 V5     F0V M4V
 Oungun        2132 D223996-6  H Hi In Na Po        301 V5     F2V
-Gvonksu       2532 C354620-7  G Ag Ni              111 Va     F9V M7D
+Gvonksu       2532 C354620-7  G Ag Ni              111 Va     F9V M7V
 Soudzae       2632 C558588-3    Ag Ni              800 Va     F7V
-Eena          2832 C664865-5  M Ri                 211 Ga     G0V M0D
+Eena          2832 C664865-5  M Ri                 211 Ga     G0V M0V
 Thebecir      3032 D536787-5    De Na Po           302 Ga     M5V
-Duvarroez     1433 C868554-B  C Ni                 704 V5     F0V M6D
+Duvarroez     1433 C868554-B  C Ni                 704 V5     F0V M6V
 Gvongel       1733 C76878C-6    Ag                 301 V5     F9V
-Tsaeggvokez   2133 D140214-6    Lo Ni              835 V5     F1V M3D
+Tsaeggvokez   2133 D140214-6    Lo Ni              835 V5     F1V M3V
 Goutsorga     2333 D210899-6    De Po              502 V5     M2V
 Akhodon       2533 E8586AC-6    Na Ni              801 Va     F0V
-Ouksgzueue    2633 D322757-2  G Ag                 214 Va     M4V M5D
+Ouksgzueue    2633 D322757-2  G Ag                 214 Va     M4V M5V
 Ogluaedh      2733 D978633-3    Na Ni Po           800 Va     F7V
 Ilepee        2833 D6478AA-2  S                    100 Ga     F8V
 Vaa           2933 D33369C-6  S Ag Ni Ri           400 Ga     K0IV
-Oensiatiot    3033 C7B5337-8    Lo Ni              101 Ga     F7V M1D
-Cetheine      3133 E401400-4    Ni                 200 Ga     F4V M7D
+Oensiatiot    3033 C7B5337-8    Lo Ni              101 Ga     F7V M1V
+Cetheine      3133 E401400-4    Ni                 200 Ga     F4V M7V
 Otpos         3233 C444796-5  M Na                 804 Ga     G7V
-Aengllog      1234 C696A76-C    Hi In              303 V5     F9V M2D
-Ugzfersung    1834 C425667-1    Ag Ni              806 V5     G5III M5V M6D
+Aengllog      1234 C696A76-C    Hi In              303 V5     F9V M2V
+Ugzfersung    1834 C425667-1    Ag Ni              806 V5     G5III M5V M6V
 Aedhoonor     2234 E200226-7    Lo Ni              125 V5     G9V M3V
-Rothkuroung   2434 D546510-4  C Ni Va              526 V5     F1V M3D
-Ista          3134 X778856-3                    R  224 Ga     G3V M3D
+Rothkuroung   2434 D546510-4  C Ni Va              526 V5     F1V M3V
+Ista          3134 X778856-3                    R  224 Ga     G3V M3V
 Ennell        3234 C552301-6  M Lo Ni              802 Ga     F9V
 Ngangazae     1735 D55289E-0    Po                 802 V5     F9V
 Ueghaen       1935 D130662-8  G De Na Ni Po        602 V5     G8V
@@ -341,11 +341,11 @@ Arrgutsurr    2135 C878447-7  C Ni                 304 V5     F4V M1V
 Urrguerr      2335 C585777-6  C Ag                 422 V5     G6V
 Falulduerr    2635 B300536-9  G Ni Va              301 V5     G4V
 Tongati       2935 C455977-B  M Hi In Wa           401 Ga     F5V
-Otlitehe      3035 C675657-9  M Ni                 502 Ga     M4V M5D
-Khakhang      1636 A675565-9  G Ag Ni              502 V5     M4V M5D
+Otlitehe      3035 C675657-9  M Ni                 502 Ga     M4V M5V
+Khakhang      1636 A675565-9  G Ag Ni              502 V5     M4V M5V
 Gzongkael     1836 C556637-2  C Ag Ni              411 V5     F3V
 Ourksaea      2036 C4358A9-9  C                    203 V5     F2V
-Lodaeegzzuen  2536 C66697B-5    Hi In              800 V5     F3V M2D
+Lodaeegzzuen  2536 C66697B-5    Hi In              800 V5     F3V M2V
 Ueaeltho      2636 A557110-B    Lo Ni              315 V5     F4V M6V
 Itac          2836 C536210-7  M Ic Lo Ni Va        402 Ga     M8V
 Eyi           3036 C669553-8    Ni Wa              213 Ga     F5V
@@ -354,33 +354,33 @@ Ellee         3236 C551000-7    Ba Lo Ni Wa        313 Ga     F5V
 Lluerzaez     1337 E551630-5  C Ni Po              313 V5     F5V
 Gzugo         1437 A130535-C    De Ni Po           314 V5     F9V
 Duoeng        1537 D667336-5    Lo Ni              622 V5     F9V
-Itsarrg       1637 D86A532-5    Ni Wa              114 V5     G9V M0D
-Kaeogzghung   1937 B7736A5-8    Ag Ni              501 V5     F9V M7D
+Itsarrg       1637 D86A532-5    Ni Wa              114 V5     G9V M0V
+Kaeogzghung   1937 B7736A5-8    Ag Ni              501 V5     F9V M7V
 Dukaers       2337 A587125-9    Lo Ni              813 V5     F9V
-Oelkfaezong   2637 C120644-5  C De Na Ni Po        217 V5     K4V M4D
+Oelkfaezong   2637 C120644-5  C De Na Ni Po        217 V5     K4V M4V
 Inoued        2837 E889534-5    Ag Ni              203 Ga     F1V
 Aang          2937 D786333-7    De Lo Ni           804 Ga     G0V
-Eyeto         3237 E100494-5    De Ni Po           443 Ga     F5V M0D
-Sudhaenga     1538 C100979-D    Hi Na Va           443 V5     F5V M0D
+Eyeto         3237 E100494-5    De Ni Po           443 Ga     F5V M0V
+Sudhaenga     1538 C100979-D    Hi Na Va           443 V5     F5V M0V
 Onggvaerrgh   2038 D386503-4  C Ag Ni              420 V5     F4V
-Oukhsoureghz  2138 EAA8475-5  C Fl Ni              302 V5     M8V M6D
-Ksoegusnoeks  2638 C300978-C  C Hi Na Va           903 V5     G0V M4D
+Oukhsoureghz  2138 EAA8475-5  C Fl Ni              302 V5     M8V M6V
+Ksoegusnoeks  2638 C300978-C  C Hi Na Va           903 V5     G0V M4V
 Ini           3038 B8768AD-7  S                    100 Ga     F0V
 Ngaeugh       1339 C876430-4    Ni                 100 V5     F0V
-Ruthfaegh     1439 BAA6753-8  C Fl                 703 V5     M0V M5D
-Logzagzoeng   1939 E6A1348-2    Fl Lo Ni           400 V5     M6III G0D
+Ruthfaegh     1439 BAA6753-8  C Fl                 703 V5     M0V M5V
+Logzagzoeng   1939 E6A1348-2    Fl Lo Ni           400 V5     M6III G0V
 Verundzogz    2039 B210333-7  G Lo Ni              722 V5     G9V
-Roulnoul      2739 C754664-3    Ag Ni              200 V5     K4V M7D
+Roulnoul      2739 C754664-3    Ag Ni              200 V5     K4V M7V
 Saha          3139 A86A443-B  B Ni                 704 Ga     M2V
 Aethou        1440 C86A302-B  G Lo Ni Wa           704 V5     M2V
-Saoeng        1540 C51177B-5  C Ic Na              113 V5     M8V M5D
-Kaetoe        1640 C252232-9  C Lo Ni Po           316 V5     F5V M6D
+Saoeng        1540 C51177B-5  C Ic Na              113 V5     M8V M5V
+Kaetoe        1640 C252232-9  C Lo Ni Po           316 V5     F5V M6V
 Ougakh        1740 C542743-4    Po                 900 V5     K3V M2V
 Vanknarraegh  1940 C200403-9    Ni Va              701 V5     M0II
-Ksagval       2140 B563753-A  G Ag Ri              220 V5     F4V M0D
-Kigukhs       2340 C45597A-6    Hi In              415 V5     F2V M2D
+Ksagval       2140 B563753-A  G Ag Ri              220 V5     F4V M0V
+Kigukhs       2340 C45597A-6    Hi In              415 V5     F2V M2V
 Gnogal        2440 B51055A-A    Ni                 600 V5     M0V
-Tuekheaekgil  2540 D453322-6  C Lo Ni Po           614 V5     F1V M8D
-Tsaeousorrg   2940 C9A59CE-9    Fl Hi In           305 V5     M6V M6D
-Poma          3140 E210578-4    Ni                 905 Ga     K7V M4D
+Tuekheaekgil  2540 D453322-6  C Lo Ni Po           614 V5     F1V M8V
+Tsaeousorrg   2940 C9A59CE-9    Fl Hi In           305 V5     M6V M6V
+Poma          3140 E210578-4    Ni                 905 Ga     K7V M4V
 Touwoe        3240 C67A665-A  S Ni Wa              401 Ga     F0V

--- a/res/Sectors/M1105/Irugangong.sec
+++ b/res/Sectors/M1105/Irugangong.sec
@@ -10,22 +10,22 @@ Irugangong
 #PlanetName   Loc. UPP Code   B   Notes         Z  PBG Al LRX *
 #----------   ---- ---------  - --------------- -  --- -- --- -
 .             0101 X627000-0    Ba Lo Ni           023 --     K2V 
-.             0401 X989000-0    Ba Lo Ni           004 --     F9V M5D 
+.             0401 X989000-0    Ba Lo Ni           004 --     F9V M5V
 .             0801 X455000-0    Ba Lo Ni           010 --     F4V 
-.             1201 X787000-0    Ba Lo Ni           014 --     F9V M6D 
+.             1201 X787000-0    Ba Lo Ni           014 --     F9V M6V
 .             1601 X879000-0    Ba Lo Ni           000 --     F0V 
-.             2901 X140000-0    Ba De Lo Ni Po     006 --     G6V M3D 
-.             0502 X000000-0    As Ba Lo Ni        005 --     M6V M2D 
-.             0702 X787000-0    Ba Lo Ni           004 --     F2V M5D 
-.             0802 X888000-0    Ba Lo Ni           006 --     F5V M4D 
-.             1302 X370000-0    Ba De Lo Ni        021 --     F2V M5D 
+.             2901 X140000-0    Ba De Lo Ni Po     006 --     G6V M3V
+.             0502 X000000-0    As Ba Lo Ni        005 --     M6V M2V
+.             0702 X787000-0    Ba Lo Ni           004 --     F2V M5V
+.             0802 X888000-0    Ba Lo Ni           006 --     F5V M4V
+.             1302 X370000-0    Ba De Lo Ni        021 --     F2V M5V
 .             1402 X362000-0    Ba Lo Ni           003 --     G6V 
 .             1702 X9C5000-0    Ba Fl Lo Ni        000 --     M5V 
 .             2502 X444000-0    Ba Lo Ni           013 --     M2V 
-.             2602 X653000-0    Ba Lo Ni Po        010 --     F5V M2D 
+.             2602 X653000-0    Ba Lo Ni Po        010 --     F5V M2V
 .             2702 X9A5000-0    Ba Fl Lo Ni        003 --     M8III M7V 
-.             2802 X8B6000-0    Ba Fl Lo Ni        023 --     G2V M0D 
-.             3102 X335000-0    Ba Lo Ni           014 --     K5V M3D 
+.             2802 X8B6000-0    Ba Fl Lo Ni        023 --     G2V M0V
+.             3102 X335000-0    Ba Lo Ni           014 --     K5V M3V
 .             0703 X523000-0    Ba Lo Ni Po        014 --     M2V 
 .             0803 X7B3000-0    Ba Fl Lo Ni        011 --     K0V 
 .             1203 XAAA000-0    Ba Fl Lo Ni Wa     003 --     F7II 
@@ -36,146 +36,146 @@ Irugangong
 .             0604 X510000-0    Ba Lo Ni           004 --     M6V 
 .             0704 X99A000-0    Ba Lo Ni Wa        002 --     F2V 
 .             1004 X643000-0    Ba Lo Ni Po        022 --     F9V 
-.             1504 X200000-0    Ba Lo Ni Va        000 --     M0V M8D 
+.             1504 X200000-0    Ba Lo Ni Va        000 --     M0V M8V
 .             1604 X000000-0    As Ba Lo Ni        000 --     M2V 
 .             2004 X799000-0    Ba Lo Ni           033 --     F6V 
 .             3004 X888000-0    Ba Lo Ni           001 --     M4V 
 .             0805 X576000-0    Ba Lo Ni           004 --     G3V 
 .             1005 X300000-0    Ba Lo Ni Va        015 --     F6V 
-.             1405 X636000-0    Ba Lo Ni           003 --     M5V M2D 
+.             1405 X636000-0    Ba Lo Ni           003 --     M5V M2V
 .             1605 X120000-0    Ba De Lo Ni Po     020 --     M6V M1V 
 .             2405 X692000-0    Ba Lo Ni           000 --     F1V 
 .             3005 X320000-0    Ba De Lo Ni Po     011 --     G9V M5V 
-.             0606 X511000-0    Ba Ic Lo Ni        006 --     M0V M3D 
+.             0606 X511000-0    Ba Ic Lo Ni        006 --     M0V M3V
 .             0706 X456000-0    Ba Lo Ni           000 --     F9V 
 .             0806 X874000-0    Ba Lo Ni           004 --     F6V 
 .             1006 X520000-0    Ba De Lo Ni Po     003 --     M0V 
 .             1306 X99A000-0    Ba Lo Ni Wa        022 --     F2V 
-.             1506 X6A2000-0    Ba Fl Lo Ni        017 --     M8V M3D 
+.             1506 X6A2000-0    Ba Fl Lo Ni        017 --     M8V M3V
 .             1706 X538000-0    Ba Lo Ni           003 --     M2V 
 .             2006 X433000-0    Ba Lo Ni Po        007 --     M1V M3V 
-.             2706 X757000-0    Ba Lo Ni           028 --     M6V M5D 
+.             2706 X757000-0    Ba Lo Ni           028 --     M6V M5V
 .             0307 X512000-0    Ba Ic Lo Ni        000 --     M1V 
 .             0507 X500000-0    Ba Lo Ni Va        024 --     M8V 
 .             0907 X684000-0    Ba Lo Ni           013 --     G3V 
-.             1007 X898000-0    Ba Lo Ni           002 --     M2V M6D 
+.             1007 X898000-0    Ba Lo Ni           002 --     M2V M6V
 .             1207 XAA6000-0    Ba Fl Lo Ni        023 --     F1V 
 .             1707 X438000-0    Ba Lo Ni           000 --     M1V 
-.             2207 X588000-0    Ba Lo Ni           016 --     F8V M6D 
+.             2207 X588000-0    Ba Lo Ni           016 --     F8V M6V
 .             2307 X300000-0    Ba Lo Ni Va        000 --     M7V 
 .             2407 X738000-0    Ba Lo Ni           030 --     G0V 
 .             3107 X220000-0    Ba De Lo Ni Po     024 --     G2V 
-.             0208 X9AA000-0    Ba Fl Lo Ni Wa     003 --     M0V M4D 
+.             0208 X9AA000-0    Ba Fl Lo Ni Wa     003 --     M0V M4V
 .             0708 X344000-0    Ba Lo Ni           013 --     F3V 
 .             0808 X130000-0    Ba De Lo Ni Po     008 --     M2V K9V 
-.             1008 X302000-0    Ba Ic Lo Ni Va     001 --     M4V M3D 
-.             1508 X552000-0    Ba Lo Ni Po        012 --     F3V M5D 
+.             1008 X302000-0    Ba Ic Lo Ni Va     001 --     M4V M3V
+.             1508 X552000-0    Ba Lo Ni Po        012 --     F3V M5V
 .             1608 XA9A000-0    Ba Lo Ni Wa        032 --     G0V 
 .             1708 X402000-0    Ba Ic Lo Ni Va     013 --     G6V 
 .             2108 X88A000-0    Ba Lo Ni Wa        024 --     F9V 
 .             2408 X310000-0    Ba Lo Ni           011 --     G0V 
-.             2508 X547000-0    Ba Lo Ni           006 --     K0V M3D 
+.             2508 X547000-0    Ba Lo Ni           006 --     K0V M3V
 .             2608 X728000-0    Ba Lo Ni           020 --     A1V 
-.             0209 X778000-0    Ba Lo Ni           013 --     F7V M2D 
+.             0209 X778000-0    Ba Lo Ni           013 --     F7V M2V
 .             1009 X896000-0    Ba Lo Ni           012 --     F9V 
 .             1409 X313000-0    Ba Ic Lo Ni        004 --     G5V 
 .             1509 X450000-0    Ba De Lo Ni Po     012 --     F6V 
 .             1609 X446000-0    Ba Lo Ni           001 --     G1V 
 .             2009 X310000-0    Ba Lo Ni           005 --     M7V 
-.             2909 X656000-0    Ba Lo Ni           005 --     G5V M7D 
+.             2909 X656000-0    Ba Lo Ni           005 --     G5V M7V
 .             3209 X9B3000-0    Ba Fl Lo Ni        000 --     M8V 
 .             0910 X510000-0    Ba Lo Ni           000 --     M6V 
-.             1510 X635000-0    Ba Lo Ni           003 --     M6V M2D 
+.             1510 X635000-0    Ba Lo Ni           003 --     M6V M2V
 .             1810 X746000-0    Ba Lo Ni           014 --     F2V 
 .             1910 X583000-0    Ba Lo Ni           010 --     F1V M0V 
 .             3010 X55A000-0    Ba Lo Ni Wa        003 --     K6V 
-.             3210 X696000-0    Ba Lo Ni           011 --     F8V M6D 
+.             3210 X696000-0    Ba Lo Ni           011 --     F8V M6V
 .             0411 X6B2000-0    Ba Fl Lo Ni        000 --     M6V 
-.             1111 X689000-0    Ba Lo Ni           004 --     G2V M6D 
+.             1111 X689000-0    Ba Lo Ni           004 --     G2V M6V
 .             1311 X569000-0    Ba Lo Ni           000 --     F2V 
 .             2111 X664000-0    Ba Lo Ni           000 --     F2V 
 .             0412 X542000-0    Ba Lo Ni Po        014 --     F7V 
 .             0812 X88A000-0    Ba Lo Ni Wa        000 --     M2V 
 .             1112 X753000-0    Ba Lo Ni Po        004 --     F4V 
-.             0613 X000000-0    As Ba Lo Ni        004 --     K5V M8D 
-.             1313 X130000-0    Ba De Lo Ni Po     012 --     K1V M7D 
+.             0613 X000000-0    As Ba Lo Ni        004 --     K5V M8V
+.             1313 X130000-0    Ba De Lo Ni Po     012 --     K1V M7V
 .             1913 X8C4000-0    Ba Fl Lo Ni        004 --     G3V 
 .             1214 X230000-0    Ba De Lo Ni Po     001 --     F0V 
 .             1614 X444000-0    Ba Lo Ni           000 --     F0V 
-.             2014 X538000-0    Ba Lo Ni           003 --     K2V M3D 
-.             2314 X440000-0    Ba De Lo Ni Po     014 --     M0V M8D 
-.             2414 X343000-0    Ba Lo Ni Po        004 --     F7V M4D 
+.             2014 X538000-0    Ba Lo Ni           003 --     K2V M3V
+.             2314 X440000-0    Ba De Lo Ni Po     014 --     M0V M8V
+.             2414 X343000-0    Ba Lo Ni Po        004 --     F7V M4V
 .             3014 X8B4000-0    Ba Fl Lo Ni        000 --     M2V 
-.             0815 X645000-0    Ba Lo Ni           000 --     F3V M7D 
-.             1615 X6B4000-0    Ba Fl Lo Ni        014 --     K4V M3D 
-.             1815 XAE8000-0    Ba Fl Lo Ni        010 --     M1V M2D 
+.             0815 X645000-0    Ba Lo Ni           000 --     F3V M7V
+.             1615 X6B4000-0    Ba Fl Lo Ni        014 --     K4V M3V
+.             1815 XAE8000-0    Ba Fl Lo Ni        010 --     M1V M2V
 .             2015 X886000-0    Ba Lo Ni           004 --     F0V 
 .             2115 X9B2000-0    Ba Fl Lo Ni        014 --     F9V M2V 
 .             0716 X252000-0    Ba Lo Ni Po        004 --     G0V 
-.             0916 X351000-0    Ba Lo Ni Po        000 --     F0V M5D 
+.             0916 X351000-0    Ba Lo Ni Po        000 --     F0V M5V
 .             1116 X667000-0    Ba Lo Ni           003 --     F9V 
 .             0117 X667000-0    Ba Lo Ni           000 --     F2V 
-.             0317 X544000-0    Ba Lo Ni           014 --     K9V M5D 
+.             0317 X544000-0    Ba Lo Ni           014 --     K9V M5V
 .             0417 X436000-0    Ba Lo Ni           001 --     M3V 
 .             0917 X454000-0    Ba Lo Ni           011 --     F1V 
-.             1117 X232000-0    Ba Lo Ni Po        010 --     M5V M5D 
+.             1117 X232000-0    Ba Lo Ni Po        010 --     M5V M5V
 .             1217 X76A000-0    Ba Lo Ni Wa        002 --     G6V 
-.             1617 X110000-0    Ba Lo Ni           012 --     G7V M7D 
-.             1717 X623000-0    Ba Lo Ni Po        037 --     G8V M7D 
-.             2417 X544000-0    Ba Lo Ni           004 --     K7V M4D 
-.             2717 X88A000-0    Ba Lo Ni Wa        002 --     F3V M3D 
+.             1617 X110000-0    Ba Lo Ni           012 --     G7V M7V
+.             1717 X623000-0    Ba Lo Ni Po        037 --     G8V M7V
+.             2417 X544000-0    Ba Lo Ni           004 --     K7V M4V
+.             2717 X88A000-0    Ba Lo Ni Wa        002 --     F3V M3V
 .             2917 X63A000-0    Ba Lo Ni Wa        020 --     M4V 
 .             0618 X666000-0    Ba Lo Ni           023 --     F4V 
 .             0718 X679000-0    Ba Lo Ni           012 --     F7V 
 .             1418 X492000-0    Ba Lo Ni           023 --     F2V 
 .             1818 X97A000-0    Ba Lo Ni Wa        004 --     F1V 
-.             2018 X559000-0    Ba Lo Ni           016 --     M7V M8D 
+.             2018 X559000-0    Ba Lo Ni           016 --     M7V M8V
 .             3018 X629000-0    Ba Lo Ni           002 --     M6V 
 .             0119 X348000-0    Ba Lo Ni           012 --     F5V 
 .             1219 X9D6000-0    Ba Fl Lo Ni        003 --     M1V 
-.             0320 X797000-0    Ba Lo Ni           000 --     F5V M1D 
-.             0720 X364000-0    Ba Lo Ni           005 --     F4V M5D 
-.             1320 X569000-0    Ba Lo Ni           006 --     F2V M5D 
+.             0320 X797000-0    Ba Lo Ni           000 --     F5V M1V
+.             0720 X364000-0    Ba Lo Ni           005 --     F4V M5V
+.             1320 X569000-0    Ba Lo Ni           006 --     F2V M5V
 .             2520 X100000-0    Ba Lo Ni Va        006 --     M7V K9V G1V 
 .             2820 X426000-0    Ba Lo Ni           000 --     G2V 
 .             0121 X726000-0    Ba Lo Ni           000 --     G6V M5V 
 .             0221 X897000-0    Ba Lo Ni           003 --     G7V 
-.             0721 X150000-0    Ba De Lo Ni Po     002 --     G3V M3D 
+.             0721 X150000-0    Ba De Lo Ni Po     002 --     G3V M3V
 .             0921 X94A000-0    Ba Lo Ni Wa        000 --     F3V 
 .             1021 X795000-0    Ba Lo Ni           023 --     G0V 
 .             1421 X742000-0    Ba Lo Ni Po        012 --     F7V 
 .             1721 X745000-0    Ba Lo Ni           003 --     F0V 
-.             2021 X96A000-0    Ba Lo Ni Wa        020 --     F3V M7D 
+.             2021 X96A000-0    Ba Lo Ni Wa        020 --     F3V M7V
 .             2121 X634000-0    Ba Lo Ni           002 --     M5V 
-.             2321 X778000-0    Ba Lo Ni           004 --     F5V M3D 
-.             0622 X584000-0    Ba Lo Ni           002 --     F0V M8D 
+.             2321 X778000-0    Ba Lo Ni           004 --     F5V M3V
+.             0622 X584000-0    Ba Lo Ni           002 --     F0V M8V
 .             0722 X301000-0    Ba Ic Lo Ni Va     014 --     K0V 
 .             0822 X584000-0    Ba Lo Ni           014 --     G5V 
 .             1322 X340000-0    Ba De Lo Ni Po     023 --     M3V 
 .             1522 X412000-0    Ba Ic Lo Ni        002 --     M0V 
 .             1822 X336000-0    Ba Lo Ni           001 --     M8V 
 .             2022 X545000-0    Ba Lo Ni           002 --     F2V 
-.             3122 X525000-0    Ba Lo Ni           005 --     G8V M7D 
-.             0123 X232000-0    Ba Lo Ni Po        023 --     M3V M0D 
-.             0423 X679000-0    Ba Lo Ni           000 --     F1V M0D 
+.             3122 X525000-0    Ba Lo Ni           005 --     G8V M7V
+.             0123 X232000-0    Ba Lo Ni Po        023 --     M3V M0V
+.             0423 X679000-0    Ba Lo Ni           000 --     F1V M0V
 .             0823 X74A000-0    Ba Lo Ni Wa        010 --     M4V 
-.             1023 X659000-0    Ba Lo Ni           012 --     F0V M3D 
+.             1023 X659000-0    Ba Lo Ni           012 --     F0V M3V
 .             1123 X676000-0    Ba Lo Ni           001 --     F2V 
 .             1323 X7A6000-0    Ba Fl Lo Ni        000 --     A7V 
 .             1423 X351000-0    Ba Lo Ni Po        004 --     F7V 
-.             1823 X76A000-0    Ba Lo Ni Wa        011 --     K3V M8D 
+.             1823 X76A000-0    Ba Lo Ni Wa        011 --     K3V M8V
 .             2923 X557000-0    Ba Lo Ni           001 --     F0V 
-.             0124 X9E5000-0    Ba Fl Lo Ni        004 --     M7V M5D 
-.             0324 X540000-0    Ba De Lo Ni Po     016 --     F5V M7D 
+.             0124 X9E5000-0    Ba Fl Lo Ni        004 --     M7V M5V
+.             0324 X540000-0    Ba De Lo Ni Po     016 --     F5V M7V
 .             0524 X362000-0    Ba Lo Ni           011 --     F9V 
 .             1524 X455000-0    Ba Lo Ni           002 --     F8V 
 .             2224 X5A0000-0    Ba De Lo Ni        022 --     K5V 
 .             0825 X797000-0    Ba Lo Ni           012 --     F8V 
-.             1225 X659000-0    Ba Lo Ni           000 --     G8V M8D 
-.             2425 X55A000-0    Ba Lo Ni Wa        005 --     F0V M4D 
+.             1225 X659000-0    Ba Lo Ni           000 --     G8V M8V
+.             2425 X55A000-0    Ba Lo Ni Wa        005 --     F0V M4V
 .             2925 X8C3000-0    Ba Fl Lo Ni        000 --     F9V 
-.             3025 X837000-0    Ba Lo Ni           012 --     M6V M0D 
-.             0726 X752000-0    Ba Lo Ni Po        011 --     F1V M2D 
+.             3025 X837000-0    Ba Lo Ni           012 --     M6V M0V
+.             0726 X752000-0    Ba Lo Ni Po        011 --     F1V M2V
 .             0826 X424000-0    Ba Lo Ni           002 --     M5V 
 .             1226 X500000-0    Ba Lo Ni Va        002 --     M0V 
 .             1526 X696000-0    Ba Lo Ni           010 --     F3V 
@@ -183,77 +183,77 @@ Irugangong
 .             2626 X413000-0    Ba Ic Lo Ni        003 --     M6V 
 .             2826 X425000-0    Ba Lo Ni           004 --     M5V 
 .             3126 X89A000-0    Ba Lo Ni Wa        024 --     F6V 
-.             0727 X835000-0    Ba Lo Ni           000 --     K1V M3D 
+.             0727 X835000-0    Ba Lo Ni           000 --     K1V M3V
 .             2227 X5A2000-0    Ba Fl Lo Ni        002 --     M0V 
-.             0228 X401000-0    Ba Ic Lo Ni Va     008 --     M2V M7D 
+.             0228 X401000-0    Ba Ic Lo Ni Va     008 --     M2V M7V
 .             0328 X73A000-0    Ba Lo Ni Wa        002 --     M5V 
 .             0728 X235000-0    Ba Lo Ni           002 --     M4V 
-.             1128 X000000-0    As Ba Lo Ni        014 --     F2V M3D M4D 
-.             2528 X786000-0    Ba Lo Ni           022 --     F8V M0D M1D 
+.             1128 X000000-0    As Ba Lo Ni        014 --     F2V M3D M4V
+.             2528 X786000-0    Ba Lo Ni           022 --     F8V M0D M1V
 .             2828 X300000-0    Ba Lo Ni Va        000 --     M7V 
 .             3028 X100000-0    Ba Lo Ni Va        013 --     F6V M1V 
 .             3228 X737000-0    Ba Lo Ni           015 --     K0V 
 .             0129 X303000-0    Ba Ic Lo Ni Va     000 --     F6V 
 .             0629 X8A0000-0    Ba De Lo Ni        014 --     F7V 
 .             1829 X372000-0    Ba Lo Ni           000 --     G8V 
-.             2229 X887000-0    Ba Lo Ni           005 --     F2V M6D 
-.             2829 X324000-0    Ba Lo Ni           005 --     M0V M5D 
-.             3029 X502000-0    Ba Ic Lo Ni Va     010 --     M2II K0D 
+.             2229 X887000-0    Ba Lo Ni           005 --     F2V M6V
+.             2829 X324000-0    Ba Lo Ni           005 --     M0V M5V
+.             3029 X502000-0    Ba Ic Lo Ni Va     010 --     M2II K0V
 .             0130 X78A000-0    Ba Lo Ni Wa        021 --     F2V 
 .             0430 X863000-0    Ba Lo Ni           000 --     F1V M7V 
 .             0530 X434000-0    Ba Lo Ni           003 --     G1V 
 .             0730 X252000-0    Ba Lo Ni Po        004 --     F9V 
 .             1830 X510000-0    Ba Lo Ni           013 --     F5V 
-.             2230 X9D2000-0    Ba Fl Lo Ni        000 --     M6V M3D 
-.             3030 X994000-0    Ba Lo Ni           025 --     F5V M6D 
-.             0531 X341000-0    Ba Lo Ni Po        000 --     K2V M0D 
-.             0631 X898000-0    Ba Lo Ni           001 --     F9V M7D 
+.             2230 X9D2000-0    Ba Fl Lo Ni        000 --     M6V M3V
+.             3030 X994000-0    Ba Lo Ni           025 --     F5V M6V
+.             0531 X341000-0    Ba Lo Ni Po        000 --     K2V M0V
+.             0631 X898000-0    Ba Lo Ni           001 --     F9V M7V
 .             0931 X8A9000-0    Ba Fl Lo Ni        002 --     F3II 
-.             1131 X884000-0    Ba Lo Ni           004 --     F2V M6D 
+.             1131 X884000-0    Ba Lo Ni           004 --     F2V M6V
 .             1531 X210000-0    Ba Lo Ni           024 --     K7V 
 .             1831 X436000-0    Ba Lo Ni           015 --     F9V 
-.             2431 X506000-0    Ba Ic Lo Ni Va     007 --     M5V M3D 
+.             2431 X506000-0    Ba Ic Lo Ni Va     007 --     M5V M3V
 .             2531 X237000-0    Ba Lo Ni           004 --     M3V 
 .             3031 X510000-0    Ba Lo Ni           024 --     K7V 
 .             0132 X96A000-0    Ba Lo Ni Wa        000 --     F0V 
 .             0832 X100000-0    Ba Lo Ni Va        004 --     M4V 
 .             0932 X648000-0    Ba Lo Ni           000 --     F7V 
-.             1732 X130000-0    Ba De Lo Ni Po     000 --     M3V M0D 
+.             1732 X130000-0    Ba De Lo Ni Po     000 --     M3V M0V
 .             2332 X575000-0    Ba Lo Ni           014 --     F4V 
 .             2832 X240000-0    Ba De Lo Ni Po     010 --     F3V 
 .             0433 X576000-0    Ba Lo Ni           003 --     F4V 
 .             0833 X896000-0    Ba Lo Ni           003 --     G5V 
-.             1433 X784000-0    Ba Lo Ni           014 --     F5V M0D 
-.             1533 X788000-0    Ba Lo Ni           002 --     F0V M3D 
+.             1433 X784000-0    Ba Lo Ni           014 --     F5V M0V
+.             1533 X788000-0    Ba Lo Ni           002 --     F0V M3V
 .             2633 X263000-0    Ba Lo Ni           000 --     F6V 
 .             0334 X666000-0    Ba Lo Ni           002 --     F6V 
-.             0634 X568000-0    Ba Lo Ni           005 --     K1V M4D 
+.             0634 X568000-0    Ba Lo Ni           005 --     K1V M4V
 .             0934 X464000-0    Ba Lo Ni           000 --     M4V 
-.             1334 X787000-0    Ba Lo Ni           004 --     F1V M4D 
+.             1334 X787000-0    Ba Lo Ni           004 --     F1V M4V
 .             1834 X9B7000-0    Ba Fl Lo Ni        010 --     F0V 
 .             0135 X120000-0    Ba De Lo Ni Po     000 --     K5V 
-.             0635 X444000-0    Ba Lo Ni           001 --     K5V M6D 
-.             1335 X7C3000-0    Ba Fl Lo Ni        024 --     K0V M3D 
+.             0635 X444000-0    Ba Lo Ni           001 --     K5V M6V
+.             1335 X7C3000-0    Ba Fl Lo Ni        024 --     K0V M3V
 .             1735 X433000-0    Ba Lo Ni Po        000 --     M3V 
 .             1935 X435000-0    Ba Lo Ni           016 --     M0V M2V 
 .             2335 X210000-0    Ba Lo Ni           004 --     K6V 
-.             2935 X556000-0    Ba Lo Ni           002 --     F9V M2D 
+.             2935 X556000-0    Ba Lo Ni           002 --     F9V M2V
 .             0436 X200000-0    Ba Lo Ni Va        003 --     F1III 
-.             0636 X76A000-0    Ba Lo Ni Wa        002 --     F7V M6D 
+.             0636 X76A000-0    Ba Lo Ni Wa        002 --     F7V M6V
 .             0836 X443000-0    Ba Lo Ni Po        014 --     M2V 
 .             1036 X444000-0    Ba Lo Ni           001 --     F4V 
-.             1236 X510000-0    Ba Lo Ni           004 --     K5V M0D 
-.             1336 X685000-0    Ba Lo Ni           003 --     F6V M1D 
+.             1236 X510000-0    Ba Lo Ni           004 --     K5V M0V
+.             1336 X685000-0    Ba Lo Ni           003 --     F6V M1V
 .             2236 X7B4000-0    Ba Fl Lo Ni        003 --     G7V K5V 
 .             2636 X784000-0    Ba Lo Ni           014 --     M3V 
-.             0137 X654000-0    Ba Lo Ni           005 --     K9V M3D 
-.             0537 X353000-0    Ba Lo Ni Po        005 --     F8V M1D 
+.             0137 X654000-0    Ba Lo Ni           005 --     K9V M3V
+.             0537 X353000-0    Ba Lo Ni Po        005 --     F8V M1V
 .             1037 X629000-0    Ba Lo Ni           003 --     F9V 
 .             1237 X441000-0    Ba Lo Ni Po        003 --     F9V 
 .             2637 X421000-0    Ba Lo Ni Po        012 --     M0III M7V 
-.             3237 X97A000-0    Ba Lo Ni Wa        007 --     K8V M7D 
-Dunaekh       0638 D233433-5    Ni Po              703 Va     M2V M2D 
-Fuerrdzou     0838 C473533-5    Ag Ni              206 Va     G8V M0D 
+.             3237 X97A000-0    Ba Lo Ni Wa        007 --     K8V M7V
+Dunaekh       0638 D233433-5    Ni Po              703 Va     M2V M2V
+Fuerrdzou     0838 C473533-5    Ag Ni              206 Va     G8V M0V
 Zosouktsue    1438 C446587-5    Ag Ni              723 Va     F4V 
 Lukhughung    1638 CAC4641-6  H Fl Ni              401 Va     F6V 
 .             3238 X545000-0    Ba Lo Ni           003 --     M1V 
@@ -263,7 +263,7 @@ Dhakonakh     1439 C426320-4  G Lo Ni              403 Va     M0V
 Lollnanougz   1539 C666469-7    Ni                 302 Va     F2V 
 Oethun        2239 C000224-7  C As Lo Ni           602 Va     M1V 
 Anghorrsoug   0440 A67A777-B  G Wa                 602 Va     F5V 
-Vuangknekh    1340 E340304-7    De Lo Ni Po        615 Va     F3V M4D 
+Vuangknekh    1340 E340304-7    De Lo Ni Po        615 Va     F3V M4V
 Gvoloer       1440 D547684-5  G Ag Ni              401 Va     F5V 
 Rrangaeng     1540 C64A87A-3    Wa                 212 Va     G9V 
-.             3140 X525000-0    Ba Lo Ni           005 --     M8V M4D 
+.             3140 X525000-0    Ba Lo Ni           005 --     M8V M4V

--- a/res/Sectors/M1105/Kfazz Ghik.tab
+++ b/res/Sectors/M1105/Kfazz Ghik.tab
@@ -12,7 +12,7 @@ Kfaz	A	0509	Soefe	C655147-5		Lo Ni		710	Va	F6 V						0
 Kfaz	A	0601	Ksoekadhao	B425400-E	K	Ni		504	Va	F4 V						0
 Kfaz	A	0602	Llaengkusous	C552757-5	C	Po		401	Va	F8 V						0
 Kfaz	A	0607	Knuougnouks	E140477-7	C	De Ni Po		504	Va	F8 V						0
-Kfaz	A	0702	Suegaeknaee	B322566-9		Ni Po		110	Va	F8 V F5 II						0
+Kfaz	A	0702	Suegaeknaee	B322566-9		Ni Po		110	Va	F5 II F8 V						0
 Kfaz	A	0709	Koungeksdoth	C432232-5	C	Lo Ni Po		102	Va	M4 V						0
 Kfaz	A	0809	Koighousaedh	C5A3545-5	K	Fl Ni		413	Va	K1 V						0
 Kfaz	A	0810	Knaaedo	C210300-7	K	Lo Ni		503	Va	M6 V						0
@@ -38,7 +38,7 @@ Kfaz	C	1803	Knotuoksu	E000415-9		As Ni		821	Va	F4 V D						0
 Kfaz	C	1905	Agorrirrar	C633675-3	C	Na Ni Po		116	Va	K7 V M4 V D						0
 Kfaz	C	1906	Lluethou	E412653-5		Ic Na Ni		901	Va	F6 V D						0
 Kfaz	C	1907	Koengko	C68A69A-5	C	Ni Ri Wa		421	Va	F3 V						0
-Kfaz	C	2002	Reru	A5958CB-9				906	Va	F9 V M0 V F6 V D						0
+Kfaz	C	2002	Reru	A5958CB-9				906	Va	F6 V M0 V F9 V D						0
 Kfaz	C	2003	Ruerrrrur	C8C3877-7		Fl		504	Va	F5 V D						0
 Kfaz	C	2103	Zaluerukhs	D371205-9	K	Lo Ni		801	Va	K9 V						0
 Kfaz	C	2107	Zifoenglaerr	C8A5000-8		Ba Fl Lo Ni		403	Va	G2 IV M5 V						0

--- a/res/Sectors/M1105/Kharrthon.sec
+++ b/res/Sectors/M1105/Kharrthon.sec
@@ -14,105 +14,105 @@ Kharrthon
 #--------1---------2---------3---------4---------5---------6---
 #PlanetName   Loc. UPP Code   B   Notes         Z  PBG Al LRX *
 #----------   ---- ---------  - --------------- -  --- -- --- -
-Giaeknoghoek  0201 C547556-6  C Ag Ni              403 Va     F0V M6D 
+Giaeknoghoek  0201 C547556-6  C Ag Ni              403 Va     F0V M6V
 Aerreong      1601 C572877-4                       310 Va     K0V 
 Gaengdhang    1701 B384572-A    Ag Ni              310 Va     F6V 
 Orraedhez     1901 E400300-5  C Lo Ni Va           722 Va     F0V 
 Savengroug    2101 C987679-3    Ag Ni              604 Va     M3V 
 Kogvuengu     2401 D779569-5  C Ni                 110 Va     G2V 
 Gnoengoezvik  2601 A000202-F    As Lo Ni           405 Va     M6III K6V 
-Athgvuek      2901 C636420-7  G Ni                 714 Va     K1V M1D 
-Uda           0502 X584225-0  C Lo Ni              613 Va     F1V M2D 
-Suetsoezu     1002 C223540-9  G Ni Po              904 Va     M4V M8D 
-Suedhaedz     1302 D100002-7    Lo Ni Va           700 Va     G4IV M8D 
-Koudzangarr   1402 C77355A-4    Ag Ni              902 Va     F2V M8D 
+Athgvuek      2901 C636420-7  G Ni                 714 Va     K1V M1V
+Uda           0502 X584225-0  C Lo Ni              613 Va     F1V M2V
+Suetsoezu     1002 C223540-9  G Ni Po              904 Va     M4V M8V
+Suedhaedz     1302 D100002-7    Lo Ni Va           700 Va     G4IV M8V
+Koudzangarr   1402 C77355A-4    Ag Ni              902 Va     F2V M8V
 Uearrdhenor   2002 E3325AB-6  C Ni Po              103 Va     G8V 
 Oeghzgnong    2402 CAB3676-8  G Fl Ni              705 Va     F7V M7V 
 Ifekhoerrers  2502 C858000-5  G Ba Lo Ni           101 Va     F2V 
-Rroezuegz     2602 C895521-7    Ag Ni              904 Va     F8V M1D 
+Rroezuegz     2602 C895521-7    Ag Ni              904 Va     F8V M1V
 Gollaksien    2802 C442002-8    Lo Ni Po           502 Va     F0V 
 Dzoghuerrvae  0103 C628343-5    Lo Ni              303 VA     M0V 
-Zaeuerrgh     0203 E447675-1  C Ag Ni              414 VA     F4V M5D 
+Zaeuerrgh     0203 E447675-1  C Ag Ni              414 VA     F4V M5V
 Dhoukfur      0303 C685785-4    Ag                 405 VA     F6V 
-Dhaekhoze     0703 A9B3676-8  G Fl Ni              701 Va     M2V M8D 
-Kurueghul     1103 C526AA5-8  G Hi In              501 Va     K5V M0D 
-Faondholan    1203 C875103-7  G Lo Ni              902 Va     F5V M4D 
+Dhaekhoze     0703 A9B3676-8  G Fl Ni              701 Va     M2V M8V
+Kurueghul     1103 C526AA5-8  G Hi In              501 Va     K5V M0V
+Faondholan    1203 C875103-7  G Lo Ni              902 Va     F5V M4V
 Duea          1303 D410424-7  G Ni                 604 Va     M0V 
 Nukfidhoe     1603 C69A474-5  G Ni Wa              822 Va     F0V 
 Khuae         1703 C120776-A    De Na Po           814 Va     M2V 
-Ufoghekhu     1903 B847464-9    Ni                 700 Va     G6V M1D 
+Ufoghekhu     1903 B847464-9    Ni                 700 Va     G6V M1V
 Rroudzifen    2103 B470526-A  G De Ni              703 Va     F9V 
-Ksoesue       2603 D310795-4  C Na                 905 Va     M6V M6D 
-Aeaghzfing    3203 C788665-4    Ag Ni Ri           303 Va     F5V M8D 
+Ksoesue       2603 D310795-4  C Na                 905 Va     M6V M6V
+Aeaghzfing    3203 C788665-4    Ag Ni Ri           303 Va     F5V M8V
 Naaellina     0104 C67347B-6  H Ni                 504 VA     K4V 
-Kiunaez       0304 C100975-A    Hi Na Va           900 VA     K4V M2D 
-Noea          0404 B460443-B    De Ni              307 VA     K8V M0D 
+Kiunaez       0304 C100975-A    Hi Na Va           900 VA     K4V M2V
+Noea          0404 B460443-B    De Ni              307 VA     K8V M0V
 Uzaaer        0604 DAA3775-2  C Fl                 514 VA     M4V 
-Sorsvadh      1204 C410856-7    Na                 316 Va     M2V M6D 
+Sorsvadh      1204 C410856-7    Na                 316 Va     M2V M6V
 Gugnaoegnae   1504 E8A1300-5  C Fl Lo Ni           701 Va     K2V 
-Urukueiaek    2804 B672763-6  C                    402 Va     G9V M1D 
-Vaevasagh     2904 A651304-C  G Lo Ni Po           404 Va     F4V M5D 
-Faeghzaeghz   3104 C437300-5    Lo Ni              704 Va     F2V M0D 
-Llaekaello    0105 C867577-6    Ag Ni              513 VA     F1V M5D 
+Urukueiaek    2804 B672763-6  C                    402 Va     G9V M1V
+Vaevasagh     2904 A651304-C  G Lo Ni Po           404 Va     F4V M5V
+Faeghzaeghz   3104 C437300-5    Lo Ni              704 Va     F2V M0V
+Llaekaello    0105 C867577-6    Ag Ni              513 VA     F1V M5V
 Lotsoerr      0505 C2608AD-5    De                 612 VA     F8V 
 Thagnirgnigh  0605 C514668-8  C Ic Ni              802 VA     M0V 
 Uenughzuen    0905 B000500-D  G As Ni              604 VA     M2V 
-Ertogoezung   1205 A00087A-A    As Na              623 Va     F9D 
+Ertogoezung   1205 A00087A-A    As Na              623 Va     F9V
 Akhkokhsursa  2005 C433676-7    Na Ni Po           302 Va     M6V 
 Aezu          2105 C869342-7    Lo Ni              801 Va     F6V 
-Rruorzaen     2405 C55A115-8    Lo Ni Wa           315 Va     M4V M2D 
+Rruorzaen     2405 C55A115-8    Lo Ni Wa           315 Va     M4V M2V
 Aear          2905 C779104-A    Lo Ni              303 Va     F8V 
 Nueouruek     3005 C96A435-8  G Ni Wa              103 Va     F9V 
 Vaenoetsuel   3205 C201223-8    Ic Lo Ni Va        704 Va     M5V M7V 
-Foerill       0306 C000866-A    As Na              106 VA     F5V M7D 
+Foerill       0306 C000866-A    As Na              106 VA     F5V M7V
 Kouskokok     0706 A120572-9  G De Ni Po           322 VA     F4V 
-Soeug         0806 C438779-3                       428 VA     K3V M2D 
-Ardzunghaell  0906 C787663-7    Ag Ni Ri           802 VA     F7V M1D 
+Soeug         0806 C438779-3                       428 VA     K3V M2V
+Ardzunghaell  0906 C787663-7    Ag Ni Ri           802 VA     F7V M1V
 Lluzdzez      1006 B40049C-8  G Ni Va              904 VA     M0V 
-Saedhaduearr  1206 C9C6545-7  G Fl Ni              906 Va     M6V M7D 
+Saedhaduearr  1206 C9C6545-7  G Fl Ni              906 Va     M6V M7V
 Dzaezarran    1306 E410501-3  C Ni                 702 Va     A0V 
 Ghoedhugu     1606 E6897CA-6  C                    700 Va     K3V 
-Uengourrvi    1706 D99A545-5    Ni Wa              603 Va     F8V M1D 
-Ghuerrghaeng  1806 C662959-6  C Hi In              704 Va     F8V M2D 
+Uengourrvi    1706 D99A545-5    Ni Wa              603 Va     F8V M1V
+Ghuerrghaeng  1806 C662959-6  C Hi In              704 Va     F8V M2V
 Angaeks       2006 D30099A-4    Hi Na Va           600 Va     F1V 
 Agzoe         2206 B200412-B    Ni Va              702 Va     M4V 
-Gaedhukagz    2606 C130100-9    De Lo Ni Po        810 Va     M0V M2D 
-Dhighaeue     2806 E100676-5  C Na Ni Va           700 Va     M1II M6D 
-Vueroeghaeng  0307 C310344-7    Lo Ni              522 VA     G9V M2D 
+Gaedhukagz    2606 C130100-9    De Lo Ni Po        810 Va     M0V M2V
+Dhighaeue     2806 E100676-5  C Na Ni Va           700 Va     M1II M6V
+Vueroeghaeng  0307 C310344-7    Lo Ni              522 VA     G9V M2V
 Dingounoerr   0507 C87859B-7  G Ag Ni              822 VA     F0V 
-Tongeghdzoeg  0707 B655320-9    Lo Ni              103 VA     F8V M4D 
+Tongeghdzoeg  0707 B655320-9    Lo Ni              103 VA     F8V M4V
 Zoesoullo     0807 E414352-6    Ic Lo Ni           101 VA     F9V M6V 
-Dzoidhi       0907 B598134-9    Lo Ni              401 VA     F5V M1D 
-Lleze         1207 C463122-4  C Lo Ni              201 Va     F7V M8D 
+Dzoidhi       0907 B598134-9    Lo Ni              401 VA     F5V M1V
+Lleze         1207 C463122-4  C Lo Ni              201 Va     F7V M8V
 Dooluesoel    1307 C520341-9  C De Lo Ni Po        103 Va     M4V 
 Roerraedzurr  1407 A666202-D    Lo Ni              700 Va     G9V 
 Gnoelageng    1607 C475545-7  G Ag Ni              514 Va     F3V 
-Khuekhuenaer  2007 E300200-5    Lo Ni Va           723 Va     M0V M1D 
-Ikhoe         2307 B512420-6    Ic Ni              702 Va     G8V M8D 
-Kifaeghuedz   2607 A355576-C  G Ag Ni              420 Va     F1V M6D 
-Aefoudzun     2807 C796552-9  H Ag Ni              902 Va     F0V M3D 
+Khuekhuenaer  2007 E300200-5    Lo Ni Va           723 Va     M0V M1V
+Ikhoe         2307 B512420-6    Ic Ni              702 Va     G8V M8V
+Kifaeghuedz   2607 A355576-C  G Ag Ni              420 Va     F1V M6V
+Aefoudzun     2807 C796552-9  H Ag Ni              902 Va     F0V M3V
 Oegargvodhol  0508 E537347-6    Lo Ni              201 VA     K2V 
 Ngeroelkhuer  0808 C69457A-5  C Ag Ni              414 VA     K5V 
 Tosdzigh      1008 D492541-6  C Ni                 303 VA     F1V 
-Rrorszetszar  1308 B769632-6    Ni                 211 Va     F6V M4D 
+Rrorszetszar  1308 B769632-6    Ni                 211 Va     F6V M4V
 Ngaezkhodz    1508 D140237-6    De Lo Ni Po        505 Va     G5V M1D F2V 
 Vudzankuers   2008 A100332-D    Lo Ni Va           104 Va     M4V 
 Okuea         2408 C588351-7  G Lo Ni              611 Va     F2V 
-Koungruerz    3108 C67A516-4  C Ni Wa              704 Va     M8V M4D 
+Koungruerz    3108 C67A516-4  C Ni Wa              704 Va     M8V M4V
 Gnaefugaa     0409 E588674-4    Ag Ni              414 VA     K6V 
 Khoeka        0509 C31375A-7    Ic Na              801 VA     M4V 
-Guezegdaedh   1109 B457431-9  G Ni                 614 VA     F5V M8D 
+Guezegdaedh   1109 B457431-9  G Ni                 614 VA     F5V M8V
 Ghodazo       1309 B231251-C  C Lo Ni Po           602 Va     F2V 
-Kozuarrgh     1509 A864689-7  G Ag Ni              313 Va     K1V M2D 
+Kozuarrgh     1509 A864689-7  G Ag Ni              313 Va     K1V M2V
 Figoung       1709 B463625-B  C Ag Ni              302 Va     F2V 
 Ekidzueoga    1809 C413674-8    Ic Na Ni           814 Va     G9V 
 Anggheng      2109 A527775-7  G                    700 Va     M5V 
 Serrilaoun    2309 A569674-8    Ni                 623 Va     F0V 
 Oeguelsave    2509 D5336AD-5    Na Ni Po           302 Va     G6V 
-Ragaetskfang  2809 A538200-B  G Lo Ni              516 Va     G3V M2D 
+Ragaetskfang  2809 A538200-B  G Lo Ni              516 Va     G3V M2V
 Dzeuelae      2909 D79447A-6  G Ni                 310 Va     G6V 
 Dzuekhae      0110 A201679-C    Ic Na Ni Va        400 VA     F0III M7V 
-Tsaorslluegh  0310 B120964-B  G De Hi In Na Po     305 VA     M2V M7D 
+Tsaorslluegh  0310 B120964-B  G De Hi In Na Po     305 VA     M2V M7V
 Gnuraun       0510 B687773-5    Ag                 502 VA     K5V 
 Douduello     0810 C853210-4    Lo Ni Po           805 VA     F6V 
 Zoeueksdhang  1110 C361896-6  C Ri                 120 VA     F1V 
@@ -120,29 +120,29 @@ Ghithae       1210 B9B8977-9  G Fl Hi In           800 VA     G1V
 Zua           1610 C321774-3  G Na Po              620 Va     M0II 
 Rredhaelling  1710 B230303-B    De Lo Ni Po        222 Va     G4IV M4V 
 Gzuela        1810 C698897-3  H                    502 Va     F3V 
-Daeksogfun    1910 B210848-7    Na                 203 Va     F2V M1D 
+Daeksogfun    1910 B210848-7    Na                 203 Va     F2V M1V
 Zuesakh       2310 D327152-3    Lo Ni              300 Va     M7II 
 Rresorrues    2610 D457532-4    Ag Ni              305 Va     F7V 
 Aengsuirr     2710 X686221-0  C Lo Ni              903 Va     F8V 
-Naerrekue     2810 D56A100-7    Lo Ni Wa           302 Va     F4V M1D 
+Naerrekue     2810 D56A100-7    Lo Ni Wa           302 Va     F4V M1V
 Gnadaki       3210 C77A335-9  G Lo Ni Wa           714 Va     F9V 
 Naitsudhdhue  1011 C140877-8    De Po              904 VA     F2V 
 Urrar         1111 D546855-0                       314 VA     K0V 
 Dzitsuthzuel  1211 C610466-8  G Ni                 502 VA     M2V 
 Kedheroue     1811 XA95452-3  C Ni                 215 Va     F2V 
-Naevueso      1911 B564877-8                       904 Va     K6V M1D 
+Naevueso      1911 B564877-8                       904 Va     K6V M1V
 Dzadaeng      2311 B995773-A  C Ag                 225 Va     F0V 
-Kfuokoug      2511 C510878-5  C Na                 704 Va     F8V M7D 
+Kfuokoug      2511 C510878-5  C Na                 704 Va     F8V M7V
 Uefanuergul   2811 C2306AA-A    De Na Ni Po        303 Va     M7V 
 Gharskall     3111 E41077A-8    Na                 614 Va     M4V 
 Dhuekaga      0112 B6897AD-6                       604 VA     F1V 
-Othaevoza     0212 D555412-1  G Ni                 105 VA     F2V M8D 
+Othaevoza     0212 D555412-1  G Ni                 105 VA     F2V M8V
 Kokikgzaz     0312 E321110-4  C Lo Ni Po           737 VA     K2V K4V 
 Vuue          0612 B323520-D    Ni Po              813 VA     K3V 
 Aeueaeue      0912 E96767B-0    Ag Ni              103 VA     F7V 
 Ikeothoer     1012 E772676-1  C Ni                 804 VA     F8V 
 Anthaengas    1112 C544964-7    Hi In              212 VA     F8V 
-Rougedhuedae  1312 C987598-6  C Ag Ni              506 VA     G3V M0D 
+Rougedhuedae  1312 C987598-6  C Ag Ni              506 VA     G3V M0V
 Daagzghu      1912 E686130-0  C Lo Ni              802 Va     F7V 
 Touaen        2512 C492331-7    Lo Ni              321 Va     F0V 
 Onsaerr       2712 D323979-5    Hi In Na Po        102 Va     F7V 
@@ -150,20 +150,20 @@ Sanourrvue    2912 B365986-C    Hi In              203 Va     F0V
 Ouae          3212 C353663-4    Ag Ni Po           422 Va     M4V 
 Kougoeknoo    0613 D000432-4    As Ni              601 VA     M7V 
 Ghadho        0713 C466667-8  C Ag Ni Ri           702 VA     F0V 
-Saeoenkoekhs  0913 B453799-7  G Ag Po              503 VA     F3V M1D 
+Saeoenkoekhs  0913 B453799-7  G Ag Po              503 VA     F3V M1V
 Aeo           1013 X888100-3    Lo Ni              404 VA     F4V 
 Oksagzadz     1213 C9A7430-6  C Fl Ni              515 VA     F9V 
 Rrokaegz      1313 C7A7675-5    Fl Ni              902 VA     M5V 
 Otia          1513 B400510-A  G Ni Va              105 Va     M0V M7D G4V 
-Gagfueging    1813 C795573-2  G Ag Ni              203 Va     F3V M8D 
+Gagfueging    1813 C795573-2  G Ag Ni              203 Va     F3V M8V
 Khueagzeaek   1913 C638557-7    Ni                 600 Va     M0V 
 Iofue         2013 E78A101-7  C Lo Ni Wa           603 Va     F0V 
-Faekhusi      2513 C00099A-6    As Hi Na           316 Va     F7D M5D M3D 
+Faekhusi      2513 C00099A-6    As Hi Na           316 Va     F7D M5D M3V
 Tsaetsaeaek   0514 C674341-6    Lo Ni              410 VA     F0V 
 Alleu         1314 C8A3537-9  C Fl Ni              910 VA     M8II M6V 
-Oeza          1714 D646000-1  C Ba Lo Ni           600 Va     G8V M7D 
-Zugnangrrang  1914 C479775-6                       303 Va     K9V M6D 
-Eog           0115 C45157B-4    Ni Po              410 VA     F5V M3D 
+Oeza          1714 D646000-1  C Ba Lo Ni           600 Va     G8V M7V
+Zugnangrrang  1914 C479775-6                       303 Va     K9V M6V
+Eog           0115 C45157B-4    Ni Po              410 VA     F5V M3V
 Eo            0915 C622877-5    Na Po              822 VA     F6V 
 Ouksoerr      1015 C667655-8    Ag Ni Ri           600 VA     F4V 
 Knoka         1115 B465542-8    Ag Ni              214 VA     F3V M0V 
@@ -171,104 +171,104 @@ Gughkfaen     1215 C78A200-A  G Lo Ni Wa           911 VA     F7V
 Thuerragae    1315 B557676-8  C Ag Ni              114 VA     F9V 
 Zuezuen       1415 E689455-6  C Ni                 713 Va     F3V 
 Asae          2115 E446665-1    Ag Ni              511 Va     F6V 
-Faaegugz      2615 C66A467-6  G Ni Wa              106 Va     K5V M4D 
-Rakoa         2915 A446976-A    Hi In              304 Va     M5V M7D 
+Faaegugz      2615 C66A467-6  G Ni Wa              106 Va     K5V M4V
+Rakoa         2915 A446976-A    Hi In              304 Va     M5V M7V
 Aenagzkson    3115 C14068B-9    De Ni Po           904 Va     M1V 
 Ulknoekhsung  3215 C869479-5    Ni                 722 Va     F8V 
 Gouengon      0216 A6A3444-C  G Fl Ni              300 VA     M6V 
 Oze           0316 C674424-2    Ni                 414 VA     F5V M4V 
-Ikhaeue       0416 C465977-8    Hi In              300 VA     M2V M8D 
+Ikhaeue       0416 C465977-8    Hi In              300 VA     M2V M8V
 Ueasa         0516 A410872-9  G Na                 110 VA     K0V 
-Tsaoughaou    0716 E200565-8  C Ni Va              724 VA     A6V M2D 
+Tsaoughaou    0716 E200565-8  C Ni Va              724 VA     A6V M2V
 Roegaeghz     0816 D545232-2    Lo Ni              621 VA     F6V 
 Dzaeigaezoun  1016 CA9A536-7  G Ni Wa              601 VA     M8V 
 Kesoudhu      1516 C551754-8  G Po                 321 Va     F2V 
 Iuegzae       1616 C120455-A  C De Ni Po           511 Va     G8V 
-Osue          1716 C538365-6    Lo Ni              402 Va     M6V M0D 
+Osue          1716 C538365-6    Lo Ni              402 Va     M6V M0V
 Soeza         1816 B348876-5  G                    510 Va     F1V 
 Kfaefoutanae  2816 D9B5748-6  G Fl                 204 Va     M2V M8V 
 Uenguekna     3216 C78487A-2  G                    504 Va     F1V 
 Tsesogtaegh   0117 B5619AA-8    Hi In              113 VA     F0V 
 Uae           0617 E384978-7  C Hi In              614 VA     F8V 
 Llasaegnoudo  0717 B8B5002-9  G Fl Lo Ni           912 VA     M7V 
-Uozouzou      2017 B352200-6    Lo Ni Po           918 Va     F5V M4D M1D 
+Uozouzou      2017 B352200-6    Lo Ni Po           918 Va     F5V M4D M1V
 Llaetha       2117 B000987-A  G As Hi Na           103 Va     F9V 
 Rrakha        2717 C55559B-4  C Ag Ni              401 Va     G2V 
-Asaegnig      3017 C8C1A7B-8    Fl Hi In           607 Va     F0V M8D 
-Iaellouk      0318 C785878-5  C                    925 VA     F3V M3D 
+Asaegnig      3017 C8C1A7B-8    Fl Hi In           607 Va     F0V M8V
+Iaellouk      0318 C785878-5  C                    925 VA     F3V M3V
 Khikingfoerz  1018 B639424-8    Ni                 303 VA     G5V 
-Vazuenaghun   1918 C451658-6    Ni Po              702 Va     F7V M1D 
-Vuenga        2318 A380513-C  G De Ni              305 Va     F5V M8D 
+Vazuenaghun   1918 C451658-6    Ni Po              702 Va     F7V M1V
+Vuenga        2318 A380513-C  G De Ni              305 Va     F5V M8V
 Ghallane      2918 E000235-A  C As Lo Ni           820 Va     F1V 
 Roelagzkedh   3218 B659100-6  G Lo Ni              100 Va     F5V 
 Rragvudhue    0119 C89A232-9    Lo Ni Wa           405 VA     F6V 
-Faesuk        0319 A2217AC-9  G Na Po              921 VA     M7V M6D 
+Faesuk        0319 A2217AC-9  G Na Po              921 VA     M7V M6V
 Koughzighaek  0519 E666878-0                       815 VA     F9V 
-Zazouvuving   0619 B300220-7  G Lo Ni Va           800 VA     M5V M2D 
+Zazouvuving   0619 B300220-7  G Lo Ni Va           800 VA     M5V M2V
 Gaesaevoe     0719 B87A685-C  G Ni Wa              602 VA     F4V 
-Ouvoe         1119 E486874-0                       604 VA     F2V M0D M7D 
-Vaeo          1519 C884523-8    Ag Ni              104 Va     F5V M3D 
-Kueghakhe     1619 A200A79-J    Hi Na Va           602 Va     F0V M7D 
+Ouvoe         1119 E486874-0                       604 VA     F2V M0D M7V
+Vaeo          1519 C884523-8    Ag Ni              104 Va     F5V M3V
+Kueghakhe     1619 A200A79-J    Hi Na Va           602 Va     F0V M7V
 Guthorr       1919 B96A441-9    Ni Wa              404 Va     F1V 
-Gegoes        2719 B6A2568-9  G Fl Ni              202 VD     G0V M5D 
+Gegoes        2719 B6A2568-9  G Fl Ni              202 VD     G0V M5V
 Nangurrghong  0420 X5007CD-2  C Na Va              400 VA     F0V M6D M4V 
-Zegzaning     0520 B220442-D  G De Ni Po           100 VA     M3V K8D 
-Aetaghinoen   0720 C98A322-9  G Lo Ni Wa           200 VA     F0V M8D 
+Zegzaning     0520 B220442-D  G De Ni Po           100 VA     M3V K8V
+Aetaghinoen   0720 C98A322-9  G Lo Ni Wa           200 VA     F0V M8V
 Gzaetaen      0820 C445559-7  G Ag Ni              714 VA     F6V 
 Deghaelaegh   1120 C764200-5  C Lo Ni              715 VA     F5V M0D F2V 
 Naegoulli     1320 D665402-6  G Ni                 500 Va     F7V 
-Euesiou       1420 B729A74-B    Hi In              814 Va     K1V M0D 
+Euesiou       1420 B729A74-B    Hi In              814 Va     K1V M0V
 Vaedhezae     1520 E274465-4  C Ni                 202 Va     F5V 
 Faekfuvae     1720 E665400-5  C Ni                 900 Va     M4V 
 Uerrogugaen   2420 C564548-2  G Ag Ni              403 VD     M3V 
 Aegounadzudh  2620 C888100-7    Lo Ni              302 VD     G7V 
-Oeoekhallong  2720 D757667-3  C Ag Ni              613 VD     F9V M4D 
+Oeoekhallong  2720 D757667-3  C Ag Ni              613 VD     F9V M4V
 Vuedzadagaeg  2820 E525210-1  C Lo Ni              214 VD     K2V 
 Llangukhug    2920 E524101-4  C Lo Ni              600 VD     M5V 
 Kfagghong     3020 D411877-3  C Ic Na              502 VD     F9V 
-Rrigzuekoen   0421 C77698A-5    Hi In              108 VA     K1V M6V M3D 
+Rrigzuekoen   0421 C77698A-5    Hi In              108 VA     K1V M6V M3V
 Llorras       0521 B120697-6  C De Na Ni Po        501 VA     M2V 
 Valukh        0621 BA69320-9  G Lo Ni              200 VA     F1V 
 Fouvueghdarr  0721 E313204-5  C Ic Lo Ni           502 VA     M1V M2V 
-Kefuengkos    0921 C687241-7  C Lo Ni              102 VA     F1V M4D 
+Kefuengkos    0921 C687241-7  C Lo Ni              102 VA     F1V M4V
 Gughuekhue    1121 D000232-7  G As Lo Ni           610 VA     M5V 
-Uthaekhaeneg  1421 D99A544-7    Ni Wa              821 Va     F3V M5D 
+Uthaekhaeneg  1421 D99A544-7    Ni Wa              821 Va     F3V M5V
 Koeoung       1521 B577000-9  C Ba Lo Ni           422 Va     F1V 
-Soetanoul     1621 D8B5742-1    Fl                 603 Va     M5V M8D 
-Toksu         2121 C344102-6  G Lo Ni              201 VD     F5V M4D 
-Gzadzuekdue   2621 B425651-C    Ni                 103 VD     K9V M5D 
-Llaksae       2721 B635366-7  G Lo Ni              917 VD     M5V M2D 
+Soetanoul     1621 D8B5742-1    Fl                 603 Va     M5V M8V
+Toksu         2121 C344102-6  G Lo Ni              201 VD     F5V M4V
+Gzadzuekdue   2621 B425651-C    Ni                 103 VD     K9V M5V
+Llaksae       2721 B635366-7  G Lo Ni              917 VD     M5V M2V
 Kaevou        3121 A340300-9  G De Lo Ni Po        423 VD     F7V 
 Gvoetouknue   0622 C531111-7  C Lo Ni Po           406 VA     F0IV M5V 
-Voduerroetho  0722 E140688-6    De Ni Po           723 VA     F3V M4D 
+Voduerroetho  0722 E140688-6    De Ni Po           723 VA     F3V M4V
 Oellang       1022 E535430-8  C Ni                 700 VA     F0V 
 Kugoezae      1122 E8B4320-4  C Fl Lo Ni           901 VA     G4V 
 Nilli         1522 C20027C-A    Lo Ni Va           500 Va     M0V 
 Gzasaekue     1822 A887766-8  G Ag Ri              701 Va     F4V 
-Soevouru      2122 B460525-C  H De Ni              725 VD     F0V M3D 
+Soevouru      2122 B460525-C  H De Ni              725 VD     F0V M3V
 Gzoufalli     2222 E400872-2  C Na Va              803 VD     F4V 
-Gzoezourrgel  2422 B87668B-6  G Ag Ni              202 VD     M0V M5D 
-Lougzageou    3022 B330241-9  G De Lo Ni Po        323 VD     F2V M6D 
-Tsikataek     0223 C684453-4  G Ni                 903 VA     F9V M3D 
+Gzoezourrgel  2422 B87668B-6  G Ag Ni              202 VD     M0V M5V
+Lougzageou    3022 B330241-9  G De Lo Ni Po        323 VD     F2V M6V
+Tsikataek     0223 C684453-4  G Ni                 903 VA     F9V M3V
 Ninkounfirs   0323 C510664-4  G Na Ni              314 VA     M2V 
 Uerra         0523 B474265-7    Lo Ni              714 VA     F9V 
-Dzaghaoda     1223 B568147-6    Lo Ni              606 Va     F7V M0D M7D 
-Fuefa         1423 C566698-7    Ag Ni Ri           816 Va     G8V M6D 
-Lleliae       1623 B8B7588-9    Fl Ni              303 Va     G1V M5D 
-Uneg          1723 C98A7BB-6  H Wa                 901 Va     F7V M0D 
-Sakhsulaezo   2023 B643567-4  C Ag Ni Po           505 VD     F2V M3D 
-Oenanganourz  2523 C492122-6  G Lo Ni              134 VD     F7V M4D 
+Dzaghaoda     1223 B568147-6    Lo Ni              606 Va     F7V M0D M7V
+Fuefa         1423 C566698-7    Ag Ni Ri           816 Va     G8V M6V
+Lleliae       1623 B8B7588-9    Fl Ni              303 Va     G1V M5V
+Uneg          1723 C98A7BB-6  H Wa                 901 Va     F7V M0V
+Sakhsulaezo   2023 B643567-4  C Ag Ni Po           505 VD     F2V M3V
+Oenanganourz  2523 C492122-6  G Lo Ni              134 VD     F7V M4V
 Aksan         2623 D424554-8    Ni                 114 VD     K6V 
 Raellsoukasa  3023 E759233-6  C Lo Ni              412 VD     F5V 
-Ouaea         0424 C774454-8    Ni                 425 VA     F3V M4D 
+Ouaea         0424 C774454-8    Ni                 425 VA     F3V M4V
 Nadanllukh    1424 B445479-9    Ni                 104 Va     F5V 
-Kuekfue       1924 A447510-A  G Ag Ni              413 VD     F9V M2D M8D 
+Kuekfue       1924 A447510-A  G Ag Ni              413 VD     F9V M2D M8V
 Rraedzousaog  2024 C95A67B-5  G Ni Wa              600 VD     F0V 
-Rrarrraeifae  2224 D796414-2    Ni                 116 VD     F5V M8D 
-Zerrou        2324 B567555-9    Ag Ni              226 VD     F2V M0D 
-Vozdhaenagz   2724 B222621-6  G Na Ni Po           204 VD     M0V M1D 
+Rrarrraeifae  2224 D796414-2    Ni                 116 VD     F5V M8V
+Zerrou        2324 B567555-9    Ag Ni              226 VD     F2V M0V
+Vozdhaenagz   2724 B222621-6  G Na Ni Po           204 VD     M0V M1V
 Zadho         0525 C726122-9    Lo Ni              102 VA     M0V 
-Aghzarrzul    0825 C774421-3  G Ni                 602 VA     F4V M5D 
+Aghzarrzul    0825 C774421-3  G Ni                 602 VA     F4V M5V
 Ikhiks        1025 C552A77-5    Hi In Po           802 Va     F6V 
 Arrgots       1425 C868876-7  C                    701 Va     F4V 
 Guegvuar      1525 A9B3450-B  G Fl Ni              304 Va     G8V 
@@ -278,7 +278,7 @@ Tsollanzae    2825 C669349-9    Lo Ni              111 VD     F2V
 Oeaeg         3025 E527659-4  C Ni                 400 VD     M8V 
 Ghourragllir  0526 B673246-7  C Lo Ni              914 VA     F0V 
 Angirrinluen  0926 E544423-3    Ni                 804 Va     F5V 
-Soong         1026 B799436-6    Ni                 501 Va     F0V M7D 
+Soong         1026 B799436-6    Ni                 501 Va     F0V M7V
 Noufuefeaek   1326 B6B3444-A    Fl Ni              733 Va     M1V M0V 
 Akatsuegerrg  1426 C260611-6  G De Ni              804 Va     F5V 
 Afaedosue     1726 C552333-5    Lo Ni Po           200 VD     G2V 
@@ -291,23 +291,23 @@ Vufegak       0527 C140764-7    De Po              303 VA     F7V
 Dzannuen      0627 C593775-4    Ag                 101 VA     F5V 
 Uenaenaguez   0827 E554568-4  C Ag Ni              600 VA     F2V 
 Sigakhosoez   0927 C579200-9  H Lo Ni              602 Va     F9V 
-Thaeve        1127 B665466-5    Ni                 703 Va     F0V M3D 
-Gnoellaaz     1227 C8A158D-5  C Fl Ni              628 Va     K3V M8D 
+Thaeve        1127 B665466-5    Ni                 703 Va     F0V M3V
+Gnoellaaz     1227 C8A158D-5  C Fl Ni              628 Va     K3V M8V
 Souog         1427 E99558D-5    Ag Ni              323 Va     F0V 
-Ksoekho       1627 A410621-C  G Na Ni              500 Va     M2V M8D 
+Ksoekho       1627 A410621-C  G Na Ni              500 Va     M2V M8V
 Oeghae        1927 C78858D-7    Ag Ni              924 VD     F2V 
 Vursllaznuz   2127 D532200-3  G Lo Ni Po           824 VD     F7V 
 Dhadulaueg    2227 D401625-5    Ic Na Ni Va        200 VD     G7IV 
-Koenoell      2327 E572522-3    Ni                 801 VD     F3V M1D 
+Koenoell      2327 E572522-3    Ni                 801 VD     F3V M1V
 Daekoedang    2927 B547654-6    Ag Ni              402 VD     F5V 
-Rravoesdhung  0128 E98A985-8  C Hi In Wa           206 VA     M2V M7D 
-Esaghkaedz    0528 C563121-8  G Lo Ni              625 VA     F6V M0D 
+Rravoesdhung  0128 E98A985-8  C Hi In Wa           206 VA     M2V M7V
+Esaghkaedz    0528 C563121-8  G Lo Ni              625 VA     F6V M0V
 Itsrrous      0628 C456874-5                       302 VA     F6V 
 Rredhonguek   1028 B676696-5    Ag Ni              104 Va     K2V 
 Aervoegh      1428 C110885-4    Na                 400 Va     K3V 
 Fakkhang      1528 D310354-7  C Lo Ni              302 Va     M2V 
 Guansusukhs   1628 A792976-D  C Hi In              515 Va     F4V 
-Oukhangferr   2028 C377444-5    Ni                 711 Va     F4V M7D 
+Oukhangferr   2028 C377444-5    Ni                 711 Va     F4V M7V
 Aedesoe       2828 D8B5315-2    Fl Lo Ni           604 Va     M4V 
 Oui           3128 B535510-8    Ni                 604 Va     M3V 
 Kurrtsas      0129 E8B4456-2    Fl Ni              902 VA     M1V 
@@ -318,27 +318,27 @@ Oufuegoknuue  2029 X310200-5    Lo Ni              400 Va     M2V M0V
 Duekhszoudz   2329 C784651-7    Ag Ni Ri           514 Va     F7V M1D F9V 
 Oenova        2529 A443688-B  G Ag Ni Po           914 Va     F5V 
 Kfalla        3029 C363A9A-B    Hi In              600 Va     F1V 
-Aksufekha     1730 E000632-3  C As Na Ni           107 Va     K7V M4D M7D 
+Aksufekha     1730 E000632-3  C As Na Ni           107 Va     K7V M4D M7V
 Segoe         2530 C22457C-6  G Ni                 702 Va     G2V 
 Asuesgnousik  2930 C424100-8  G Lo Ni              801 Va     F7V 
-Dhaeru        3030 D774000-5  C Ba Lo Ni           906 Va     M0V M7D 
+Dhaeru        3030 D774000-5  C Ba Lo Ni           906 Va     M0V M7V
 Kuefuevoe     3130 C785786-4    Ag                 403 Va     F5V 
 Knasougha     3230 C250463-3  C De Ni Po           905 Va     F5V 
 Aekok         0131 B658201-A  G Lo Ni              104 Ve     F7V 
 Zadzikon      0231 C300246-6    Lo Ni Va           522 Ve     F9V 
-Gzoevaraerr   0431 B443001-8    Lo Ni Po           904 Ve     F3V M1D 
+Gzoevaraerr   0431 B443001-8    Lo Ni Po           904 Ve     F3V M1V
 Aea           0531 C727433-6    Ni                 204 Ve     K8V 
 Uerrkhus      0931 A438572-9  C Ni                 913 Va     F0V 
 Adhinorrg     2431 C74A564-9    Ni Wa              903 Va     F1V 
 Irdongtoen    3231 C100554-B  C Ni Va              101 Va     M2V 
-Llikhio       0432 C644773-6    Ag                 604 Ve     F4V M0D 
+Llikhio       0432 C644773-6    Ag                 604 Ve     F4V M0V
 Oukhsugoeng   0832 E6A3689-3  C Fl Ni              313 Va     M8V 
-Oezedhi       0932 C346230-7  C Lo Ni              116 Va     F9V M8D 
+Oezedhi       0932 C346230-7  C Lo Ni              116 Va     F9V M8V
 Aeknaez       1132 B86A466-B  G Ni Wa              200 Va     F1V 
 Aengoeron     1232 X000447-1  C As Ni              202 Va     F2V 
 Uekonthuel    1432 E55A100-8  C Lo Ni Wa           703 Va     F7V 
 Oukgnul       1532 X677300-2  C Lo Ni              904 Va     F8V 
-Zaenuedoea    1832 E88A320-7  C Lo Ni Wa           103 Va     F7V M0D 
+Zaenuedoea    1832 E88A320-7  C Lo Ni Wa           103 Va     F7V M0V
 Kangnounug    2032 D000300-9    As Lo Ni           603 Va     M1V 
 Kaaegvoes     3032 X89968A-0    Ni                 502 Va     F7V 
 Zouraengridh  3132 C5889CE-5    Hi In              200 Va     K9V 
@@ -346,47 +346,47 @@ Raoudue       0633 B553788-6    Ag Po              401 Ve     M1V
 Lloesoouuz    1433 C100776-8  C Na Va              611 Va     M3III 
 Doeouagnoe    1533 C583000-6    Ba Lo Ni           700 Va     F3V 
 Ghueouuoghz   1633 C55568A-6  H Ag Ni              110 Va     F3V 
-Kidzurre      2333 B5A4100-6  G Fl Lo Ni           925 Va     M7V M4D 
-Aenggvourr    2533 C383677-9  C Ag Ni              801 Va     M2V M5D 
-Gnaeozokhs    2933 C363347-9  C Lo Ni              101 Va     F9V M6D 
+Kidzurre      2333 B5A4100-6  G Fl Lo Ni           925 Va     M7V M4V
+Aenggvourr    2533 C383677-9  C Ag Ni              801 Va     M2V M5V
+Gnaeozokhs    2933 C363347-9  C Lo Ni              101 Va     F9V M6V
 Ivighegouel   0734 E584545-0  C Ag Ni              224 Ve     G9V 
 Ugouksidou    0834 C300464-6    Ni Va              702 Ve     M5V 
 Zananots      0934 A455510-9  G Ag Ni              603 Ve     F5V 
-Sadhoae       1434 B352545-7    Ni Po              105 Va     F8V M5D 
+Sadhoae       1434 B352545-7    Ni Po              105 Va     F8V M5V
 Thogknoun     2234 C130577-B  C De Ni Po           500 Va     M3V M2V 
 Vaeue         2534 C200977-C  C Hi Na Va           111 Va     F6V 
-Unars         2834 E7A6453-4  C Fl Ni              705 Va     M8V M1D 
-Gaeaenil      3034 C654540-6    Ag Ni              303 Va     F0V M3D 
-Udokue        3134 A7A5542-A  G Fl Ni              200 Va     M1V M5D 
-Arrzaer       0835 C569387-8    Lo Ni              212 Ve     K1V M3D 
+Unars         2834 E7A6453-4  C Fl Ni              705 Va     M8V M1V
+Gaeaenil      3034 C654540-6    Ag Ni              303 Va     F0V M3V
+Udokue        3134 A7A5542-A  G Fl Ni              200 Va     M1V M5V
+Arrzaer       0835 C569387-8    Lo Ni              212 Ve     K1V M3V
 Tsoullaeoedz  0935 C558436-7    Ni                 300 Ve     F5V 
-Llaeelgoek    1235 C564667-3    Ag Ni Ri           102 Va     M1V M3D 
+Llaeelgoek    1235 C564667-3    Ag Ni Ri           102 Va     M1V M3V
 Thazue        1635 C3246BA-4  G Ni                 302 Va     M1V 
 Sukhuezue     1935 D534851-5  H                    303 VG     K7V 
 Oedzkullue    2635 C300240-7  C Lo Ni Va           902 Va     G2V 
-Valfong       2735 B596487-8    Ni                 214 Va     F7V F7V M5D 
-Onkhi         3235 D546751-2  C Ag                 304 Va     F4V M5D 
-Zoegasa       0436 D334422-8  C Ni                 401 Ve     M4V M7D 
-Kazouzzull    0636 A857656-9    Ag Ni              215 Ve     F0V M2D 
+Valfong       2735 B596487-8    Ni                 214 Va     F7V F7V M5V
+Onkhi         3235 D546751-2  C Ag                 304 Va     F4V M5V
+Zoegasa       0436 D334422-8  C Ni                 401 Ve     M4V M7V
+Kazouzzull    0636 A857656-9    Ag Ni              215 Ve     F0V M2V
 Zaetoesag     1036 AAB5362-B  G Fl Lo Ni           203 Va     M2V 
-Ghuorrits     1136 C346612-7  C Ag Ni              500 Va     G6V M8D 
+Ghuorrits     1136 C346612-7  C Ag Ni              500 Va     G6V M8V
 Ghogurrtirr   1236 B400878-9  G Na Va              600 Va     F8V 
 Khougnez      1636 B654541-5  G Ag Ni              320 Va     G7V 
 Gzadzizgzats  2136 C431510-7    Ni Po              110 VG     G6V 
 Ghaegzenaghz  2836 E356836-1  C                    104 Va     M7V 
 Gnaellogh     2936 E559445-5    Ni                 122 Va     G6V 
 Vitsikhal     0137 C974ABG-5  G Hi In              500 Ve     G3V 
-Dhaeuen       0337 C673614-5  G Ag Ni              615 Ve     F6V M3D 
+Dhaeuen       0337 C673614-5  G Ag Ni              615 Ve     F6V M3V
 Lluekdzuegz   1937 C9B1377-8  C Fl Lo Ni           703 VG     F0III K0V 
-Khaghethou    2037 C365875-6  G                    405 VG     F1V M1D 
+Khaghethou    2037 C365875-6  G                    405 VG     F1V M1V
 Faengousksag  2337 A586422-8    Ni                 301 Va     K4V 
 Zeghsagka     2437 B200410-B  G Ni Va              903 Va     M7V 
 Dhadhan       2637 A6A0100-9  G De Lo Ni           412 Va     G8V 
 Zedzullo      2837 C596244-7    Lo Ni              300 Va     K0V 
-Zoegne        3037 C648441-4  G Ni                 602 Va     F2V M4D 
+Zoegne        3037 C648441-4  G Ni                 602 Va     F2V M4V
 Gueghu        0138 C220677-7    De Na Ni Po        501 Ve     G2V 
-Vitsaedhueo   0738 B435246-D  C Lo Ni              108 Ve     M2V M2D 
-Ouzoeou       1038 B4555AC-9  G Ag Ni              912 Va     F4V M2D 
+Vitsaedhueo   0738 B435246-D  C Lo Ni              108 Ve     M2V M2V
+Ouzoeou       1038 B4555AC-9  G Ag Ni              912 Va     F4V M2V
 Gueouil       1438 B799455-9    Ni                 514 Va     G4V 
 Vungelkurrg   1638 B6A0A73-B  G De Hi In           703 VG     G2V 
 Duzoueksagu   1938 A43479E-7                       214 VG     K6V 
@@ -394,21 +394,21 @@ Falaekhou     2138 E535477-4  C Ni                 804 VG     F9V
 Llikaknuts    2538 D451ACF-7    Hi In Po           823 Va     F9V 
 Serra         2738 C327454-B  C Ni                 220 Va     G5V 
 Raekhagz      3238 C333115-8  C Lo Ni Po           702 VX     G0V 
-Aenaesnuzarr  0139 C569200-7    Lo Ni              122 Ve     F1V M5D 
-Khaeaenoe     0339 C789874-6                       411 Ve     F2V M7D 
+Aenaesnuzarr  0139 C569200-7    Lo Ni              122 Ve     F1V M5V
+Khaeaenoe     0339 C789874-6                       411 Ve     F2V M7V
 Nevouea       0439 C23238C-7    Lo Ni Po           602 Ve     K9III 
-Kersgaenaer   0639 X300656-2  C Na Ni Va           801 Ve     M1V M0D 
+Kersgaenaer   0639 X300656-2  C Na Ni Va           801 Ve     M1V M0V
 Kaetsedhe     0939 B526356-C  C Lo Ni              711 Va     F0III 
-Ghoutson      1139 C624979-9    Hi In              627 Va     F5V M5D 
+Ghoutson      1139 C624979-9    Hi In              627 Va     F5V M5V
 Ksukidz       1439 C300831-7    Na Va              324 Va     F1V 
-Fouaen        1639 E543799-0  C Ag Po              802 VG     M3V M6D 
+Fouaen        1639 E543799-0  C Ag Po              802 VG     M3V M6V
 Uegueg        1739 C787673-6    Ag Ni              934 VG     G3V 
 Ksaeghadh     2139 C425658-9    Ni                 703 VG     F7V 
 Theghoeir     2839 A9A6400-A  C Fl Ni              210 Va     F7V 
-Goedzuezaekh  3239 C200898-4  G Na Va              815 VX     G8D 
+Goedzuezaekh  3239 C200898-4  G Na Va              815 VX     G8V
 Aekfuontaeg   1040 C624876-2                       313 Va     F9V 
 Gvallorrour   1440 B9A379C-8  G Fl                 802 Va     M0V 
-Oenourraer    1640 D866877-2  C                    801 VG     F6V M4D 
+Oenourraer    1640 D866877-2  C                    801 VG     F6V M4V
 Allanang      2240 B584333-A  G Lo Ni              902 VG     F6V 
 Kikaeo        3140 C376655-8    Ag Ni              302 VX     G9V 
 Zegagnaknue   3240 E110978-9  C Hi Na              303 VX     M6V 

--- a/res/Sectors/M1105/Knaeleng.sec
+++ b/res/Sectors/M1105/Knaeleng.sec
@@ -34,15 +34,15 @@ Sulueng       0203 C778579-6    Ag Ni              411 Va     G8V
 Llakha        0503 B7C2556-B    Fl Ni              202 Va     M2V
 Iklorrghvoul  0603 E341250-5    Lo Ni Po           704 Va     K2V M7V
 Oegor         0703 B6767B8-6  G Ag                 400 Va     F4V
-Aedhueuen     1203 C231301-8  C Lo Ni Po           200 Va     M6V M5V
+Aedhueuen     1203 C231301-8  C Lo Ni Po           200 Va     M5V M6V
 Dadhusedz     1603 C7A3575-6  G Fl Ni              513 Va     G4V
 Kuenaz        2003 E6A2463-2  C Fl Ni              302 Va     M2V
 Naon          2703 C9D65A5-8  G Fl Ni              603 Va     F8V
-Zora          0104 B404A78-C  G Hi Ic Va           512 Va     G1D M6V
+Zora          0104 B404A78-C  G Hi Ic Va           512 Va     G1V M6V
 Saegakhau     0504 DAB8422-7  C Fl Ni              303 Va     M0V
 Khughaenuel   0704 B480574-8    De Ni              403 Va     G1V
 Gzaeghzaa     0804 B6735AE-8    Ag Ni              110 Va     F9V
-Dharrgidza    0904 C330522-5    De Ni Po           242 Va     F1V M8D F8V M3V
+Dharrgidza    0904 C330522-5    De Ni Po           242 Va     F1V M8V F8V M3V
 Thokul        1104 C221103-6  G Lo Ni Po           202 Va     M5V
 Vaoe          2204 C785366-6  C Lo Ni              404 Va     F0V
 Orrag         2404 C400100-9    Lo Ni Va           102 Va     M3V
@@ -59,16 +59,16 @@ Iraegknaen    0706 D576866-4                       515 Va     F7V M0V
 Ladha         1306 C20055A-B    Ni Va              605 Va     K7V
 Igasorr       1606 C310567-8    Ni                 500 Va     K9V
 Faaoukhan     1706 C8C6976-8  C Fl Hi In           800 Va     F4V M7V
-Aenan         1906 C9D48B9-3    Fl                 524 Va     G6V M2D F4V M8V
+Aenan         1906 C9D48B9-3    Fl                 524 Va     F4V M2V G6V M8V
 Avoeoekhs     2306 C659774-2                       700 Va     F1V
 Kakifoe       2406 C5A0899-8    De                 901 Va     F6V
 Aenggnaeng    2606 C763626-3    Ag Ni              706 Va     F9V M1V
 Saetsueno     2806 B8A9687-9    Fl Ni              212 Va     M2V
 Arrghiks      0307 E516313-1    Ic Lo Ni           210 Va     M5V M5V
 Daeedhknaek   0707 C979121-7    Lo Ni              701 Va     F4V
-Oldusasghirz  0807 C120743-6    De Na Po           626 Va     M8V M5V
+Oldusasghirz  0807 C120743-6    De Na Po           626 Va     M5V M8V
 Ghaeko        0907 D210876-7  C Na                 213 Va     F4V
-Suo           1207 C510635-9  C Na Ni              606 Va     M5V M4V
+Suo           1207 C510635-9  C Na Ni              606 Va     M4V M5V
 Gangkhueng    1707 C562465-6  G Ni                 122 Va     F4V M5V
 Ksoulla       2607 D441555-6    Ni Po              617 Va     G5V M8V
 Zoraung       2707 C896432-9    Ni                 600 Va     M3V
@@ -95,10 +95,10 @@ Fisutsogh     1310 D120200-6  G De Lo Ni Po        200 Va     G9V
 Foeourrgh     1910 E464410-3  C Ni                 632 Va     F6V M6V
 Lligalaks     2110 C437400-6  C Ni                 303 Va     G3V
 Rrodhogoe     2210 B100644-7  G Na Ni Va           503 Va     M0III M3V
-Zagezoeng     2610 C300878-5  C Na Va              702 Va     F0D M4V
+Zagezoeng     2610 C300878-5  C Na Va              702 Va     F0V M4V
 Tireen        2910 X484XXX-X    An {Rosette}       XXX Va     F2V M4V
 Fovorruenuks  3210 C755502-A    Ag Ni              922 VA     F7V
-Anesdokon     0111 C100231-9  G Lo Ni Va           702 Va     M2V M7V M0V
+Anesdokon     0111 C100231-9  G Lo Ni Va           702 Va     M0V M7V M2V
 Dzoghaen      0311 B334583-A  G Ni                 311 Va     A9IV K9V
 Faefazoo      0911 B320743-A    De Na Po           502 Va     F8V M5V
 Khueug        1511 C447563-6  C Ag Ni              620 VK     F8V
@@ -111,7 +111,7 @@ Kaegoulon     0512 A200479-B    Ni Va              103 VK     M3V
 Oou           1512 C797344-6    Lo Ni              711 VK     F6V
 Knuengolats   2012 C240502-9    De Ni Po           410 Va     F7V
 Gaevaeenae    2112 E543645-2    Ag Ni Po           303 Va     K9V M5V
-Dhovorraa     2212 A63647A-A  G Ni                 522 Va     M7V K8V
+Dhovorraa     2212 A63647A-A  G Ni                 522 Va     K8V M7V
 Aenkouz       2612 A310A78-E    Hi Na              400 Va     M3V
 Uenkhosfel    2812 B687510-9  C Ag Ni              900 VA     F4V
 Irreth        0513 A225301-G  G Lo Ni              603 VK     M6V
@@ -139,7 +139,7 @@ Karruez       0115 D423464-5    Ni Po              315 VK     G9V
 Vaksun        0515 D110642-7    Na Ni              202 VK     M3V
 Oedzang       0715 C8C2330-8  C Fl Lo Ni           302 VK     M0V M7V
 Knaekhoo      1415 A565566-8    Ag Ni              503 VK     F3V
-Luennakkaks   1515 B511442-7  C Ic Ni              418 VK     F2III M4D F3V
+Luennakkaks   1515 B511442-7  C Ic Ni              418 VK     F2III M4V F3V
 Dhakakueou    1915 X100410-0    Ni Va              200 Va     M5V
 Ngoeognaefue  2315 C410551-5  G Ni                 515 Va     G3V M0V
 Ksutssugh     2815 D657300-3    Lo Ni              900 VA     F5V
@@ -152,7 +152,7 @@ Thasoeuegi    1116 C657895-3                       615 VK     F7V M1V
 Tarrung       1316 B888874-7                       303 VK     F2V
 Lighzoetsous  1416 C5A3978-9    Fl Hi In           502 VK     F4V
 Suluz         2216 E67A213-7  C Lo Ni Wa           602 Va     K3V M5V
-Gakoungengaz  2416 A303554-A    Ic Ni Va           406 VA     M4V M1V
+Gakoungengaz  2416 A303554-A    Ic Ni Va           406 VA     M1V M4V
 Gvekse        2616 B677564-B  C Ag Ni              605 VA     F7V
 Naeaellku     2816 A8A2776-9    Fl                 103 VA     K5V
 Naksang       3016 C777215-4  H Lo Ni              507 VA     K6V M3V
@@ -166,7 +166,7 @@ Zaekakue      2417 C32487A-8  G                    224 VA     F4V
 Ksaga         2517 C6538BB-2  C Po                 800 VA     F5V
 Ghogvuon      2717 E488543-6  C Ag Ni              804 VA     G5V M4V
 Adeoesudhgug  3117 C753558-8    Ag Ni Po           211 VA     F3V
-Kave          3217 A839210-E    Lo Ni              402 VA     M5V M3V
+Kave          3217 A839210-E    Lo Ni              402 VA     M3V M5V
 Ivaegvagz     0218 B76287A-5                       904 VK     G1V
 Ksoosuegh     0318 C67557B-2  G Ag Ni              500 VK     F2V
 Gnua          0918 B6A0310-6    De Lo Ni           202 VK     M6V
@@ -190,7 +190,7 @@ Aroeoeur      1020 X749689-0  C Ni                 301 VK     F1V M3V
 Thaethunokh   1220 E98A368-7  C Lo Ni Wa           703 VK     F8V M7V
 Khokhdzagzon  1520 C445788-7  G Ag                 515 Va     F5V M5V
 Nufue         1620 E673423-4    Ni                 501 Va     G9V M3V
-Kozagho       2220 C6B4420-5    Fl Ni              602 VA     M6V M1V
+Kozagho       2220 C6B4420-5    Fl Ni              602 VA     M1V M6V
 Aeghikhsghes  2620 D384875-4                       814 VA     F8V
 Luzgolgan     2920 C7599BD-8  G Hi In              204 VA     F3V
 Aesing        3220 C448489-5  G Ni                 604 VA     G5V
@@ -198,7 +198,7 @@ Voeorsaerr    0121 B876404-9  C Ni                 202 VK     F2V
 Ullaorz       0421 A4246A6-A  G Ni                 800 VK     F6V
 Khaeuek       1221 B9B7353-A    Fl Lo Ni           723 VK     F8V
 Vugnodhos     1521 C352220-6    Lo Ni Po           120 Va     F4V
-Kuksezsong    1621 B8A078B-9    De                 902 Va     M3V M1V
+Kuksezsong    1621 B8A078B-9    De                 902 Va     M1V M3V
 Aerungokh     1921 E667778-3    Ag                 403 VA     G4V
 Ghaezoa       2421 C575123-2    Lo Ni              123 VA     F3V M0V
 Ghasa         2721 C785242-6    Lo Ni              615 VA     F0V M2V
@@ -241,14 +241,14 @@ Gokokhllukug  2824 A538410-B    Ni                 700 VA     K0V
 Dugsasae      2924 C53259D-8  C Ni Po              314 VA     G3V
 Uksits        3024 D694240-6  C Lo Ni              804 VA     M2V
 Gurruzaengan  0225 C866120-2    Lo Ni              613 VK     K4V
-Khaezaikue    0325 C224447-A  C Ni                 806 VK     M8V M6V
+Khaezaikue    0325 C224447-A  C Ni                 806 VK     M6V M8V
 Rrouuekhs     0525 C2117CF-4    Ic Na              523 VK     K8III
-Oegturr       0825 C653579-5    Ag Ni Po           805 VK     M6V M1V
+Oegturr       0825 C653579-5    Ag Ni Po           805 VK     M1V M6V
 Llaeksaezal   1525 E200500-6  C Ni Va              701 Va     M8V
 Nuetaoknen    1625 A68A200-D  G Lo Ni Wa           401 Va     F5V M0V
 Dzaezele      1725 C484200-9  G Lo Ni              600 Va     M1V
 Rruezakhsaz   1825 B575576-B    Ag Ni              920 Va     F1V
-Louthurrg     2325 CAB6202-8  H Fl Lo Ni           500 VA     M8V M6V
+Louthurrg     2325 CAB6202-8  H Fl Lo Ni           500 VA     M6V M8V
 Knaedzae      3025 B648535-4    Ag Ni              215 VA     F0V M2V
 Kouzalogh     3125 C648668-2  C Ag Ni              902 VA     M4V M8V
 Dikhsaers     0126 C586677-6  G Ag Ni              927 VK     F8V K2V M5V
@@ -268,20 +268,20 @@ Saenknanuerr  1827 C373555-9    Ag Ni              814 Va     F4V M8V
 Vuthengang    2527 C76A244-5    Lo Ni Wa           713 Ve     F1V
 Safofaevue    0628 C646310-7  G Lo Ni              703 VK     K3V
 Dhudzzugh     0728 C554121-7    Lo Ni              536 VK     K3V M1V
-Kazudou       0928 C473464-A    Ni                 614 VK     F3V M2D F3V M0D M5V
+Kazudou       0928 C473464-A    Ni                 614 VK     F3V M2V F3V M0V M5V
 Soukogthae    1228 C100302-9  C Lo Ni Va           703 Va     M7V
 Daengvagh     1328 C466979-B    Hi In              815 Va     F9V M7V
 Kuellingez    2528 E484534-6  C Ag Ni              505 Ve     K9V
-Oedhthueghz   3028 CAC8642-2  C Fl Ni              501 Ve     M7V M5V
+Oedhthueghz   3028 CAC8642-2  C Fl Ni              501 Ve     M5V M7V
 Gzizue        3128 A595530-D  G Ag Ni              224 Ve     K2V
 Ghezesurrgh   0129 B231500-C  C Ni Po              903 Ve     M2V M8V
-Zoevanaegats  0229 B6A3523-7  C Fl Ni              406 Ve     F2V M7D M8V
+Zoevanaegats  0229 B6A3523-7  C Fl Ni              406 Ve     F2V M7V M8V
 Zozaeue       1129 D654341-6  C Lo Ni              905 Va     K9V
 Fonveg        2129 A452332-A    Lo Ni Po           900 Ve     F8V
 Kadzue        2329 C234436-7    Ni                 702 Ve     M2V
 Ksoghzozaz    2529 D9B3567-6    Fl Ni              311 Ve     M3V M8V
 Egefae        2629 C200235-A    Lo Ni Va           820 Ve     M6V
-Nudzaeda      3029 C236401-A  C Ni                 602 Ve     M6V M1V
+Nudzaeda      3029 C236401-A  C Ni                 602 Ve     M1V M6V
 Gaktsolig     3129 C120999-B    De Hi In Na Po     315 Ve     G9V M2V
 Llaknurroen   0730 E455648-3  C Ag Ni              503 Ve     F0V M2V
 Sazesuerrgh   1530 C504505-8  G Ic Ni Va           823 Ve     K6V
@@ -340,9 +340,9 @@ Dzaeva        0236 A220511-F  G De Ni Po           104 Ve     M0V M4V
 Khuengzanigz  0336 B844246-9  G Lo Ni              800 Ve     F3V
 Faesouk       0536 B559641-5  G Ni                 603 Ve     G0V
 Aekekue       0636 A200872-D  G Na Va              123 Ve     F9V
-Rrangaesgza   0736 B100588-C    Ni Va              204 Ve     M8V M6V
+Rrangaesgza   0736 B100588-C    Ni Va              204 Ve     M6V M8V
 Aezo          0836 C5757CA-4    Ag                 300 Ve     F9V
-Faekaaae      1036 E866977-8    Hi In              318 Ve     G1V M2D F0V
+Faekaaae      1036 E866977-8    Hi In              318 Ve     F0V M2V G1V
 Dzongaerr     1236 C7B2132-7  G Fl Lo Ni           144 Ve     M4V M4V
 Ghua          1836 X667000-0    Ba Lo Ni           014 Ve     G0V
 Raersoghanuz  2236 E463110-8  C Lo Ni              612 Ve     F1V
@@ -379,10 +379,10 @@ Llunankerz    0240 B261487-A    Ni                 102 Ve     F5V
 Arrggan       0340 E671742-2                       305 Ve     F8V
 Koufakhoog    0740 C22049B-B  G De Ni Po           430 Ve     M1V
 Zotuon        1440 E12057A-9    De Ni Po           902 Ve     M6V M7V
-Gnodhou       2040 C59A862-5    Wa                 801 Ve     M4V M3V
+Gnodhou       2040 C59A862-5    Wa                 801 Ve     M3V M4V
 Kueangaenvo   2240 E0009CC-9  C As Hi Na           304 Ve     F0V
 Goguekurrgh   2440 E50179A-5    Ic Na Va           907 Ve     M1V M1V
 Ghoeoer       2540 C679536-6    Ni                 210 Ve     F4V
 Dukfoellar    2940 C354430-5    Ni                 401 Va     K7V
 Untuen        3040 C433854-7    Na Po              614 Va     F3V
-Arrgnoenues   3140 C768698-8    Ag Ni Ri           925 Va     F3V M1D M3V
+Arrgnoenues   3140 C768698-8    Ag Ni Ri           925 Va     F3V M1V M3V

--- a/res/Sectors/M1105/Ksinanirz.sec
+++ b/res/Sectors/M1105/Ksinanirz.sec
@@ -18,7 +18,7 @@ Ksinanirz
 .             1101 X262000-0    Ba Lo Ni           003 --     F0V 
 Oukegaeguerr  1501 E695468-1    Ni                 213 Va     F3V M3V
 Tsadzguez     1601 A754105-9  G Lo Ni              823 Va     F8V M6V
-Tsuetsnozug   1701 B231778-8  C Na Po              400 Va     M2V K8V
+Tsuetsnozug   1701 B231778-8  C Na Po              400 Va     K8V M2V
 Enguksuerrug  2001 C223134-9    Lo Ni Po           803 Va     K5V 
 Rughoe        2201 B374777-5  G Ag                 705 Va     F3V M6V
 Konourogh     2301 B532363-A  G Lo Ni Po           810 Va     M8V 
@@ -30,7 +30,7 @@ Zaetsarrg     3001 C767358-4  C Lo Ni              223 Va     K7V
 Gnuuekfedz    0602 D200878-4    Na Va              414 Va     F8V
 .             1102 X78A000-0    Ba Lo Ni Wa        002 --     G5V 
 Llarthoelal   2002 A47367B-A  G Ag Ni              312 Va     M6V 
-Vouvou        2302 E2009CA-5  C Hi Na Va           904 Va     F6D M7V
+Vouvou        2302 E2009CA-5  C Hi Na Va           904 Va     F6V M7V
 Uerragaefae   2402 C56497C-5    Hi In              304 Va     F4V 
 Tueaeue       2902 C514434-4  G Ic Ni              441 Va     M5V M7V
 Dhangaeks     3002 A878974-B  G Hi In              506 Va     M1V M1V
@@ -42,7 +42,7 @@ Irtaek        1703 A9B4310-A    Fl Lo Ni           203 Va     M3II
 Thouirru      1803 C474675-5    Ag Ni              303 Va     F1V 
 Tsaghzksuell  3203 C899458-7  C Ni                 405 Va     F5V M0V
 Vothookh      0404 D633676-4    Na Ni Po           107 Va     K2V M5V
-Thaoedhaekhs  0504 B9B8649-A  H Fl Ni              802 Va     M1V M5D M0V
+Thaoedhaekhs  0504 B9B8649-A  H Fl Ni              802 Va     M0V M5V M1V
 Gagvaekerr    0804 E686878-3  C                    805 VP     F5V 
 Dougha        0904 A545203-8  G Lo Ni              505 VP     F6V M8V
 Saaghun       1004 E788773-2    Ag                 922 VP     F3V M5V
@@ -55,12 +55,12 @@ Dugzaesi      2204 C636666-4  C Ni                 705 Va     M3V M4V
 Eraezors      2404 B866765-8    Ag Ri              504 Va     F9V M8V
 Uezaekaren    2604 C445305-9    Lo Ni              213 Va     F1V 
 Ghouga        2704 X989778-1  C                    705 Va     F3V 
-Rruzathantek  2804 C739266-9    Lo Ni              707 Va     K0V M1D M0V
+Rruzathantek  2804 C739266-9    Lo Ni              707 Va     K0V M1V M0V
 .             0105 X363000-0    Ba Lo Ni           011 --     F2V M7V
 Suerrouroe    0905 C966879-1                       500 VP     F1V 
-Kekoeghuegh   1005 D886001-5    Lo Ni              202 VP     F4V M3D F5V M6V
-Ghokhogva     1805 E100000-9  C Ba Lo Ni Va        723 Va     M5V M4V
-Surrarrgh     1905 C43297A-C    Hi In Na Po        407 Va     G2V M3D F5V M2V
+Kekoeghuegh   1005 D886001-5    Lo Ni              202 VP     F4V M3V F5V M6V
+Ghokhogva     1805 E100000-9  C Ba Lo Ni Va        723 Va     M4V M5V
+Surrarrgh     1905 C43297A-C    Hi In Na Po        407 Va     F5V M3V G2V M2V
 Gvanaerran    2005 B100323-9  G Lo Ni Va           303 Va     G2V 
 Ksounaz       2205 E200442-4    Ni Va              804 Va     G7V 
 Okharuz       2505 B436855-8                       704 Va     F9V 
@@ -74,7 +74,7 @@ Aedzaue       1406 D377A7A-A    Hi In              203 VP     K5V M7V
 Tsoeghours    1506 B301565-9    Ic Ni Va           103 VP     A0V
 Aeghaedhi     1806 C76A212-9    Lo Ni Wa           804 Va     F9V M5V
 Khuuo         1906 C97677A-4    Ag                 502 Va     K1V 
-Zoenaedhtsus  2206 D400876-2    Na Va              500 Va     G1D M6V
+Zoenaedhtsus  2206 D400876-2    Na Va              500 Va     G1V M6V
 Oksa          2506 A501226-9  G Ic Lo Ni Va        615 Va     G8V 
 Fioilug       0307 C78A664-3    Ni Ri Wa           206 Va     F5V M8V
 Uraegou       0707 B655357-9  G Lo Ni              605 VR     F1V M2V
@@ -83,7 +83,7 @@ Koerukhukh    0907 C345466-6  G Ni                 510 VR     F0V
 Rraekhus      1007 B325899-8                       712 VR     K4V 
 Aegzeoe       1307 E100244-A    Lo Ni Va           411 VP     M5III K4V 
 Gnughenangi   1707 B1607B7-9  G De                 303 Va     K6V M0V
-Lengikakh     2007 E220435-7    De Ni Po           100 Va     M6V M1V M8V
+Lengikakh     2007 E220435-7    De Ni Po           100 Va     M1V M6V M8V
 Khoenugzaghz  3207 C9C5000-9    Ba Fl Lo Ni        801 Va     G7V 
 Khaello       0208 B672677-7    Ni                 215 Va     G6V 
 Nourrghfourz  0808 E333400-8  C Ni Po              914 VR     M4V 
@@ -92,16 +92,16 @@ Aellonorrgh   1308 D873454-6  G Ni                 602 VP     F8V
 Ularr         1408 A355578-B  G Ag Ni              502 VP     F0V 
 Rrozuetsae    1508 B681874-8                       834 VP     F0V M6V
 Tsatha        1608 D352697-2  G Ni Po              500 VP     F2V 
-Ksigtsodho    1808 B639676-7    Ni                 502 Va     M5V G6V
+Ksigtsodho    1808 B639676-7    Ni                 502 Va     G6V M5V
 Dulloue       2108 E400102-5  C Lo Ni Va           732 Va     M0V M2V
-Kaeuerzgueg   0109 C433666-4  C Na Ni Po           707 Va     M8V M2V
+Kaeuerzgueg   0109 C433666-4  C Na Ni Po           707 Va     M2V M8V
 Enouvarro     0209 C484652-7    Ag Ni Ri           604 Va     F9V M1V
 Ouaklloluen   0609 B658201-A  G Lo Ni              303 VR     K5V 
 Tuetangalou   0709 C66197C-3    Hi In              901 VR     F4V 
-Ouellanourz   0809 C585777-3  C Ag                 228 VR     M1V F3V M6V
+Ouellanourz   0809 C585777-3  C Ag                 228 VR     F3V M1V M6V
 Arruezaegh    1209 B345588-5  C Ag Ni              404 VP     F7V 
 Gueovou       1309 E310533-4    Ni                 324 VP     F6V 
-Ksueghale     1509 C634325-5    Lo Ni              616 VP     K2V F3V M1V
+Ksueghale     1509 C634325-5    Lo Ni              616 VP     F3V K2V M1V
 Ghagugharr    1609 B665574-6  C Ag Ni              800 VP     F8V 
 Ungugudz      1809 C9C48AB-3    Fl                 223 Va     F3V M6V
 Rerukh        2009 X632243-1  C Lo Ni Po           103 Va     F8V M3V
@@ -111,8 +111,8 @@ Vesueksaon    0210 C427776-9                       203 Va     M4V
 Gzouno        0310 B000768-A  C As Na              903 Va     M6V 
 Rroiroers     0410 A687789-A  G Ag                 103 Va     F3V M1V
 Goeollaz      0910 CA9A977-9  G Hi In Wa           404 Va     F2V 
-Aenarou       1010 E210452-9    Ni                 701 Va     M8V M1V
-Dzaerakhsaeg  0111 B310657-7  C Na Ni              301 Va     M4V M0V
+Aenarou       1010 E210452-9    Ni                 701 Va     M1V M8V
+Dzaerakhsaeg  0111 B310657-7  C Na Ni              301 Va     M0V M4V
 Kfuegvakue    0211 A482500-B    Ni                 500 Va     G6V 
 Ngadzughz     0311 D443A7C-4  H Hi In Po           735 Va     M6V M6V
 Roukharr      0511 D63AAA8-7    Hi In Wa           100 Va     F8V 
@@ -157,7 +157,7 @@ Roeagha       1517 E79A987-5    Hi In Wa           912 Va     F3V M7V
 Rafuegvuerro  1917 C535144-6  G Lo Ni              902 Va     M3V 
 Ivakhsoes     2517 E9E1778-5  C Fl                 105 Va     M3V M5V
 Ngaradhur     2617 B68A222-A    Lo Ni Wa           813 Va     F8V M5V
-Naeaou        2717 A51275A-7    Ic Na              802 Va     M3V M2V
+Naeaou        2717 A51275A-7    Ic Na              802 Va     M2V M3V
 Rralludh      3217 E85A6B7-4  C Ni Wa              602 Va     F5V 
 Ruezerrfugar  0118 C000553-9  G As Ni              302 Va     M2V 
 Sighangarorr  0218 C669555-7    Ni                 204 Va     F9V M8V
@@ -187,7 +187,7 @@ Soeugi        1421 C762214-4    Lo Ni              300 Va     G1V M2V
 Sunzorkhasou  1721 B676878-A  G                    603 Va     G2V 
 Khazoekhskha  2321 C653420-9    Ni Po              704 Va     F7V M2V
 Aerakhsaghz   2621 C767869-4  G Ri                 333 Va     F7V 
-Udakhag       3021 B100857-C  G Na Va              905 Va     M6D M2V
+Udakhag       3021 B100857-C  G Na Va              905 Va     M2V M6V
 Roksue        0122 E435443-7    Ni                 900 Va     M8V 
 Tanuedhue     0322 B778100-8  G Lo Ni              905 Va     F3V M7V
 Azzongekh     0422 A210558-D    Ni                 902 Va     F4V 
@@ -198,14 +198,14 @@ Ueoegvaghung  0223 C736002-8    Lo Ni              600 Va     F0V
 Uegvaegni     0423 B360664-6    De Ni Ri           304 Va     F9V 
 Dhuerrosegh   1623 B533889-7  G Na Po              704 Va     M0V M2V
 Gvueksoudzu   0124 A100548-D  G Ni Va              412 Va     G7III M0V 
-Tsagnoe       0524 C326674-4    Ni                 614 Va     F8V M3D F4V 
+Tsagnoe       0524 C326674-4    Ni                 614 Va     F4V M3V F8V
 Goevaturr     0724 A444562-9  G Ag Ni              226 Va     F4V M8V
 Garuegsaring  0824 C5A6300-B  G Fl Lo Ni           102 Va     M5V M5V 
 Zaengaening   1024 C694300-7    Lo Ni              600 Va     G4V 
-Gvosousuerr   1924 C728553-8    Ni                 513 Va     M5V M6D M5V
+Gvosousuerr   1924 C728553-8    Ni                 513 Va     M5V M6V M5V
 Vakhuegh      0125 E200255-4    Lo Ni Va           400 Va     K1V 
 Ataetu        0225 B200100-D  G Lo Ni Va           701 Va     M5V 
-Doveka        0525 C201564-9    Ic Ni Va           622 Va     M5V M1V
+Doveka        0525 C201564-9    Ic Ni Va           622 Va     M1V M5V
 Vuedhavug     1025 B543534-5    Ag Ni Po           912 Va     F3V 
 Rassoughzao   1125 C694300-7    Lo Ni              812 Va     F1V M8V
 Konokh        1325 C77657C-4    Ag Ni              511 Va     F2V M2V
@@ -247,7 +247,7 @@ Thuguegousa   0430 XA78422-0  C Ni                 302 Va     F0V
 Ksaekhaae     0730 C525203-6  G Lo Ni              402 Va     M4V 
 Aaedzouz      0830 C647513-7    Ag Ni              720 Va     F6V M5V 
 Yehigeton     1530 E53369C-4    Na Ni Po           504 Ve     K5V M0V 
-Seseto        2030 E789452-7    Ni                 916 Ve     M7V M0V
+Seseto        2030 E789452-7    Ni                 916 Ve     M0V M7V
 Locae         2430 C654988-8  S Hi In              800 Ve     F9V 
 Kuesatsu      0231 A427368-B  G Lo Ni              811 Va     M3III M7V 
 Lugviae       0531 C465775-7    Ag                 810 Va     F1V 
@@ -290,21 +290,21 @@ Ienbet        2535 E656677-1    Ag Ni              620 Ve     F3V
 Ueoe          0336 C578355-8    Lo Ni              203 Va     M3V 
 Arsaghza      0436 B473267-7  H Lo Ni              221 Va     K0V 
 Raerksungarr  0536 X230778-0    De Na Po           403 Va     F7V 
-Tarrgote      0736 B210535-A    Ni                 600 Va     M3V M1V 
+Tarrgote      0736 B210535-A    Ni                 600 Va     M1V M3V
 Kosta         1436 C789797-7  M Ri                 313 Ve     F2V 
 Onde          1536 C887657-9  M Ag Ni Ri           510 Ve     F4V 
 Bragofond     1736 C563400-9  S Ni                 210 Ve     F3V 
 Segrarruefo   0137 C506696-4  C Ic Ni Va           402 Va     M8V 
 Gvueukhgzoe   0237 B500777-7    Na Va              201 Va     G4V M2V 
 Sekhurour     0337 C470654-5    De Ni              200 Va     F6V 
-Ueonugzaeng   0537 B9C8778-A    Fl                 900 Va     M2V M1V 
+Ueonugzaeng   0537 B9C8778-A    Fl                 900 Va     M1V M2V
 Ungugzaezogh  0837 A837145-B  G Lo Ni              700 Va     M0V 
 Atsoerghourz  0937 E67A350-6    Lo Ni Wa           800 Va     F8V M0V
 Okaegvong     1037 C785666-3    Ag Ni Ri           700 Va     F6V 
 Ese           1437 C575000-8  S Ba Lo Ni           700 Ve     F1V 
-Langed        1837 CAA6234-7  S Fl Lo Ni           300 Ve     M2V M5V 
+Langed        1837 CAA6234-7  S Fl Lo Ni           300 Ve     M2V M5V
 Yomeceth      2137 E4536AA-3    Ag Ni Po           100 Ve     F0V 
-Whothelle     2237 C411610-A  S Ic Na Ni           603 Ve     M8V M0V 
+Whothelle     2237 C411610-A  S Ic Na Ni           603 Ve     M0V M8V
 Yolinga       2937 B6A286A-7    Fl                 813 Ve     F8V 
 Rilalnughz    0538 B566651-A  G Ag Ni Ri           601 Va     M5V 
 Ueoudhdoeth   0638 C411431-8  G Ic Ni              135 Va     A3V M0V
@@ -312,7 +312,7 @@ Aksrrue       0738 C644889-2                       104 Va     F8V M3V
 Ourrruaks     1038 B4136A8-A  G Ic Na Ni           104 Va     G2V 
 Iha           1338 C9E3788-5    Fl                 114 Ve     M0V M6V
 Widbaen       1538 E97A278-9    Lo Ni Wa           500 Ve     K2V M4V
-Codithishe    1938 B989630-7  S Ni                 102 Ve     F7V M7D M1V
+Codithishe    1938 B989630-7  S Ni                 102 Ve     F7V M7V M1V
 Hellewanse    2138 A587ABE-G  S Hi In              104 Ve     F0V 
 Ecet          2338 C789120-6  M Lo Ni              700 Ve     F2V 
 Tofeo         2438 C559352-7    Lo Ni              703 Ve     F8V 
@@ -334,8 +334,8 @@ Aknoutsagh    0340 X677686-0  C Ag Ni              615 Va     F6V M7V
 Ksaega        0440 C679636-5  G Ni                 504 Va     F5V 
 Foekoe        0540 E5377AB-2  C                    301 Va     A2V 
 Tsurougvae    0640 D6377BE-5                       403 Va     M6V 
-Sughankoung   0740 C100578-7    Ni Va              701 Va     M7V M4V
-Kanangall     0940 B77A003-A  G Lo Ni Wa           703 Va     G3V M8D M0V
+Sughankoung   0740 C100578-7    Ni Va              701 Va     M4V M7V
+Kanangall     0940 B77A003-A  G Lo Ni Wa           703 Va     G3V M8V M0V
 Cauw          1240 E696516-4    Ag Ni              603 Ve     F7V M5V
 Keors         1340 X546632-0    Ag Ni           R  213 Ve     F4V 
 Houriwwep     1540 B227731-8  B                    504 Ve     G6V 

--- a/res/Sectors/M1105/Listanaya.sec
+++ b/res/Sectors/M1105/Listanaya.sec
@@ -65,9 +65,9 @@ Listanaya
 .             0908 X497000-0    Ba Lo Ni           010 --     F0V 
 .             1208 X676000-0    Ba Lo Ni           015 --     F0V 
 .             2108 X423000-0    Ba Lo Ni Po        013 --     K8II 
-.             2308 X434000-0    Ba Lo Ni           016 --     M3V K3V 
+.             2308 X434000-0    Ba Lo Ni           016 --     K3V M3V
 .             2508 X000000-0    As Ba Lo Ni        001 --     M4V 
-.             3008 X457000-0    Ba Lo Ni           002 --     F6V M6D F7V 
+.             3008 X457000-0    Ba Lo Ni           002 --     F6V M6V F7V
 .             0609 X868000-0    Ba Lo Ni           001 --     G5V M7V
 .             0709 X683000-0    Ba Lo Ni           012 --     F8V 
 .             1009 X300000-0    Ba Lo Ni Va        011 --     M5III G1V 
@@ -81,21 +81,21 @@ Listanaya
 .             1810 X68A000-0    Ba Lo Ni Wa        013 --     K1V 
 .             2210 X260000-0    Ba De Lo Ni        013 --     F8V M7V
 .             2610 X521000-0    Ba Lo Ni Po        001 --     M0V 
-.             0611 X7C6000-0    Ba Fl Lo Ni        001 --     M5V M0V
+.             0611 X7C6000-0    Ba Fl Lo Ni        001 --     M0V M5V
 .             0811 X352000-0    Ba Lo Ni Po        015 --     K1V 
 .             1011 X000000-0    As Ba Lo Ni        010 --     M3V 
 .             1111 X7A2000-0    Ba Fl Lo Ni        002 --     M4II M1V
 .             1211 X564000-0    Ba Lo Ni           000 --     F2V M3V
 .             1811 X332000-0    Ba Lo Ni Po        001 --     F9V M4V
 .             1911 X5A5000-0    Ba Fl Lo Ni        000 --     M7III M2V 
-.             2511 X410000-0    Ba Lo Ni           005 --     M6V M5V
+.             2511 X410000-0    Ba Lo Ni           005 --     M5V M6V
 .             2811 X210000-0    Ba Lo Ni           003 --     M6V 
 .             3111 X675000-0    Ba Lo Ni           003 --     F8V 
 .             1112 X574000-0    Ba Lo Ni           005 --     G0V M5V
 .             2212 X427000-0    Ba Lo Ni           002 --     A5V M8V
 .             1013 X888000-0    Ba Lo Ni           027 --     F1V M5V
 .             1213 X200000-0    Ba Lo Ni Va        001 --     F4V 
-.             1413 X332000-0    Ba Lo Ni Po        015 --     M8V M3D M7V
+.             1413 X332000-0    Ba Lo Ni Po        015 --     M3V M8V M7V
 Aekhogh       2413 D558142-7    Lo Ni              704 Va     F3V 
 .             3113 X443000-0    Ba Lo Ni Po        003 --     K5V 
 .             0214 X482000-0    Ba Lo Ni           003 --     F9V 
@@ -106,21 +106,21 @@ Aekhogh       2413 D558142-7    Lo Ni              704 Va     F3V
 .             1314 X666000-0    Ba Lo Ni           020 --     F3V 
 Gharuerr      1914 D483211-4  C Lo Ni              600 Va     F1V 
 Sogzaerrars   2014 D00087A-4    As Na              813 Va     G1V 
-Oudaer        2114 E201577-5  C Ic Ni Va           627 Va     M0V M6D M8V
+Oudaer        2114 E201577-5  C Ic Ni Va           627 Va     M0V M6V M8V
 .             0215 X544000-0    Ba Lo Ni           014 --     F6V 
 .             0815 X666000-0    Ba Lo Ni           004 --     M5V M8V
-.             1115 XA6A000-0    Ba Lo Ni Wa        025 --     G9V M3D F1V 
+.             1115 XA6A000-0    Ba Lo Ni Wa        025 --     F1V M3V G9V
 Oegzogh       1615 C685679-2  G Ag Ni              214 VE     G7V 
 Forrthorrkur  2515 B87997C-A    Hi In              803 Va     F7V 
-Uedzkfal      2815 C95A873-9    Wa                 804 Va     F0V M3D M4V M1V
+Uedzkfal      2815 C95A873-9    Wa                 804 Va     F0V M3V M4V M1V
 .             0816 X475000-0    Ba Lo Ni           020 --     F7V 
 .             0916 X633000-0    Ba Lo Ni Po        000 --     M1V 
 Uelus         1716 E466ABC-B  C Hi In              601 VE     K2V 
 Rarrghoth     2216 D766573-4  C Ag Ni              704 Va     F1V 
-Ouoedengueks  2316 C874764-4    Ag                 707 Va     F1V M7D M0V
+Ouoedengueks  2316 C874764-4    Ag                 707 Va     F1V M7V M0V
 .             0317 X435000-0    Ba Lo Ni           001 --     M0V M7V
 Ollaz         1217 C747975-9    Hi In              821 Va     F4V M3V
-Tsagakaeng    1617 C527103-7  G Lo Ni              102 VE     M7V M4V
+Tsagakaeng    1617 C527103-7  G Lo Ni              102 VE     M4V M7V
 Thegaeldhaen  1717 C300675-6    Na Ni Va           402 VE     G5V 
 Aekfueghz     2617 EA85102-1  C Lo Ni              801 Va     F1V 
 Ksaedaghoull  2817 E487799-5    Ag Ri              124 Va     M3V 
@@ -134,7 +134,7 @@ Soukaerrgun   0919 B327862-6                       810 Va     F0V M2V
 Zavaegvinakh  1419 C83A644-8  G Ni Wa              714 Va     F9V M1V
 Vaesaelgvuer  1619 C575796-5    Ag                 203 VE     F5V 
 Gofae         2519 C365577-8    Ag Ni              803 Va     F3V M3V
-Kheloen       2719 E555203-2    Lo Ni              423 Va     G8V M3D F7V 
+Kheloen       2719 E555203-2    Lo Ni              423 Va     F7V M3V G8V
 Doeoea        2819 C00067A-6  G As Na Ni           815 Va     K2V M8V
 Faghzenthaez  0420 B455A77-D  C Hi In              813 Va     F7V 
 Entharan      0720 D77A674-3    Ni Wa              305 Va     F8V M8V
@@ -149,12 +149,12 @@ Zoghorsaers   2521 C997544-5  C Ag Ni              703 Va     F0V M0V
 Khueu         2721 C545000-3    Ba Lo Ni           612 Va     F5V M4V
 .             3021 X540000-0    Ba De Lo Ni Po     022 --     F0V 
 .             3121 X000000-0    As Ba Lo Ni        012 --     G4V 
-Zouzol        0122 E414673-3  C Ic Ni              211 Va     M2V M7D F4V 
+Zouzol        0122 E414673-3  C Ic Ni              211 Va     F4V M7V M2V
 Uergzik       1122 E9B4337-8    Fl Lo Ni           200 Va     M6V 
 Tague         2722 C401757-9    Ic Na Va           105 Va     M2V M5V
 Khoeangong    0323 CAAA530-6    Fl Ni Wa           100 Va     M1V 
 Kaeksingu     0423 A6A5553-C    Fl Ni              904 Va     G9V M0V
-Ukhag         1023 E78757B-1    Ag Ni              407 Va     F5V M2D M6V
+Ukhag         1023 E78757B-1    Ag Ni              407 Va     F5V M2V M6V
 Gharaegoukh   1423 CA76546-8    Ag Ni              104 Va     K5V M0V
 Agueghgvul    2123 B686AA8-7  G Hi In              401 Va     K1V 
 Aeghung       2223 E448225-4    Lo Ni              202 Va     M1V 
@@ -174,11 +174,11 @@ Uaerr         1027 B370779-9  G De                 600 Va     K9V
 Ueounaghzaen  1127 A8A3137-8    Fl Lo Ni           603 Va     G9V M0V
 Ououghzdarrg  2027 C130676-9    De Na Ni Po        603 Va     M0V 
 Voeea         2627 C55367B-7    Ag Ni Po           511 Va     F1V M0V
-Eaou          2927 C592778-6                       703 Va     F1V M6D F3V M8V
+Eaou          2927 C592778-6                       703 Va     F1V M6V F3V M8V
 Vaueekh       3027 C465111-6    Lo Ni              701 Va     F4V M1V
 Uuengrarz     3127 B9B7375-8  G Fl Lo Ni           824 Va     F2V M5V
 Kagzoez       0228 C987587-3    Ag Ni              511 Va     F1V 
-Eoe           0928 D865876-3                       900 Va     M4V M2V
+Eoe           0928 D865876-3                       900 Va     M2V M4V
 Gaetstheng    1228 C758878-3  G                    205 Va     G1V M3V
 Akhsthagrae   1628 A73A558-F  G Ni Wa              202 Va     A0V M6V
 Aorrgdhoull   1828 C330465-7    De Ni Po           224 Va     K0V M7V
@@ -186,7 +186,7 @@ Gvoeaer       2828 C000103-C    As Lo Ni           400 Va     F0V M4V
 Khanougae     2928 B667447-8  G Ni                 902 Va     M2V M6V
 Dzerkoerorr   3028 C9B6413-9  G Fl Ni              714 Va     K8V M0V
 Ounorronokhs  3128 B9B5221-5    Fl Lo Ni           714 Va     K0V 
-Ksougaeks     0529 E574532-3    Ag Ni              402 Va     F0V M8D M1V 
+Ksougaeks     0529 E574532-3    Ag Ni              402 Va     F0V M8V M1V
 Vougghaerrg   0729 C624676-4  G Ni                 314 Va     F6V M8V
 Ouaeig        1229 C579877-6  G                    905 Va     F6V 
 Rrunruer      1729 C446358-4    Lo Ni              822 Va     F1V M8V
@@ -199,7 +199,7 @@ Aedaer        1530 C300525-9  C Ni Va              101 Va     M3III G3V
 Uverrghouz    2030 C110446-9    Ni                 600 VL     M5V M7V 
 Kfaeguekhoel  2130 C64776A-1    Ag                 302 VL     F7V 
 Ourzurrgaegz  2530 C220558-6    De Ni Po           700 VL     M0V 
-Gzouksknuedh  2630 C7C3365-8    Fl Lo Ni           824 VL     M7V M2V M2V 
+Gzouksknuedh  2630 C7C3365-8    Fl Lo Ni           824 VL     M2V M7V M2V
 Ea            2830 C97A536-9    Ni Wa              503 VL     F1V 
 Edhungueoe    3130 C534222-8  G Lo Ni              812 Va     F5V 
 Arzoerzueu    0231 C858510-7    Ag Ni              513 Va     F9V M5V
@@ -209,7 +209,7 @@ Ouakhsaer     1131 CAC8543-6  G Fl Ni              802 Va     M0V
 Oughakaer     1531 C270544-7  C De Ni              121 Va     F6V 
 Tigue         1931 C120345-7  C De Lo Ni Po        704 VL     M0V M3V
 Oksoghzukh    2031 C412485-6  G Ic Ni              403 VL     M0V 
-Zoukang       2131 E8C4262-5  C Fl Lo Ni           712 VL     M6V M0V
+Zoukang       2131 E8C4262-5  C Fl Lo Ni           712 VL     M0V M6V
 Oursarrgen    2231 C757000-7    Ba Lo Ni           604 VL     F6V M8V
 Agzong        2331 E666455-4  C Ni                 312 VL     F1V M1V
 Zuedzetsnarr  2431 E574358-5    Lo Ni              803 VL     F8V M4V
@@ -224,7 +224,7 @@ Tsoea         2432 B362978-7    Hi In              500 VL     K2V
 Agaeksots     2532 C7B2887-5  C Fl                 310 VL     F4V M7V
 Ghaghzfoghoz  2732 D300243-8    Lo Ni Va           516 VL     M0II K6V 
 Kfarrelong    2832 C553541-5    Ag Ni Po           124 VL     K3V 
-Roghularrg    2932 C000325-A    As Lo Ni           405 VL     M1V M0V
+Roghularrg    2932 C000325-A    As Lo Ni           405 VL     M0V M1V
 Akdzogh       1133 C677131-7    Lo Ni              506 Va     G9V M8V
 Gaghirr       1333 E644789-5  C Ag                 611 Va     F2V 
 Khueksengouz  1433 C659742-8                       800 Va     F5V M2V
@@ -244,14 +244,14 @@ Dhavukhong    1235 C89A756-6  C Wa                 931 Va     F0V M7V
 Gvaearaerr    1335 E864231-4  C Lo Ni              803 Va     M1V 
 Iagfag        1635 E7A0788-6    De                 900 Va     M1V 
 Akozgon       2135 C778465-6    Ni                 313 Va     F9V 
-Ararrkughzen  2335 C587133-8    Lo Ni              436 Va     F7V M5D M7V
+Ararrkughzen  2335 C587133-8    Lo Ni              436 Va     F7V M5V M7V
 Kfaenganoeng  2635 A665211-9    Lo Ni              804 Va     G5V 
 Kfuefue       2735 B471362-5    Lo Ni              101 Va     F8V M7V
 Guenourr      3035 E435A76-A  C Hi In              102 Va     F1V 
 Kughuuego     0236 C797155-7    Lo Ni              900 Va     F9V 
 Kfukuegzviks  0736 A34287B-A  C Po                 513 Va     F8V 
 Uerrueth      1436 AAE8514-E    Fl Ni              500 Va     M8V 
-Voesez        1836 B000988-C  G As Hi Na           913 Va     F0D M5V
+Voesez        1836 B000988-C  G As Hi Na           913 Va     F0V M5V
 Aoksuguleng   2336 X637343-2  C Lo Ni              700 Va     F1V 
 Dhalaelang    3036 C654576-7    Ag Ni              403 Va     K6V 
 Uesuue        0137 C21136A-6    Ic Lo Ni           902 Va     K1V 

--- a/res/Sectors/M1105/OeghzVaerrghr.sec
+++ b/res/Sectors/M1105/OeghzVaerrghr.sec
@@ -147,7 +147,7 @@ Kfaekaeaoe    1015 C666658-3    Ag Ni Ri           300 Va     F2V
 Onadhagz      1315 A744530-9  G Ag Ni              503 Va     K5V M2V
 Llaueth       1415 C331468-B  H Ni Po              802 Va     M3V 
 Nanoe         1515 E969215-7  C Lo Ni              114 Va     M2V M3V
-Aeudh         2215 CAA4845-7  C Fl                 505 Va     M8V M5V
+Aeudh         2215 CAA4845-7  C Fl                 505 Va     M5V M8V
 Kolunoung     2715 D598420-2  G Ni                 911 Va     F9V 
 Atsgoer       3015 C76869B-3  C Ag Ni Ri           400 Va     F1V 
 Aeksdzaz      0516 C200878-6  G Na Va              621 Va     F2V
@@ -237,7 +237,7 @@ Dhaetsaek     1229 B9A8538-8  G Fl Ni              114 Va     M0V M5V
 Dueaeza       1329 C250876-3    De Po              922 Va     K9V M5V
 Kedhugh       2229 C355779-3    Ag                 500 Va     F3V 
 Kherdaerroez  2629 E648103-5    Lo Ni              113 Va     F1V M5V
-Gaezun        0130 C300751-B    Na Va              107 Va     M5V M3V
+Gaezun        0130 C300751-B    Na Va              107 Va     M3V M5V
 Aekfuerrg     0730 C422310-8  G Lo Ni Po           720 Va     F2V 
 Rikarrga      2130 E866633-1  C Ag Ni              102 Va     F0V 
 Aedhuegael    0231 B424110-9  C Lo Ni              414 Va     K2V 
@@ -280,7 +280,7 @@ Aegho         1137 CAB6676-3    Fl Ni              600 Va     G8III M1V
 Khoegverr     1337 E694976-6    Hi In              900 Va     F1V 
 Kfugouz       1537 C456522-6  G Ag Ni              800 Va     M5V 
 Aekhurrgtaen  1837 C000977-D    As Hi Na           212 Va     F9V 
-Dhavasunu     1937 A9B5626-8  G Fl Ni              821 Va     M4V M3V
+Dhavasunu     1937 A9B5626-8  G Fl Ni              821 Va     M3V M4V
 Aekoeou       2137 E564213-6    Lo Ni              300 Va     F9V 
 Ugueth        0138 B658201-A  G Lo Ni              402 VX     M4V 
 Ezosaedz      0338 C472687-5    Ni                 607 VX     F1V M8V

--- a/res/Sectors/M1105/Rfigh.sec
+++ b/res/Sectors/M1105/Rfigh.sec
@@ -140,7 +140,7 @@ Rfigh
 .             3213 X140000-0    Ba De Lo Ni Po     003 --     F8V 
 .             0114 X461000-0    Ba Lo Ni           017 --     G9V M0V
 .             0414 X571000-0    Ba Lo Ni           016 --     F3V M6V G1V
-.             0614 X8D1000-0    Ba Fl Lo Ni        004 --     M7V M0V
+.             0614 X8D1000-0    Ba Fl Lo Ni        004 --     M0V M7V
 .             1114 X310000-0    Ba Lo Ni           008 --     M5V M6V
 .             1314 X542000-0    Ba Lo Ni Po        004 --     F8V M3V M0V
 .             1614 X510000-0    Ba Lo Ni           004 --     K9V M5V
@@ -322,7 +322,7 @@ Rfigh
 .             1129 X241000-0    Ba Lo Ni Po        011 --     F2V M3V
 .             1529 X100000-0    Ba Lo Ni Va        002 --     M4V 
 .             1929 X100000-0    Ba Lo Ni Va        000 --     K6III 
-.             2129 X202000-0    Ba Ic Lo Ni Va     002 --     M2V G0V
+.             2129 X202000-0    Ba Ic Lo Ni Va     002 --     G0V M2V
 .             2229 X233000-0    Ba Lo Ni Po        002 --     M2V M6V
 .             2429 X633000-0    Ba Lo Ni Po        000 --     M0V 
 .             2729 XAD2000-0    Ba Fl Lo Ni        000 --     K3V 


### PR DESCRIPTION
@inexorabletash asked me to, when submitting bulk sector-data fixen, break up said fixen PRs into different classes of sectors, so here goes with squaring up the stellar data in Undeveloped Sectors.
I'm not making any deliberate attempt to canonicalise star sizes as per T5.10 Book 3 p 28.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is _swapped_ into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).