### PR TITLE
Fix Katoonah sector stellar data

### DIFF
--- a/res/Sectors/M1105/Katoonah.sec
+++ b/res/Sectors/M1105/Katoonah.sec
@@ -46,8 +46,8 @@ Wampath                   0106 C774574-9 S Ag Ni                       223 -- F5
 Umberlog                  0110 C565600-7   Ag Ni                       725 -- G7 V
 Kyrean                    0113 XAD5000-0   Ba Fl Lo Ni                 100 -- M4 V
 Fecal                     0114 X461000-0   Ba Lo Ni                    313 -- F5 III
-Katusa                    0115 X658000-0   Ba Lo Ni                    513 -- G4 V M3 D
-XENO                      0120 X799977-5   Hi In Wa                    215 -- F3 V M8 D
+Katusa                    0115 X658000-0   Ba Lo Ni                    513 -- G4 V M3 V
+XENO                      0120 X799977-5   Hi In Wa                    215 -- F3 V M8 V
 Teaizg                    0122 X324354-9   Na Lo Ni                    313 -- F5 IV
 Tortuga                   0130 A556681-A C Ag Ni                       100 -- G1 III
                           0132 X000000-0   As Ba Lo Ni                 313 -- M3 V
@@ -62,23 +62,23 @@ Appleonamis               0222 X676454-8   Lo Ni Wa                    620 -- K6
                           0239 X735231-1   Ag Lo Ni Po                 502 -- K8 V
                           0240 X371000-0   Ba Lo Ni                    024 -- F6 VI
 Martuf                    0302 C516350-B C Na Ni Po                    713 Gr K3 IV
-Yata                      0304 A776456-D N Ag Ni                       410 Gr M4 V M6 D
-GEANAK                    0306 A858950-E N Ag Hi In Ri                 502 Gr K5 V M7 D
+Yata                      0304 A776456-D N Ag Ni                       410 Gr M4 V M6 V
+GEANAK                    0306 A858950-E N Ag Hi In Ri                 502 Gr K5 V M7 V
 Unggrae                   0309 B8A6556-C   Ag Ni                       513 -- G3 III
-ALUVIA                    0312 A97A956-E A Ag Hi In Wa Ri              514 Aa F4 V M2 D
+ALUVIA                    0312 A97A956-E A Ag Hi In Wa Ri              514 Aa F4 V M2 V
                           0316 X510000-0   Ba Lo Ni                    005 -- F0 IV
                           0317 X406000-0   Ba Ic Lo Ni Va              113 -- M5 V M5 V
                           0328 X230000-0   Ba De Lo Ni Po              012 -- F3 IV
                           0333 X000000-0   As Ba Lo Ni                 222 -- K8 V
 Mykoku                    0402 B34366A-B   Na Ni Po                    303 Gr G3 V
 Excelcior                 0403 AAAA456-D A Ag Ni Ri Wa                 114 Gr G5 III
-Bachk                     0404 B9674A3-B C Ag Lo Ni                    505 Gr G3 V M2 D
+Bachk                     0404 B9674A3-B C Ag Lo Ni                    505 Gr G3 V M2 V
 Klepto                    0405 C575410-B C Ag Lo Ni                    913 Gr K2 V
 Kenghl                    0410 C310576-A S Ba De Ni                    702 -- G3 V M1 V
 Canash                    0414 C567456-C   Ag Lo Ni                    024 -- G5 III
                           0421 X431000-0   Ba Lo Ni Po                 003 -- K3 V
-                          0433 X400000-0   Ba Lo Ni Va                 002 -- M3 V M4 D
-                          0434 X370000-0   Ba De Lo Ni                 024 -- G4 V M7 D
+                          0433 X400000-0   Ba Lo Ni Va                 002 -- M3 V M4 V
+                          0434 X370000-0   Ba De Lo Ni                 024 -- G4 V M7 V
                           0439 X432000-0   Ba Lo Ni Po                 003 -- K7 VI
                           0440 X445000-0   Ba Lo Ni                    012 -- K8 VI
 Norak                     0502 C57A77B-9   Ag In Ri Wa                 803 Gr G2 III
@@ -87,146 +87,146 @@ Annubis                   0509 X645573-7   Ag Ni Po                    413 -- G5
 Bacccara                  0510 X557000-0   Ba Lo Ni                    134 -- F0 V F4 V
                           0517 X200000-0   Ba Lo Ni Va                 020 -- K3 V
 Chrystal                  0518 X000000-0   As Ba Lo Ni                 011 -- M2 V
-Sphere                    0520 C8A6555-B   Ag Ni Ri                    902 -- F4 V M1 D
+Sphere                    0520 C8A6555-B   Ag Ni Ri                    902 -- F4 V M1 V
 Kadiera                   0524 X987756-1   Ag Ni Ri                    123 -- G4 V
-Luvzsav                   0526 X656452-3   Ag Lo Ni                    315 -- M4 V M4 D
+Luvzsav                   0526 X656452-3   Ag Lo Ni                    315 -- M4 V M4 V
 Delahara                  0529 C3414AA-C S Na Lo Ni Po                 313 -- K3 VI
 Mohennan                  0530 A868556-E N Ag Ni                       713 -- F6 V
                           0531 X221000-0 * Ba Lo Ni Po                 030 -- K2 VI
                           0538 X371000-0   Ba Lo Ni                    402 -- G3 V
 Borekk                    0602 A5855A7-C C Ag Ni                       214 Gr K7 V
-ALTARE                    0604 A6D7959-D A Ag Fl Hi                    925 Gr G4 V M2 D
-Grryak                    0606 X937600-9   Na Lo Ni                    912 -- K3 V M6 D
+ALTARE                    0604 A6D7959-D A Ag Fl Hi                    925 Gr G4 V M2 V
+Grryak                    0606 X937600-9   Na Lo Ni                    912 -- K3 V M6 V
 Huesean                   0609 X444357-9   Na Lo Ni                    303 -- G3 III
                           0614 X8D1000-0   Ba Fl Lo Ni                 013 -- G3 V
 Ramili                    0617 A597575-A   Ag Ni                       304 -- K4 V
 Schktala                  0618 A758697-C   Ag Ni                       623 -- M3 III
-Homgmerz                  0620 C634572-B   Na Lo Ni                    613 -- F6 VI M8 D
+Homgmerz                  0620 C634572-B   Na Lo Ni                    613 -- M8 V F6 VI
 Newaygo                   0622 X9A6396-1   Ag Fl Lo Ni                 312 -- M1 V
 Huiron                    0627 C6845A7-C S Na Lo Ni Po                 512 -- G3 V
 Wyandot                   0628 C2105A7-C S Ba Lo Ni                    212 -- K7 V
 Graakoa                   0629 C866553-C   Ag Lo Ni                    812 -- K3 IV
 Tiazmah                   0630 C234567-9   Na Lo Ni Po                 322 -- F8 V
                           0639 X000000-0   As Ba Lo Ni                 321 -- K3 III
-Irkirka                   0707 C88A853-A   Ag In Ri Wa                 605 -- G4 V M3 D
+Irkirka                   0707 C88A853-A   Ag In Ri Wa                 605 -- G4 V M3 V
 Digia                     0708 A867850-B   Ba Lo Ni                    400 -- F5 III
-Antioc                    0710 C352550-A   Na Lo Ni Po                 510 -- K3 IV M6 D
-WAFDO                     0711 A8A7A6A-B N Ag Fl Hi In                 223 -- G3 V M6 D
+Antioc                    0710 C352550-A   Na Lo Ni Po                 510 -- K3 IV M6 V
+WAFDO                     0711 A8A7A6A-B N Ag Fl Hi In                 223 -- G3 V M6 V
 Kurikesu                  0712 C46856A-B   Ba De Lo Ni                 205 -- K4 VI
 Ntendo                    0713 C14056A-B S Ba De Lo Ni Po              922 -- M3 V
 Ounrea                    0717 X846753-5   Ag Ni Po                    413 -- K3 V
-MOSAIC                    0718 X9B6A75-6   Ag Fl Hi In                 113 -- G4 V M8 D
-Reagis                    0720 AA67766-C N Ag In                       714 -- F6 V M8 D
+MOSAIC                    0718 X9B6A75-6   Ag Fl Hi In                 113 -- G4 V M8 V
+Reagis                    0720 AA67766-C N Ag In                       714 -- F6 V M8 V
                           0723 X358000-0   Ba Lo Ni                    804 -- K3 V
                           0725 X366000-0   Ba Lo Ni                    500 -- K5 VI
 Kartuum                   0726 X86A321-1   Ag Lo Ni Wa                 210 -- G8 V
-Ottowa                    0728 A8A86A7-C N Ag Fl Ni                    423 -- F7 V M8 D
-Cheyenne                  0730 C987657-9   Ag Ni                       613 -- G4 V M1 D
-                          0732 X541000-0   Ba Lo Ni Po                 213 -- K7 III M6 D
-Cemenola                  0733 X9A6457-7   Ag Fl Lo Ni                 714 -- F8 V M4 D
+Ottowa                    0728 A8A86A7-C N Ag Fl Ni                    423 -- F7 V M8 V
+Cheyenne                  0730 C987657-9   Ag Ni                       613 -- G4 V M1 V
+                          0732 X541000-0   Ba Lo Ni Po                 213 -- K7 III M6 V
+Cemenola                  0733 X9A6457-7   Ag Fl Lo Ni                 714 -- F8 V M4 V
                           0735 X310000-0   Ba Lo Ni                    313 -- K3 VI
 Alturo                    0736 C53A456-C   Ag Lo Ni Wa                 510 -- M3 V
-Fuelstaup                 0805 E867757-3   Ag Ni                       613 Gr F5 III M2 D
+Fuelstaup                 0805 E867757-3   Ag Ni                       613 Gr F5 III M2 V
 Shadarm                   0807 B320400-A S Ba De Lo Ni Po              804 -- G1 IV
 Alu                       0808 E67677B-8   Ba Lo Ni                    800 -- F3 III
-Sirzurka                  0809 C424242-9 S Na Lo Ni                    404 -- F5 V G3 D
+Sirzurka                  0809 C424242-9 S Na Lo Ni                    404 -- F5 V G3 V
 Isuzu                     0810 B252300-C r Na Lo Ni Po                 612 -- G4 V
                           0815 X310000-0   Ba Lo Ni                    013 -- M3 V
-                          0816 X384000-0   Ba Lo Ni                    010 -- G3 V M5 D
-Halatoa                   0831 B423657-C   Na Lo Ni                    614 -- F8 V M7 D
-KAYLA                     0834 A9AA955-E N Ag Hi In Wa Ri              123 -- F7 V M5 D
+                          0816 X384000-0   Ba Lo Ni                    010 -- G3 V M5 V
+Halatoa                   0831 B423657-C   Na Lo Ni                    614 -- F8 V M7 V
+KAYLA                     0834 A9AA955-E N Ag Hi In Wa Ri              123 -- F7 V M5 V
 KEAGLE                    0904 A861A75-E A De Hi In                    515 -- M4 V
 Keetal                    0905 X98A567-C C Ag Lo Ni Wa                 502 -- F3 III
-Sadreev                   0909 A6768A7-C N Ag Ni                       824 -- F4 IV M5 D
+Sadreev                   0909 A6768A7-C N Ag Ni                       824 -- F4 IV M5 V
 Gardinyah                 0910 C682667-C   Ba Fl Lo Ni                 622 -- M1 V
-NAUTICA                   0911 A97A956-E N Ag Hi In Ri Wa              412 -- M3 V M6 D
+NAUTICA                   0911 A97A956-E N Ag Hi In Ri Wa              412 -- M3 V M6 V
 Cyduku                    0912 A210456-A   Ba Lo Ni                    313 -- G2 V
 REISENAU                  0913 A6049AA-C N Ic Hi In Va                 713 -- G3 V
 Butniff                   0918 AA88455-D N Ba Lo Ni                    214 -- F3 V
 Sikaal                    0919 A887766-D C Ag Ni Ri                    424 -- M7 V
-Nabeen                    0921 X454000-0   Ba Lo Ni                    523 -- F5 V M3 D
-TRACA                     0924 A888A53-E   Ag Hi In Ri                 410 -- G3 V M3 D
-                          0928 X462000-0   Ba Lo Ni                    100 -- F0 V M2 D
-Ishadala                  0930 C866875-C   Ag Ni Cm                    724 -- G5 V M5 D
+Nabeen                    0921 X454000-0   Ba Lo Ni                    523 -- F5 V M3 V
+TRACA                     0924 A888A53-E   Ag Hi In Ri                 410 -- G3 V M3 V
+                          0928 X462000-0   Ba Lo Ni                    100 -- F0 V M2 V
+Ishadala                  0930 C866875-C   Ag Ni Cm                    724 -- G5 V M5 V
 Intfen                    0931 A9A7753-B N Ag Fl Ni Ri                 603 -- K3 V
                           0935 X100000-0   Ba Lo Ni Va                 913 -- K2 V
                           0940 X361000-0   Ba Lo Ni                    303 -- F3 III
 Cheutoi                   1005 C100669-C C Ba Lo Ni Va                 902 -- G4 V
-Urgungtalz                1006 B88986A-C N Ag In                       212 -- F3 V M8 D
+Urgungtalz                1006 B88986A-C N Ag In                       212 -- F3 V M8 V
 Hialeah                   1010 C303567-C S Ba Ic Lo Ni Va              810 -- M3 V
 Amadi                     1013 C8578A8-7   Ag In Ri                    300 -- G2 III
 Schall                    1015 B47A655-B   Ag Lo Ni Wa                 634 -- G4 V
 Ianshepl                  1017 C957553-9   Ba Lo Ni                    802 -- F5 V
 Zietdkl                   1027 X895400-4   Ag Lo Ni                    505 -- M4 V
-                          1032 X100000-0   Ba Lo Ni Va                 110 -- M6 V M3 D
-Khroulg                   1034 A88A557-A   Ba Lo Ni Wa                 725 -- K6 IV M3 D
-Charlzul                  1036 C787656-A   Ba Lo Ni                    323 -- F6 V M1 D
+                          1032 X100000-0   Ba Lo Ni Va                 110 -- M3 V M6 V
+Khroulg                   1034 A88A557-A   Ba Lo Ni Wa                 725 -- K6 IV M3 V
+Charlzul                  1036 C787656-A   Ba Lo Ni                    323 -- F6 V M1 V
                           1037 X574000-0   Ba Lo Ni                    113 -- K8 V
                           1039 X444000-0   Ba Lo Ni                    813 -- G8 V
                           1040 X150000-0   Ba De Lo Ni Po              111 -- M2 V
-Azur                      1102 B676656-C C Ag Ni                       922 -- F5 V M4 D
+Azur                      1102 B676656-C C Ag Ni                       922 -- F5 V M4 V
 Greanak                   1103 E865753-8   Ba Lo Ni                    302 -- M4 V
 Vzeckeng                  1106 A97A86A-C N Ag In Wa                    313 -- G2 III
 Tristan                   1109 X323000-0   Ba Lo Ni Po                 700 -- M4 V
 Morgan                    1110 AA68840-C N Ag In Ri                    412 -- G3 V
-Physeril                  1112 C764455-7   Ba Lo Ni                    312 -- M4 V M6 D
-Bwisliser                 1114 B310678-A   Ba Lo Ni                    413 -- G8 V M6 D
-Pimpin                    1116 A967833-C A Ag In                       913 -- F9 V M7 D
-Majoinir                  1117 A530544-A A De Lo Ni Po                 522 -- A5 V M3 D
+Physeril                  1112 C764455-7   Ba Lo Ni                    312 -- M4 V M6 V
+Bwisliser                 1114 B310678-A   Ba Lo Ni                    413 -- G8 V M6 V
+Pimpin                    1116 A967833-C A Ag In                       913 -- F9 V M7 V
+Majoinir                  1117 A530544-A A De Lo Ni Po                 522 -- A5 V M3 V
 Zerapli                   1120 AA87500-C N Ag Ni Po                    125 -- F5 V
 MALOHK                    1121 D567978-A   Ag Hi In                    424 -- G4 V
 Fortafiber                1122 A767300-B   Ag Lo Ni                    823 -- F8 IV M1 IV
                           1126 X222000-0   Ba Lo Ni Po                 004 -- M5 V
-                          1129 X241000-0   Ba Lo Ni Po                 123 -- M1 V M3 D
+                          1129 X241000-0   Ba Lo Ni Po                 123 -- M1 V M3 V
 Halatoa                   1131 A767858-B   Ag In Ri                    824 -- K7 V
-Moutoulk                  1134 C867756-7   Ba Lo Ni                    103 -- K2 V M3 D
+Moutoulk                  1134 C867756-7   Ba Lo Ni                    103 -- K2 V M3 V
 Ibutlphil                 1135 C142365-9   De Lo Ni Po                 520 -- G7 V
                           1137 X6B1000-0   Ba Fl Lo Ni                 624 -- G1 V
-Zeabr                     1207 C43336A-B C Na Lo Ni Po                 922 -- F5 V M5 D
+Zeabr                     1207 C43336A-B C Na Lo Ni Po                 922 -- F5 V M5 V
 Kareoke                   1210 A5746BA-C   Ba Lo Ni                    803 -- M5 III
 Kietoawu                  1231 C300366-B S Ba Lo Ni Va                 303 -- M6 V
                           1234 X573000-0   Ba Lo Ni                    603 -- F8 V
                           1239 X858000-0   Ba Lo Ni                    913 -- G2 V
-Freeworld                 1306 A876553-E N Ag Lo Ni Ri                 923 -- K3 V M5 D
+Freeworld                 1306 A876553-E N Ag Lo Ni Ri                 923 -- K3 V M5 V
 Kuezo                     1307 C8067AA-9 C Ic Na Lo Ni                 103 -- F7 V
 DELPHI                    1308 A797957-C   Ag Hi In Ri                 924 -- G4 V
 Ieuz                      1309 X511300-C C Ba Ic Lo Ni                 222 -- K3 V M4 V
 Frey                      1312 X265555-9   Na Lo Ni                    503 -- M3 V
-Haufbrau                  1314 C542359-C   Ba Lo Ni Po                 613 Hl K3 V M3 D M0 D
-Caladbolg                 1315 X364000-0 S Ba Lo Ni                    710 Hl F7 V M7 D
-Tukadump                  1316 D967477-7   Ba Lo Ni                    124 Hl G4 V M8 D
+Haufbrau                  1314 C542359-C   Ba Lo Ni Po                 613 Hl K3 V M3 V M0 V
+Caladbolg                 1315 X364000-0 S Ba Lo Ni                    710 Hl F7 V M7 V
+Tukadump                  1316 D967477-7   Ba Lo Ni                    124 Hl G4 V M8 V
 BRYZKK                    1318 CA76959-A   Ag Hi In Ri                 410 -- G5 V
 Sylvan                    1320 A8A6758-E N Ag Fl Ri Cp                 701 Sa F5 V
 Dresdia                   1322 AA78683-C S Ag Ni Ri                    925 Sa G3 V
-Mayeaux                   1325 C576657-C   Ba Lo Ni                    614 Sa F5 V M5 D
-                          1330 X976000-0   Ba Lo Ni                    212 -- G6 V M2 D
-VLAD                      1332 A758957-D N Ag Hi In Ri                 213 -- G4 V M6 D
+Mayeaux                   1325 C576657-C   Ba Lo Ni                    614 Sa F5 V M5 V
+                          1330 X976000-0   Ba Lo Ni                    212 -- G6 V M2 V
+VLAD                      1332 A758957-D N Ag Hi In Ri                 213 -- G4 V M6 V
 Wafadi                    1333 D343313-B S Ba Lo Ni Po                 720 -- M3 V
                           1335 X7A3000-0   Ba Fl Lo Ni                 222 -- KV IV
-                          1339 X564000-0   Ba Lo Ni                    403 -- M1 V M6 D
+                          1339 X564000-0   Ba Lo Ni                    403 -- M1 V M6 V
 DARMA                     1404 B8899AA-C N Ag Hi In Ri                 623 -- G3 VI
 Tomorri                   1405 B34236A-C S Na Lo Ni Po                 414 -- G2 III
 KHERROU                   1407 A78A953-E A Ag Hi In Wa                 904 -- K3 VI
-Rhmadiil                  1410 E866878-7 N Ag Ni Po                    703 -- M4 V M4 D
+Rhmadiil                  1410 E866878-7 N Ag Ni Po                    703 -- M4 V M4 V
 Noe                       1413 A4675A5-A   Ag Lo Ni                    212 Hl M4 V
 Tortuga                   1415 A898300-B   Ag Lo Ni                    225 Hl M7 IV
-Verili                    1416 A9779A8-E A Ag Hi In Ri                 313 Hl G2 IV M7 D
+Verili                    1416 A9779A8-E A Ag Hi In Ri                 313 Hl G2 IV M7 V
 Zadiakal                  1418 B435267-9 S Na Lo Ni Po                 702 -- M5 V
-DREA                      1420 B656957-D N Ag Hi In                    414 Sa G5 V M1 D
-Cybzuul                   1421 C967300-8   Ag Lo Ni                    720 Sa M3 V G2 V F3D
-Solmulti                  1423 D15036A-C S Ba De Lo Ni Po              312 Sa G9 V M5 D
+DREA                      1420 B656957-D N Ag Hi In                    414 Sa G5 V M1 V
+Cybzuul                   1421 C967300-8   Ag Lo Ni                    720 Sa F3 V G2 V M3 V
+Solmulti                  1423 D15036A-C S Ba De Lo Ni Po              312 Sa G9 V M5 V
 ILPIC                     1424 A7A7953-F N Ag Fl Hi In Ri              813 Sa F4 V
 Jobio                     1426 C771771-C S De Ni Po                    712 De K3 VI
-Umex                      1427 X221000-0   Ba Lo Ni Po                 010 De G3 V M2 D
-Nueralla                  1431 B678657-B N Ag Ni Ri                    420 -- K2 V M4 D
-NARVEEN                   1434 A876954-E A Ag Hi In Ri Cp              213 -- G3 V M8 D
+Umex                      1427 X221000-0   Ba Lo Ni Po                 010 De G3 V M2 V
+Nueralla                  1431 B678657-B N Ag Ni Ri                    420 -- K2 V M4 V
+NARVEEN                   1434 A876954-E A Ag Hi In Ri Cp              213 -- G3 V M8 V
                           1436 X587000-0   Ba Lo Ni                    110 -- A6 IV
                           1503 X6B5000-0   Ba Fl Lo Ni                 110 -- G1 V
                           1505 X542000-0   Ba Lo Ni Po                 102 -- F8 V
-                          1507 X757000-0   Ba Lo Ni                    135 -- G4 V M5 D
+                          1507 X757000-0   Ba Lo Ni                    135 -- G4 V M5 V
                           1508 X686000-0   Ba Lo Ni                    100 -- G4 V
-                          1509 X853000-0   Ba Lo Ni Po                 124 -- F7 V M4 D
-                          1515 X99A000-0   Ba Lo Ni Wa                 104 -- G0 V M3 D
+                          1509 X853000-0   Ba Lo Ni Po                 124 -- F7 V M4 V
+                          1515 X99A000-0   Ba Lo Ni Wa                 104 -- G0 V M3 V
                           1516 X455000-0   Ba Lo Ni                    112 -- F6 V
                           1518 X510000-0   Ba Lo Ni                    610 -- G4 V
 Tashkent                  1520 C776456-B   Ba Lo Ni Po                 323 Sa K8 V
@@ -238,75 +238,75 @@ Veagui                    1529 X100000-0   Ba Lo Ni Va                 020 De F6
 JARROD                    1602 A768956-C   Ba Lo Ni                    513 -- G3 VI
 AMANDA                    1608 AA97A59-E N Ba Lo Ni                    214 -- G4 V
 Behamut                   1613 A000400-D   As Ba Lo Ni                 623 Hl M4 V
-Zues                      1614 B514755-B   Na Ni Po                    803 Hl G3 V M5 D
-Shakir                    1616 E638856-6   Na In Po                    112 Hl G4 V G9 V M2 D
+Zues                      1614 B514755-B   Na Ni Po                    803 Hl G3 V M5 V
+Shakir                    1616 E638856-6   Na In Po                    112 Hl G4 V G9 V M2 V
 NEAGAK                    1618 B8A5953-B   Na Hi In                    614 -- M1 V M9 V
-FUBAR                     1620 A877920-C N Ag Hi In Ri                 714 Sa G3 V M2 D
-Zietsck                   1621 C778155-9 W Na Lo Ni Po                 510 Sa G3 V M3 D
+FUBAR                     1620 A877920-C N Ag Hi In Ri                 714 Sa G3 V M2 V
+Zietsck                   1621 C778155-9 W Na Lo Ni Po                 510 Sa G3 V M3 V
 Riizuku                   1622 A8668A9-C A Ag In Ri                    125 Sa M5 V
 Ingfre                    1623 C849775-7   Ag In Ri                    402 Sa K2 V
 Hirohita                  1626 C696575-C   Ag Lo Ni                    914 De F8 VI
 DRACONIA                  1627 A967958-F A Ag Hi In                    425 De G3 V G5 V
-TORONAGA                  1628 A857956-E N Ag Hi In Ri                 202 De F8 V M5 D
+TORONAGA                  1628 A857956-E N Ag Hi In Ri                 202 De F8 V M5 V
                           1701 X561000-0   Ba Lo Ni                    813 -- F6 V
 Jyell                     1707 A312457-E r Ba Ic Lo Ni                 310 -- K3 III
 Blodi                     1711 B435656-B   Na Ni Po                    804 -- K6 V
 Aitia                     1712 X000000-0   As Ba Lo Ni                 010 -- M3 V
 Razmar                    1716 C683554-A   Na Lo Ni                    624 Hl K3 V F4 V
-Sayardal                  1720 A662626-C N Na Ni Po                    913 Sa M5 V M2 D
+Sayardal                  1720 A662626-C N Na Ni Po                    913 Sa M2 V M5 V
 Mileaki                   1721 C454531-C   Na Lo Ni                    104 Sa G8 V G3 V
-Brea                      1726 A7A78A7-C   Ag In Ri                    126 -- G5 V M2 D
+Brea                      1726 A7A78A7-C   Ag In Ri                    126 -- G5 V M2 V
 Fraxys                    1732 C223322-C C Na Lo Ni Po                 313 -- M3 V
-Zanemahon                 1733 A77869A-7   Ag Ni Ri                    510 -- K3 IV M3 D
+Zanemahon                 1733 A77869A-7   Ag Ni Ri                    510 -- K3 IV M3 V
 Norwak                    1734 X658000-0   Ba Lo Ni                    614 -- F7 VI
-Sagev                     1736 AA67653-C   Ag Ni Po                    003 -- K2 V M2 D
-Danaphad                  1737 D534000-0   Ba Lo Ni                    010 -- G3 V M2 D
-Sherru                    1738 C696555-B   Ag Lo Ni                    604 -- F4 V M8 D
-Ashak                     1739 C357356-B   Na Lo Ni                    213 -- G4 V M2 D
+Sagev                     1736 AA67653-C   Ag Ni Po                    003 -- K2 V M2 V
+Danaphad                  1737 D534000-0   Ba Lo Ni                    010 -- G3 V M2 V
+Sherru                    1738 C696555-B   Ag Lo Ni                    604 -- F4 V M8 V
+Ashak                     1739 C357356-B   Na Lo Ni                    213 -- G4 V M2 V
 Ryku                      1804 X222000-0   Ba Lo Ni                    214 -- G3 V
 Pilot                     1805 X000000-0   As Ba Lo Ni                 222 -- F3 IV
-Menth                     1809 C310459-9   Ba Lo Ni                    414 -- K3 V M5 D
+Menth                     1809 C310459-9   Ba Lo Ni                    414 -- K3 V M5 V
 Saphire                   1810 B468777-C   Ba Lo Ni                    902 -- G7 V
 Kartoonah                 1813 A698855-E   Ag In Ri                    514 -- G2 V
 SHALANDRA                 1815 B876A55-D N Ag Hi In Ri                 613 Hl K3 V
-ALUVIAL                   1817 A968958-C N Ag Hi In Ri                 413 Sa M4 V M7 D
+ALUVIAL                   1817 A968958-C N Ag Hi In Ri                 413 Sa M4 V M7 V
 P-3x-117                  1818 X000000-0 S As Ba Lo Ni                 011 Sa G9 V
 Chahult                   1819 B664756-C N Na Ni Po                    711 Sa M2 V
-Myrettia                  1821 X754853-C   Na Lo Ni                    413 Sa M2 V M5 D
-Haita                     1824 X794497-7   Na Lo Ni                    204 -- K3 V M6 D
+Myrettia                  1821 X754853-C   Na Lo Ni                    413 Sa M2 V M5 V
+Haita                     1824 X794497-7   Na Lo Ni                    204 -- K3 V M6 V
 Miogeku                   1826 D547475-A   Na Lo Ni                    510 De M5 V
-Olsmech                   1827 B888777-9   Ag Ni Ri                    615 De K3 V M6 D
+Olsmech                   1827 B888777-9   Ag Ni Ri                    615 De K3 V M6 V
                           1831 X400000-0   Ba Lo Ni Va                 013 -- K3 IV
                           1832 X100000-0   Ba Lo Ni Va                 012 -- K6 V
                           1833 X212000-0   Ba Ic Lo Ni                 013 -- G2 V
-Medina                    1835 AA6A350-C   Na Lo Ni Wa                 704 -- F6 V M2 D
+Medina                    1835 AA6A350-C   Na Lo Ni Wa                 704 -- F6 V M2 V
                           1836 X355000-0   Ba Lo Ni                    012 -- G8 VI
                           1839 X513000-0   Ba Ic Lo Ni                 513 -- F8 VI
-Batlac                    1902 A796853-C   Ag In Ri                    102 -- G6 VI M3 D
+Batlac                    1902 A796853-C   Ag In Ri                    102 -- M3 V G6 VI
 Tipric                    1912 X410000-0   Ba Lo Ni                    010 -- M1 III
 Daidalus                  1914 D6988A6-A   Ba Lo Ni                    513 -- M3 V M3 V
 Enon                      1916 A222557-D N Na De Lo Ni                 310 Hl G3 IV
-Anbar                     1920 B36266A-A   Ba Ni Po                    115 Sa G1 V M8 D
+Anbar                     1920 B36266A-A   Ba Ni Po                    115 Sa G1 V M8 V
 Blackwater                1922 C233313-A   Na Lo Ni Po                 514 Sa M3 III M5 V
 MYTHDRANOR                1923 A897A56-E N Ag Hi In Ri                 902 Sa G5 V
 Tohave                    1927 A656676-B N Ba Lo Ni                    403 De K3 V
 Penzes                    1928 X240000-0   Ba De Lo Ni Po              000 De G9 V
 Iletrah                   1929 C100345-C S Ba Lo Ni Va                 310 De K9 V
-                          1933 X100000-0   Ba Lo Ni Va                 014 -- M7 V M3 V
+                          1933 X100000-0   Ba Lo Ni Va                 014 -- M3 V M7 V
                           1939 X472000-0   Ba Lo Ni                    013 -- G4 V
 Anrapili                  2013 D434974-5   Ba Lo Ni                    703 -- F5 VI
 Tripic                    2015 A30026A-C S Ba Lo Ni Va                 922 Hl M4 V
 Domcat                    2016 X63A000-0   Ba Lo Ni Wa                 315 Hl F6 V
 Aitaptiid                 2020 X699000-0 N Ba Lo Ni                    405 Sa M4 V M6 V M5 V
 Haifa                     2027 C451555-B S Ba Lo Ni Po                 920 De K4 IV
-Artotxem                  2030 A396650-C N Ba Lo Ni                    802 -- K5 V M4 D
+Artotxem                  2030 A396650-C N Ba Lo Ni                    802 -- K5 V M4 V
 Togzul                    2031 A468720-C C Ag In Po                    200 Rv K6 VI
 Blood                     2034 C867653-A C Ag Ni Po                    704 Rv G7 V
                           2035 X537000-0   Ba Lo Ni                    005 -- F6 VI
                           2037 X867000-0   Ba Lo Ni                    010 -- G3 V
                           2039 X200000-0   Ba Lo Ni Va                 012 -- K3 V
                           2040 X676000-0   Ba Lo Ni                    314 -- M4 V
-                          2101 X76A000-0   Ba Lo Ni Wa                 114 -- G6 V M2 D K8 V
+                          2101 X76A000-0   Ba Lo Ni Wa                 114 -- G6 V M2 V K8 V
                           2102 X78A000-0   Ba Lo Ni Wa                 212 -- M8 V
                           2103 X230000-0   Ba De Lo Ni Po              135 -- F8 V M1 V
 Lyope                     2109 X561000-0   Ba Lo Ni                    123 -- F3 VI
@@ -316,9 +316,9 @@ Wykarp                    2116 X7C2000-0   Ba Fl Lo Ni                 020 Hl M3
 Muniz                     2117 C775557-A   Ag Lo Ni                    613 Hl K3 IV
 Shirmi                    2118 X300000-0   Ba Lo Ni Va                 012 Hl F3 VI
 CITIDEL                   2119 AA6995D-D A Ag Hi In                    914 Hl K1 IV
-                          2124 X400000-0   Ba Lo Ni Va                 014 -- M3 V M6 D
+                          2124 X400000-0   Ba Lo Ni Va                 014 -- M3 V M6 V
 Kestlif                   2127 X100000-0   Ba Lo Ni Va                 513 De G4 V
-Haven                     2129 X202200-C C Ba Ic Lo Ni Va              904 -- K3 IV G0 D
+Haven                     2129 X202200-C C Ba Ic Lo Ni Va              904 -- K3 IV G0 V
 Arnell                    2130 A556770-C C Ag Lo Ni                    605 -- F6 IV
 Tortuga                   2133 C342650-A C Na Lo Ni Po                 222 -- G4 V
 Asylem                    2135 A7A5460-A N Na Fl Lo Ni                 610 Rv F6 VI
@@ -326,142 +326,142 @@ Asylem                    2135 A7A5460-A N Na Fl Lo Ni                 610 Rv F6
                           2138 X654000-0   Ba Lo Ni                    013 -- F8 V
                           2202 XAB4000-0   Ba Fl Lo Ni                 100 -- F6 V
 Gorignac                  2213 X312000-0   Ba Ic Lo Ni                 010 -- K7 V
-Skell                     2218 C659657-C   Ag Ni Po                    123 Hl F3 V M0 D
+Skell                     2218 C659657-C   Ag Ni Po                    123 Hl F3 V M0 V
 Tristan                   2219 C453554-C   Ba Lo Ni Po                 604 Hl G5 V
 Watxell                   2220 X200367-B S Ba Lo Ni Va                 212 Hl F9 V
-                          2222 X575000-0   Ba Lo Ni                    902 -- G3 V M1 D
+                          2222 X575000-0   Ba Lo Ni                    902 -- G3 V M1 V
                           2224 X331000-0   Ba Lo Ni Po                 010 -- K3 V
                           2225 X969000-0   Ba Lo Ni                    420 -- K1 V
 Atraiu                    2227 B235555-C S Na Lo Ni                    215 De F8 III
-Narrsum                   2229 X233223-C   Na Lo Ni Po                 114 -- M3 V M2 D
+Narrsum                   2229 X233223-C   Na Lo Ni Po                 114 -- M2 V M3 V
 Hitler                    2232 E7B4596-9 C Na Fl Lo Ni                 424 -- K3 IV
-                          2235 X535000-0   Ba Lo Ni                    123 -- F7 V M0 D
+                          2235 X535000-0   Ba Lo Ni                    123 -- F7 V M0 V
                           2236 X242000-0   Ba Lo Ni Po                 012 -- K3 VI
-                          2240 XAC6000-0   Ba Fl Lo Ni                 024 -- G6 V M8 D
+                          2240 XAC6000-0   Ba Fl Lo Ni                 024 -- G6 V M8 V
                           2304 X548000-0   Ba Lo Ni                    502 -- K3 VI
 PYCUS                     2310 A998957-F A Ag Hi In Ri                 704 -- G7 VI
-                          2313 X270000-0   Ba De Lo Ni                 001 -- M3 V M0 D
+                          2313 X270000-0   Ba De Lo Ni                 001 -- M0 V M3 V
                           2314 X210000-0   Ba Lo Ni                    003 -- M2 V
-Naruvgrr                  2316 C888555-C   Ag Lo In Ri                 813 Hl G1 V M3 D
+Naruvgrr                  2316 C888555-C   Ag Lo In Ri                 813 Hl G1 V M3 V
 Lezina                    2317 A9998A9-C   Ag Hi In                    624 Hl G3 III
-Chairnobel                2320 A300557-C N Na Lo Ni Va                 212 Hl M4 V M8 D
-                          2323 X699000-0   Ba Lo Ni                    814 -- F6 V M6 D
+Chairnobel                2320 A300557-C N Na Lo Ni Va                 212 Hl M4 V M8 V
+                          2323 X699000-0   Ba Lo Ni                    814 -- F6 V M6 V
                           2324 X360000-0   Ba De Lo Ni                 000 -- M7 V
 DEVINLI                   2328 A768955-C   Ag Hi In                    624 De F8 VI
 Zantex                    2331 AA67654-C N Ag Ni                       011 De K3 V K3 V
                           2336 X6A2000-0   Ba Fl Lo Ni                 010 -- F4 IV
                           2337 X869000-0   Ba Lo Ni                    020 -- G2 V
                           2339 X89A000-0   Ba Lo Ni Wa                 124 -- F3 V
-Upixoc                    2340 X555555-5   Na Lo Ni                    123 -- G3 V M0 D
-Kenner                    2404 A642655-C   Ba Lo Ni Po                 313 -- F7 V M5 D
+Upixoc                    2340 X555555-5   Na Lo Ni                    123 -- G3 V M0 V
+Kenner                    2404 A642655-C   Ba Lo Ni Po                 313 -- F7 V M5 V
 IRKERRA                   2406 A674953-F N Ba Lo Ni                    402 -- G3 V
 Enos                      2409 A515552-E N Ba Ic Lo Ni                 900 -- G4 V
-SALIAH                    2414 B846956-C   Na Hi In                    504 -- K3 V M2 D
+SALIAH                    2414 B846956-C   Na Hi In                    504 -- K3 V M2 V
 Arasola                   2416 A868757-C N Na Lo Ni                    824 Hl F8 VI
 Eulass                    2419 A766855-C   Ba Lo Ni                    513 Hl K2 IV
                           2422 X347000-0   Ba Lo Ni                    912 -- G8 V
-Tybor                     2428 C5647C7-9   Na Lo Ni                    114 De F6 V M5 D
+Tybor                     2428 C5647C7-9   Na Lo Ni                    114 De F6 V M5 V
 Vaveen                    2429 A633675-C   Na Lo Ni                    600 De G4 V
 Carnage                   2430 CAAA555-A   Ba Lo Ni                    610 De K1 V
 Tess                      2431 X310310-9 S Ba Lo Ni                    613 De F6 V
 Ghosoeg                   2433 C585853-B   Ba Lo Ni                    513 -- G7 V
-KOUEVI                    2434 AA9A950-D N Ba Lo Ni Wa                 113 -- G5 V M8 D
+KOUEVI                    2434 AA9A950-D N Ba Lo Ni Wa                 113 -- G5 V M8 V
 Genisis                   2436 A769657-C N Ag Ni Wa                    720 -- F6 IV
 Carrion                   2437 C857360-N   Ba Lo Ni                    320 Rv F3 V
-Sopdal                    2440 X400000-0   Ba Lo Ni Va                 012 -- K4 V M1 D
-                          2501 X868000-0   Ba Lo Ni                    102 -- F3 V M5 D
+Sopdal                    2440 X400000-0   Ba Lo Ni Va                 012 -- K4 V M1 V
+                          2501 X868000-0   Ba Lo Ni                    102 -- F3 V M5 V
 Chydra                    2506 C200553-A   Na Lo Ni Va                 822 -- M3 V
-                          2513 X484000-0   Ba Lo Ni                    115 -- F5 V M5 D
+                          2513 X484000-0   Ba Lo Ni                    115 -- F5 V M5 V
 Joulupukki                2517 C472359-C S De Na Lo Ni                 101 Hl K5 V
-Olentero                  2519 E455200-A   Na Lo Ni                    113 Hl F1 V M8 D
-Ideratl                   2520 A98789A-C N Ag Hi In Ri                 126 Hl G2 V M5 D
-Bael                      2521 A57376A-C N Na Ni Po                    323 -- G3 V M2 D
+Olentero                  2519 E455200-A   Na Lo Ni                    113 Hl F1 V M8 V
+Ideratl                   2520 A98789A-C N Ag Hi In Ri                 126 Hl G2 V M5 V
+Bael                      2521 A57376A-C N Na Ni Po                    323 -- G3 V M2 V
 RHINE                     2524 A9A696A-C   Ag Fl Hi In                 902 -- K3 V
 Rundus                    2525 B79A754-C   Ba Lo Ni Wa                 123 -- F5 V
-Vreckeg                   2527 C555555-C C Ba Lo Ni                    323 -- G3 V M0 D
+Vreckeg                   2527 C555555-C C Ba Lo Ni                    323 -- G3 V M0 V
                           2607 X410000-0   Ba Lo Ni                    102 -- A5 V
                           2609 X552000-0   Ba Lo Ni Po                 124 -- F4 V
-Gryla                     2616 A467663-A S Ag Ni Po                    103 -- F9 V M8 D
+Gryla                     2616 A467663-A S Ag Ni Po                    103 -- F9 V M8 V
 Vasdomir                  2617 A96A69A-C N Ag Lo Ni Wa                 111 -- F2 V
 Calrysian                 2618 X200200-A   Ba Lo Ni Va                 102 -- M4 V
 Blitz                     2619 C210000-7 S Na Lo Ni                    103 -- M2 V
 Alise                     2622 C768777-C C Ag In Ri                    115 -- G2 V G2 V
 Vega                      2626 A867634-C N Ag Lo Ni Va                 613 -- M5 V
 Montenyl                  2632 X555000-0   Ba Lo Ni                    803 -- G1 V
-Aszear                    2634 X788455-1   Ag Lo Ni                    701 -- G4 V M7 D
-Gakal                     2636 X635000-0   Ba Lo Ni                    424 -- K3 V M3 D
+Aszear                    2634 X788455-1   Ag Lo Ni                    701 -- G4 V M7 V
+Gakal                     2636 X635000-0   Ba Lo Ni                    424 -- K3 V M3 V
                           2701 XAA7000-0   Ba Lo Ni                    102 -- M8 V
                           2704 X98A000-0   Ba De Lo Ni Po              106 -- M0 V M0 V
                           2712 X678000-0   Ba Lo Ni                    100 -- F2 V
-Fouettard                 2715 A8A99A8-A N Ba Fl Lo Ni                 123 -- M6 V M4 D
+Fouettard                 2715 A8A99A8-A N Ba Fl Lo Ni                 123 -- M4 V M6 V
 Liamsitt                  2716 C564654-A   Ba Lo Ni                    112 -- F5 V
 Valkrie                   2721 A55556A-C N Ba Lo Ni Po                 204 -- F6 V
 Mookbar                   2723 A867456-B N Ag Lo Ni                    703 -- G3 V
 Zekeal                    2725 D87A553-C C Ag Lo Ni Wa                 313 -- K6 IV
 Curacao                   2727 A867856-B N Ag Hi In Ri                 614 -- M3 IV
-Yugiku                    2729 AAD7755-C   Ag Fl Ni                    310 -- G3 V M3 D
+Yugiku                    2729 AAD7755-C   Ag Fl Ni                    310 -- G3 V M3 V
 Alkali                    2733 X762000-0   Ba Lo Ni                    302 -- K3 VI
 Pequanak                  2735 X656656-1   Ba Lo Ni                    513 -- G2 V
 Kartawala                 2736 X561000-0   Ba Lo Ni                    112 -- K5 V
 Chahult                   2737 A567657-6 C Ag Lo Ni                    202 -- F3 VI
-                          2808 X643000-0   Ba Lo Ni Po                 117 -- F8 V M3 D
+                          2808 X643000-0   Ba Lo Ni Po                 117 -- F8 V M3 V
 Tuku                      2821 B6B5777-C   Ag Fl Ni                    813 -- F4 III
-Cygus                     2823 A678757-C N Ag Ni                       612 -- G4 iV
+Cygus                     2823 A678757-C N Ag Ni                       612 -- G4 IV
 Tauri                     2824 C342557-C S Ba Lo Ni Po                 313 -- F3 IV
-Hunter                    2825 C412567-C S Na Ic Lo Ni                 303 -- G3 V M5 D
+Hunter                    2825 C412567-C S Na Ic Lo Ni                 303 -- G3 V M5 V
 Las Vega                  2829 A957753-C   Ag Cm In                    911 -- K6 IV
 Kodrigue                  2831 X224000-0   Ba Lo Ni                    913 -- M3 V
-Tztilphi                  2833 X786753-4   Ag Lo Ni                    624 -- K4 IV M5 D
+Tztilphi                  2833 X786753-4   Ag Lo Ni                    624 -- K4 IV M5 V
 Thornastor                2834 X747000-0   Ba Lo Ni                    303 -- F8 III
 Karatula                  2835 X463000-0   Ba Lo Ni                    204 -- K2 VI
 Kietal                    2839 AAE7856-A   Ag Fl Hi In                 723 -- G7 V
                           2903 X867000-0   Ba Lo Ni                    102 -- M3 V
-                          2916 X360000-0   Ba De Lo Ni                 104 -- F7 V M5 D
-                          2918 X7A2000-0   Ba Fl Lo Ni                 104 -- M1 V M7 D
+                          2916 X360000-0   Ba De Lo Ni                 104 -- F7 V M5 V
+                          2918 X7A2000-0   Ba Fl Lo Ni                 104 -- M1 V M7 V
 Rylacor                   2923 A686525-C N Ba Lo Ni                    813 -- G3 V
 INTASH                    2924 B86A975-D   Ag Hi In Ri                 325 -- K3 IV
 Avoral                    2925 C535678-B C Na Lo Ni                    214 -- G2 III
-Advent                    2926 C534654-C C Na Lo Ni                    615 -- M3 V M1 D
-                          3005 X341000-0   Ba Lo Ni Po                 103 -- F9 V M0 D
-                          3007 X681000-0   Ba Lo Ni                    125 -- F4 V M5 D
+Advent                    2926 C534654-C C Na Lo Ni                    615 -- M1 V M3 V
+                          3005 X341000-0   Ba Lo Ni Po                 103 -- F9 V M0 V
+                          3007 X681000-0   Ba Lo Ni                    125 -- F4 V M5 V
                           3011 X785000-0   Ba Lo Ni                    100 -- K0 V
                           3013 X543000-0   Ba Lo Ni Po                 114 -- K0 V
-                          3015 X669000-0   Ba Lo Ni                    101 -- F3 V M6 D
-                          3016 X682000-0   Ba Lo Ni                    105 -- F3 V M7 D
+                          3015 X669000-0   Ba Lo Ni                    101 -- F3 V M6 V
+                          3016 X682000-0   Ba Lo Ni                    105 -- F3 V M7 V
                           3017 X471000-0   Ba Lo Ni                    114 -- F2 V
-Triasla                   3021 X100000-0   Ba Lo Ni Va                 201 -- M4 V M0 V
+Triasla                   3021 X100000-0   Ba Lo Ni Va                 201 -- M0 V M4 V
 DUUR IMAR                 3025 A8A7957-D N Ag Fl Hi In                 614 -- G3 IV
 Sittahr                   3027 A548854-C N Na Lo Ni                    303 -- K3 III
 Duln                      3028 B6105B9-B S Ba Lo Ni                    514 -- M1 IV
 Fatima                    3031 X782427-1   Na Lo Ni                    203 -- F7 V
 Iconia                    3032 X212000-0   Ba Ic Lo Ni                 313 -- F6 III
 Nojacks                   3034 XAC4000-0   Ba Fl Lo Ni                 422 -- G2 V
-                          3101 X110000-0   Ba Lo Ni                    101 -- M3 V M7 D
+                          3101 X110000-0   Ba Lo Ni                    101 -- M3 V M7 V
                           3103 X776000-0   Ba Lo Ni                    101 -- G8 V
                           3115 X200000-0   Ba Lo Ni Va                 123 -- M3 V
                           3116 X668000-0   Ba Lo Ni                    103 -- F9 V
                           3120 X000000-0   As Ba Lo Ni                 104 -- K8 V M1 V
-OLYBRIUS                  3123 A888959-D A Ag Hi In Ri                 413 -- F3 V M4 D
+OLYBRIUS                  3123 A888959-D A Ag Hi In Ri                 413 -- F3 V M4 V
 Barter                    3124 B557850-B   Ba Lo Ni                    723 -- M3 V F9 V
-Delta                     3125 A8A7653-D N Ag In Ri                    612 -- F4 V M6 D
+Delta                     3125 A8A7653-D N Ag In Ri                    612 -- F4 V M6 V
 Kybarak                   3126 B2226AE-B N Na De Ni Po                 503 -- M4 V
 Hostage                   3127 C35066A-B   Ba Lo Ni Po                 720 -- K3 V
-Efortxev                  3132 X570000-0   Ba De Lo Ni                 502 -- M2 V M1 D
+Efortxev                  3132 X570000-0   Ba De Lo Ni                 502 -- M1 V M2 V
 Skrelja                   3138 X77A000-0   Ba Lo Ni Wa                 200 -- K2 IV
                           3204 X688000-0   Ba Lo Ni                    104 -- G3 V
                           3207 X663000-0   Ba Lo Ni                    102 -- F1 V
                           3209 X464000-0   Ba Lo Ni                    110 -- F0 V
                           3210 X501000-0   Ba Ic Lo Ni Va              104 -- K8 V
-                          3211 X226000-0   Ba Lo Ni                    103 -- M0 V M6 D
+                          3211 X226000-0   Ba Lo Ni                    103 -- M0 V M6 V
                           3213 X140000-0   Ba De Lo Ni Po              103 -- F8 V
-                          3215 X210000-0   Ba Lo Ni                    102 -- M0 III K6 D
+                          3215 X210000-0   Ba Lo Ni                    102 -- M0 III K6 V
                           3217 X110000-0   Ba Lo Ni                    102 -- F2 IV
 Outpost                   3222 X120369-C S Na De Lo Ni Po              703 -- F6 V
-Aledan                    3224 A754876-B   Ba Lo Ni                    303 -- K4 V M5 D
+Aledan                    3224 A754876-B   Ba Lo Ni                    303 -- K4 V M5 V
 Mecca                     3226 B68A8AE-B N Ba Lo Ni                    614 -- G3 V
 Lonewadi                  3229 C89A759-C   Ba Lo Ni Wa                 613 -- G3 V
 Njpki                     3232 X200000-0   Ba Lo Ni Va                 123 -- M3 V
 Omxa                      3233 X120000-0   Ba De Lo Ni Po              803 -- G3 V
 Aipwi                     3236 X425000-0 * Ba Lo Ni                    810 -- K5 V
-Dewan                     3238 X867594-3   Ba Lo Ni                    714 -- K3 VI M2 D
+Dewan                     3238 X867594-3   Ba Lo Ni                    714 -- M2 V K3 VI
 


### PR DESCRIPTION
Clean up stellar data in M1105 Katoonah

First, any main-sequence "dwarfs" (eg G3 D) are promoted to size V (G3 V).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg M5 V M8 V M2 V) is swapped into the first star (M2 V M8 V M5 V).

For cases such as M6 V M1 D, if a promoted "dwarf" is now the best primary candidate, so be it (M1 V M6 V).