### PR TITLE
Fix Zhdant sector stellar data

### DIFF
--- a/res/Sectors/M1105/zhdant.sec
+++ b/res/Sectors/M1105/zhdant.sec
@@ -25,66 +25,66 @@ Zhdant
 
 Ilviei        0109 C200431-C    Va Ni              504 Zh M6 V
 Enzhtladr     0110 A687658-D  Z Ag Ni Ri           612 Zh M7 V
-Pradjaie      0115 D745486-7    Ni                 904 Zh M4 D
+Pradjaie      0115 D745486-7    Ni                 904 Zh M4 V
 Oddlekliekl   0116 D567324-8  Z Ni                 210 Zh F4 V
 Te Zdansaa    0119 E582674-5    Ni Ri              302 Zh F4 V
 TIATLIEADEV   0120 A400AAA-E  Y Va Hi In Na        724 Zh M5 V
-Ratlechzder   0123 B3427AB-A  Z Po                 221 Zh F7 D
+Ratlechzder   0123 B3427AB-A  Z Po                 221 Zh F7 V
 Dlelstekre    0126 A88A6A8-E  Z Wa Ni              603 Zh F1 V
-DLIVLDLA      0129 A795ADD-D  Z Hi In              503 Zh F0 D
+DLIVLDLA      0129 A795ADD-D  Z Hi In              503 Zh F0 V
 Anchvlanzhad  0130 E552312-4    Lo Ni Po           905 Zh F7 V M3 V
 Pemchtod      0132 B87A455-B    Wa Ni              613 Zh K0 V
 Iazdizh       0133 B8B8574-C  Z Fl Ni              523 Zh M1 V
-Dabryo        0137 A46A872-C  Z Wa Ri              414 Zh M8 D
-Vezhna        0203 A4658CC-9  Z                    503 Zh F7 V M6 D
+Dabryo        0137 A46A872-C  Z Wa Ri              414 Zh M8 V
+Vezhna        0203 A4658CC-9  Z                    503 Zh F7 V M6 V
 Ianshenj      0208 B527786-B    Ni                 603 Zh F9 V M5 V
 Qianienshietl 0212 B77669C-B  Y Ag Ni              104 Zh M3 V
-Lofenzh       0213 E55A366-6    Wa Lo Ni O:0214    721 Zh F3 V M2 D
+Lofenzh       0213 E55A366-6    Wa Lo Ni O:0214    721 Zh F3 V M2 V
 Ivin          0214 A98A659-D    Wa Ri              111 Zh F5 V
 Azzdedr       0216 E3118A9-8    Ic Na              610 Zh F6 V M5 V
-Aqanzzhdiabl  0223 D211404-9    Ic Na              903 Zh M3 V F6 V
+Aqanzzhdiabl  0223 D211404-9    Ic Na              903 Zh F6 V M3 V
 Qievjach      0224 C76A528-A    Wa Ni              504 Zh F1 V
 Liatsrza      0228 E445424-8    Ni                 813 Zh G4 V
 IEAZHIZH      0229 B677997-B    Hi In              602 Zh F6 V
-Oqpri         0232 B9A578A-9    Fl                 401 Zh K4 V M5 D
+Oqpri         0232 B9A578A-9    Fl                 401 Zh K4 V M5 V
 BIAZIMS       0234 B586ABB-E    Hi                 113 Zh G5 V
 Rafatlianzh   0235 E336445-7    Ni Po              514 Zh A5 V
 Taplbrieqlets 0240 A676321-C  Z Lo Ni              210 Zh M2 V
 IADVADA       0302 A77399B-E  Z Hi In Cp           304 Zh M5 V
-Yal Vri       0303 B534677-B    Ni                 323 Zh G9 V M7 D
-Tlenshiebr    0307 B749310-C  Z Lo Ni              302 Zh K3 V M9 D
-Azhia Naz     0308 A574551-E  Z Ag Ni              305 Zh M7 V M7 D
+Yal Vri       0303 B534677-B    Ni                 323 Zh G9 V M7 V
+Tlenshiebr    0307 B749310-C  Z Lo Ni              302 Zh K3 V M9 V
+Azhia Naz     0308 A574551-E  Z Ag Ni              305 Zh M7 V M7 V
 VLADEFEF      0315 C100A55-D    Va Hi In Na        824 Zh F0 V
-Blel          0317 C242435-7    Ni Po              222 Zh G7 V M0 D
+Blel          0317 C242435-7    Ni Po              222 Zh G7 V M0 V
 Sazhiebr      0319 B372224-9    Lo Ni              614 Zh M7 V
 ECHSHIAANZH   0322 B529ADC-D    Hi In              604 Zh F1 V
-Biezi         0326 D237570-8    Ni                 704 Zh M1 V M4 D
-Vianch        0335 C668585-6    Ag Ni              802 Zh M7 V G0 D
+Biezi         0326 D237570-8    Ni                 704 Zh M1 V M4 V
+Vianch        0335 C668585-6    Ag Ni              802 Zh G0 V M7 V
 MEKRASH       0336 A768AAA-E  Y Hi Cp              523 Zh M7 V
 Feiaz         0338 A456426-B    Ni                 601 Zh M2 V M7 V
-Tlatonsh      0339 C667649-6    Ag Ni Ri         U 710 Zh K9 D
+Tlatonsh      0339 C667649-6    Ag Ni Ri         U 710 Zh K9 V
 Zhiadlnere    0340 B584797-8    Ag Ri              804 Zh F2 V
 Ievrinj       0403 D95A400-9    Wa Ni            U 100 Zh G4 V
 Dlopansh      0406 A582431-D  Y Ni Po              312 Zh M5 V
 Zdieq         0409 D77769A-6    Ag Ni              710 Zh M8 V
-Ezhdiar       0411 E230511-7    De Ni Po           910 Zh M1 V M4 D
-Dablfliansh   0414 D344356-6    Lo Ni Po           910 Zh M7 V M8 D
+Ezhdiar       0411 E230511-7    De Ni Po           910 Zh M1 V M4 V
+Dablfliansh   0414 D344356-6    Lo Ni Po           910 Zh M7 V M8 V
 Vol           0416 C41487C-9    Ic                 520 Zh F2 V
 DASHIPR       0418 A675AFC-E  Z Hi In Cp           523 Zh M5 V
-Flatliaanch   0419 B303640-C    Va Ic Ni Na        903 Zh M8 V M7 D M1 D
+Flatliaanch   0419 B303640-C    Va Ic Ni Na        903 Zh M1 V M7 V M8 V
 Ovloplats     0420 C344735-7    Ag                 504 Zh K7 V
 ZHDINTSADR    0421 D628AAB-A  Z Hi In              904 Zh M3 V
-Shtanso       0425 B65A56A-C    Wa Ni O:0322       303 Zh K2 D M8 D
+Shtanso       0425 B65A56A-C    Wa Ni O:0322       303 Zh K2 V M8 V
 Ierdratodr    0428 C150559-9  Z De Ni Po           604 Zh K5 V M4 V
 Zhdianzrl     0431 A223325-C  Y Lo Ni Po           124 Zh K3 V M4 V
 Jiedrzdiets   0432 B234335-A    Lo Ni              404 Zh M7 V
 Antsrpr       0437 B200484-C  Z Va Ni              613 Zh K6 V
 FIAPR         0440 A442926-E    Hi In An           524 Zh F1 V
 Sianbistiaql  0507 C362502-A    Ni Po              913 Zh F7 V
-Denzhimie     0512 A595555-C    Ag Ni              202 Zh F9 V M4 D
+Denzhimie     0512 A595555-C    Ag Ni              202 Zh F9 V M4 V
 Yaskekue      0514 B6876X3-E  Q Ag Ni Ri An        523 Dr M7 V
 Ple'shtenzh   0516 C333556-B    Ni Po              722 Zh M9 V
-Qlonjia       0517 C969375-6  Z Lo Ni              623 Zh F7 V M4 D
+Qlonjia       0517 C969375-6  Z Lo Ni              623 Zh F7 V M4 V
 Kel           0518 B335525-B    Ni D1              504 Zh K7 V
 Kenshjievr    0521 C9A479C-8    Fl                 223 Zh M7 V
 Zharkash      0522 E468524-7    Ag Ni              112 Zh G2 IV
@@ -95,22 +95,22 @@ Iaflianiaqr   0528 D687536-7    Ag Ni C5           903 Zh K1 V
 Zhdekr        0530 A7A6527-D  Z Fl Ni              804 Zh M4 V
 Kevstetyie    0531 B354353-A    Lo Ni              504 Zh F5 V
 Flotl         0535 C7C1586-B  Z Fl Ni              803 Zh M5 V
-AJA           0536 A78A986-D    Wa Hi              813 Zh F7 V M4 D
+AJA           0536 A78A986-D    Wa Hi              813 Zh F7 V M4 V
 Krievla       0537 B676876-7    Ri                 204 Zh F4 V
 Tliavrianch   0602 B68969C-B    Ni Ri              600 Zh M5 V
 DREPADZE      0603 B859AAA-D  Z Hi                 925 Zh G4 V
 Oiedr         0606 E624100-7    Lo Ni              723 Zh G7 V
 Iatlbench     0607 BA9A576-B    Wa Hi              504 Zh M8 V
 Vravrchtia    0609 B132656-C    Wa Ni Po           204 Zh K7 V
-Jrbrianch     0610 B79A454-D  Z Wa Ni              700 Zh M3 V M2 V
+Jrbrianch     0610 B79A454-D  Z Wa Ni              700 Zh M2 V M3 V
 SAFRAPL       0611 A370957-E    De Hi In           222 Zh F1 V M4 V
 Driechi       0614 A234471-E  Z Ni                 703 Zh M2 V
 ENZHIAVL      0617 C788A98-A    Hi                 902 Zh F9 V
-Detsplieshia  0620 C585200-8    Lo Ni C9           814 Zh F9 D M1 D
+Detsplieshia  0620 C585200-8    Lo Ni C9           814 Zh F9 V M1 V
 Plobradash    0622 C538528-9    Ni                 610 Zh G3 V M6 V
 Iazqatl       0628 C000377-B    As Lo Ni           313 Zh M4 V
 Da'bits       0629 E468727-5    Ag N1              304 Zh F3 V
-Zebrafmiadl   0634 C3457A5-7    Ag                 711 Zh F5 D M7 D
+Zebrafmiadl   0634 C3457A5-7    Ag                 711 Zh F5 V M7 V
 Idr Jdel      0637 CA96304-9    Lo Ni              103 Zh F3 V
 Zhelizhins    0639 X440334-6    De Lo Ni Po      F 330 Zh M5 II
 Dav           0701 C738554-B    Ni                 802 Zh M4 II
@@ -119,25 +119,25 @@ Brolyeze      0703 B48486A-D    Ri O:0603          813 Zh F8 V
 Drianiadriel  0707 A966220-B  Z Lo Ni              413 Zh F1 IV
 Oviaansh      0709 C536441-7    Ni An              222 Zh M7 V
 Benshqra      0711 A377663-B    Ag Ni O:0611       122 Zh M9 V
-Mrkr          0715 C646123-8    Lo Ni              714 Zh F7 D
-Ilvliel       0716 D642510-5    Ni Po              412 Zh F4 D
-Tiedr         0718 X423000-0    Ba Lo Ni         F 904 Zh K3 V M9 D
+Mrkr          0715 C646123-8    Lo Ni              714 Zh F7 V
+Ilvliel       0716 D642510-5    Ni Po              412 Zh F4 V
+Tiedr         0718 X423000-0    Ba Lo Ni         F 904 Zh K3 V M9 V
 Avria         0720 C466651-A  Z Ag Ni Ri           713 Zh F5 V
-Jdavriatsebl  0721 E7838AB-4    Ri               U 304 Zh K7 V M5 D
+Jdavriatsebl  0721 E7838AB-4    Ri               U 304 Zh K7 V M5 V
 Lirraif       0728 C678323-7    Lo Po              805 Zh M7 V
-Chibre        0732 B552431-A    Ni Po              703 Zh F7 D
-Eshnaievr     0733 C466653-8    Ag Ni              400 Zh B5 D
-Shifrtliaz    0734 C445524-9    Ag Ni              813 Zh K4 D M9 D
+Chibre        0732 B552431-A    Ni Po              703 Zh F7 V
+Eshnaievr     0733 C466653-8    Ag Ni              400 Zh B5 V
+Shifrtliaz    0734 C445524-9    Ag Ni              813 Zh K4 V M9 V
 Dronjfezhish  0736 B737336-C    Lo Ni              703 Zh M3 V
 Zdonzhvietl   0737 B589668-9  Z Ni Ri Mr           420 Zh K3 III
-INZHDEPL DRIEP0738 B5009A9-C    Va Hi In Na        805 Zh F3 D
+INZHDEPL DRIEP0738 B5009A9-C    Va Hi In Na        805 Zh F3 V
 Chtek         0740 D889678-3    Ni Ri            U 300 Zh K1 V
 Dradi         0805 CAFA444-C    Fl Wa Ni           301 Zh M0 V
 Pakrashziavr  0806 C200433-B    Va Ni              301 Zh M3 V
 Zi Sebria     0808 C250575-9  Z De Ni Po           203 Zh M5 V
 IATIAIEPR     0811 C6649C4-5    Hi                 603 Zh F5 V
 Braqlia       0812 B9C5101-C    Fl Lo Ni           223 Zh G3 V
-Qrialdats     0814 C587655-9    Ag Ni Ri           520 Zh F3 V M9 D
+Qrialdats     0814 C587655-9    Ag Ni Ri           520 Zh F3 V M9 V
 Plejditsie    0815 B000457-D  Z As Ni              123 Zh F5 V
 Qriokro       0820 E325453-7    Ni                 300 Zh K3 III
 Flia'sar      0822 C7A2776-D    Fl                 612 Zh F7 III
@@ -146,10 +146,10 @@ Qriam         0829 B673885-9  Z                    631 Zh A1 V
 Klikivr       0831 E0007A9-9    As Na              312 Zh M2 V
 Viat          0833 D683463-5  Z Ni O:0934          203 Zh K5 V M3 V
 Tanjbrelo     0836 C367543-8  Z Ag Ni              704 Zh M5 V
-Kiarbonjivr   0901 A635243-C  Z Lo Ni              312 Zh M6 V M8 D
+Kiarbonjivr   0901 A635243-C  Z Lo Ni              312 Zh M6 V M8 V
 ETL           0902 AAC597B-E    Fl Hi              313 Zh G5 V
 Anchjdant     0905 C79A78A-A    Wa               U 603 Zh F9 V M1 V
-Evzhdianz     0909 A555641-C  Z Ag Ni              302 Zh F6 V M0 D
+Evzhdianz     0909 A555641-C  Z Ag Ni              302 Zh F6 V M0 V
 TLAVLIEI      0913 C586976-A  Z Hi                 511 Zh F5 V
 Kaflde        0914 B89A769-C    Wa O:0915          112 Zh M3 V
 Ialpa         0915 A766745-C    Ag Ri              223 Zh K1 IV K8 V
@@ -159,333 +159,333 @@ JDIEPLEQR     0921 E5239B6-8    Hi In Na Po        401 Zh F9 V
 DLECHFRIA'    0922 CAC897A-A  Z Fl Hi              804 Zh G7 III
 Flienjmiench  0924 B887696-9    Ag Ni Ri           401 Zh M3 V
 Kiflladl      0925 E353532-4    Ni Po              104 Zh K6 V
-YASHETLAVR    0927 C000AFF-E    As Hi In Na      U 524 Zh M2 D M7 D
+YASHETLAVR    0927 C000AFF-E    As Hi In Na      U 524 Zh M2 V M7 V
 I'di          0928 B7B4728-B    Fl                 914 Zh M4 V
-VELIEIRBE     0931 C2339B9-B    Hi Na Po           205 Zh G4 D
-Dliamtiaqe    0932 B240657-C    De Ni              404 Zh F0 V M4 D
+VELIEIRBE     0931 C2339B9-B    Hi Na Po           205 Zh G4 V
+Dliamtiaqe    0932 B240657-C    De Ni              404 Zh F0 V M4 V
 Chikrdapr     0934 A666787-C    Ag Ri D2           104 Zh G0 V
 Kiadlensh     0937 A793486-A    Ni                 400 Zh F0 V
-ILAIAIASHIE   0938 B578ABB-D    Hi In              722 Zh F4 D
+ILAIAIASHIE   0938 B578ABB-D    Hi In              722 Zh F4 V
 Enchiap       0939 A466796-C    Ag Ri An           404 Zh K3 V
-Blablet       1004 B776753-9  Z Ag                 410 Zh F7 D
+Blablet       1004 B776753-9  Z Ag                 410 Zh F7 V
 Tsotliedrant  1005 A672432-C    Ni                 904 Zh M9 V
 Yia'rnch      1008 CAB2547-A    Fl Ni              404 Zh K6 III
 Jeazhivr      1013 D441448-7    Ni Po              124 Zh G2 V
 Achoqr        1014 D354777-5    Ag                 805 Zh M7 III
 Tinsh         1018 AAB6855-D  Z Fl                 911 Zh G4 V M9 V
-Kiail         1019 B45769D-A    Ag Ni              523 Zh M7 V K6 IV
-Iaprprietl    1021 A888876-C    Ri D3              202 Zh K8 D
-Zhodri        1022 E797666-5    Ag Ni O:1021       702 Zh F2 D M3 D
-Jivladavl     1024 B67855A-A    Ag Ni C4           400 Zh G4 D M3 D
+Kiail         1019 B45769D-A    Ag Ni              523 Zh K6 IV M7 V
+Iaprprietl    1021 A888876-C    Ri D3              202 Zh K8 V
+Zhodri        1022 E797666-5    Ag Ni O:1021       702 Zh F2 V M3 V
+Jivladavl     1024 B67855A-A    Ag Ni C4           400 Zh G4 V M3 V
 Diapche       1025 C675684-8    Ag Ni Ri           615 Zh F2 V
-Blieme        1026 C848562-9  Z Ag Ni O:0927     U 601 Zh F3 V M6 D
-SOTSZHDIAO    1029 C7A098C-B    De Hi              605 Zh F2 V M9 D
-Briaji        1030 C53789D-9                       504 Zh F1 D
-Tiepl         1033 E849333-7    Lo Ni              600 Zh F2 D
+Blieme        1026 C848562-9  Z Ag Ni O:0927     U 601 Zh F3 V M6 V
+SOTSZHDIAO    1029 C7A098C-B    De Hi              605 Zh F2 V M9 V
+Briaji        1030 C53789D-9                       504 Zh F1 V
+Tiepl         1033 E849333-7    Lo Ni              600 Zh F2 V
 Ia Sishetlel  1034 B100110-C    Va Lo Ni           912 Zh K0 V
 Eshdlients    1039 B767642-9    Ag Ni Ri           903 Zh F2 V
-Sinzazhda     1102 A566111-C  Z Lo Ni              700 Zh G8 D M7 D
-Viribr        1104 B7B4100-D    Fl Lo Ni           800 Zh F1 V M4 D
-Tianjshier    1107 A6A5643-E  Z Fl Ni              225 Zh F2 D
+Sinzazhda     1102 A566111-C  Z Lo Ni              700 Zh G8 V M7 V
+Viribr        1104 B7B4100-D    Fl Lo Ni           800 Zh F1 V M4 V
+Tianjshier    1107 A6A5643-E  Z Fl Ni              225 Zh F2 V
 Eplstiash     1109 C522357-B    Lo Ni Po           600 Zh G2 V
-Enshklame     1110 B7A4889-A    Fl               U 814 Zh F9 D
+Enshklame     1110 B7A4889-A    Fl               U 814 Zh F9 V
 Flo'fliezhie  1116 D56587B-3    Ri               U 712 Zh G9 V
 Piabldal      1119 C230377-A    De Lo Ni Po        814 Zh G4 V
-Zhdintre      1121 B54477A-8    Ag                 200 Zh M4 D
-SHTENZH QLOTL 1123 A544A75-E  Z Hi In              702 Zh F1 D
-Dlia'abl      1126 B798569-9    Ni O:1127          404 Zh F8 V M4 D M0 D
+Zhdintre      1121 B54477A-8    Ag                 200 Zh M4 V
+SHTENZH QLOTL 1123 A544A75-E  Z Hi In              702 Zh F1 V
+Dlia'abl      1126 B798569-9    Ni O:1127          404 Zh F8 V M4 V M0 V
 Priatsziarr   1127 A558757-C    Ag Ni              300 Zh G4 V
-TIANS DA' JEFR1128 B494A9C-E  Z Hi In              613 Zh F8 D M9 D M2 D
+TIANS DA' JEFR1128 B494A9C-E  Z Hi In              613 Zh F8 V M9 V M2 V
 Voibr         1131 A58765B-B  Z Ag Ni Ri           804 Zh K4 V
 Senshiak      1134 C212345-A    Ic Lo Ni           302 Zh A1 V
-Driensho      1140 D355652-4    Ag Ni              820 Zh F1 D M4 D M1 D
-Ejriens       1201 B477167-8  Z Lo Ni O:1301       305 Zh F0 D
+Driensho      1140 D355652-4    Ag Ni              820 Zh F1 V M4 V M1 V
+Ejriens       1201 B477167-8  Z Lo Ni O:1301       305 Zh F0 V
 Briavniedl    1203 E759451-7    Ni                 403 Zh F6 V
 CHIASHOV      1204 A534ABA-E  Y Hi Cp              423 Zh F0 V
-Anchfial      1206 A534333-D    Lo Ni              303 Zh M0 V M0 D
+Anchfial      1206 A534333-D    Lo Ni              303 Zh M0 V M0 V
 Nochvi        1207 B888655-A    Ag Ni Ri           102 Zh G1 V
 Diabriefa     1208 C786533-8    Ag Ni D2           623 Zh F1 V M6 V
-Ontsavre'     1210 B334511-C    Ni                 600 Zh M4 V M2 D
+Ontsavre'     1210 B334511-C    Ni                 600 Zh M2 V M4 V
 FIA VLENCHTA  1211 B61499C-B  Z Ic Hi In Na        222 Zh K0 V
 Kaythe        1217 A4855X5-E  Q Ag Ni An           424 Dr G0 V
-Ferchoblvel   1221 C656659-7    Ag Ni              103 Zh K6 V M4 D
-Chti'di       1222 C38487C-A    Ri                 902 Zh M2 D
+Ferchoblvel   1221 C656659-7    Ag Ni              103 Zh K6 V M4 V
+Chti'di       1222 C38487C-A    Ri                 902 Zh M2 V
 Lantizh Ant   1225 B65458A-A    Ag Ni              400 Zh K9 V
 Iqletsi       1226 B768676-9    Ag Ni Ri           514 Zh G6 V
-Plazdiets     1230 C66875A-8    Ag Ri              603 Zh F4 V M0 D
+Plazdiets     1230 C66875A-8    Ag Ri              603 Zh F4 V M0 V
 JESEZYIENJIE  1235 A578956-E  Y Hi In Cp           603 Zh F3 V
 Revr          1236 C344683-8    Ag Ni              104 Zh M0 V
-Azhiapsta     1238 C966616-5  Z Ag Ni              111 Zh F9 D
-Brezdrontlie  1239 C322245-9    Lo Ni              812 Zh K7 V M6 D
-Iakroshia     1240 D798796-6    Ag                 421 Zh F6 D M7 D
-Pibiansia     1301 A77669C-C  Z Ag Ni An           101 Zh F0 D
-Tlrnzh        1304 E223211-8    Lo Ni Po           225 Zh M7 V M4 D
+Azhiapsta     1238 C966616-5  Z Ag Ni              111 Zh F9 V
+Brezdrontlie  1239 C322245-9    Lo Ni              812 Zh K7 V M6 V
+Iakroshia     1240 D798796-6    Ag                 421 Zh F6 V M7 V
+Pibiansia     1301 A77669C-C  Z Ag Ni An           101 Zh F0 V
+Tlrnzh        1304 E223211-8    Lo Ni Po           225 Zh M4 V M7 V
 Rafieqr       1307 B68A651-C    Wa Ri Ni           300 Zh F4 V
 Ialil         1310 A516627-C  Z Ic Ni              904 Zh K6 V
 Jdizialia     1313 B454353-C  Z Lo Ni              302 Zh A1 V
 Zdarapel      1314 E766344-4    Lo Ni              831 Zh A1 V
 Enssazi'      1315 A523136-C  Y Lo Ni Po           714 Zh M0 V M9 V
-Iaplpa'tlal   1316 D323566-9    Ni Po O:1315       512 Zh F3 III M3 D
-TLIAQBRAV     1319 A876974-E  Z Hi In Cp           402 Zh M5 V K8 V
+Iaplpa'tlal   1316 D323566-9    Ni Po O:1315       512 Zh F3 III M3 V
+TLIAQBRAV     1319 A876974-E  Z Hi In Cp           402 Zh K8 V M5 V
 Plietsvie     1321 E556688-4    Ag Ni              720 Zh F0 V M7 V
 Iashintdria   1323 A354535-E  Z Ag Ni              203 Zh K0 V
-Kiroadr       1324 C567687-7    Ag Ni Ri           703 Zh F9 D M8 D
-Tiak          1325 A569697-A  Y Ni Ri              304 Zh F0 D
-FRIANJEKRIZH  1326 B89AA58-E    Wa Hi In           103 Zh F2 D
-ZDRINT        1328 AA899A6-D    Hi Cp              903 Zh M9 V G1 V
-EQASHTEPLI    1329 A8786A7-B  Z Ag Ni              805 Zh K8 D
+Kiroadr       1324 C567687-7    Ag Ni Ri           703 Zh F9 V M8 V
+Tiak          1325 A569697-A  Y Ni Ri              304 Zh F0 V
+FRIANJEKRIZH  1326 B89AA58-E    Wa Hi In           103 Zh F2 V
+ZDRINT        1328 AA899A6-D    Hi Cp              903 Zh G1 V M9 V
+EQASHTEPLI    1329 A8786A7-B  Z Ag Ni              805 Zh K8 V
 Zhdonchiano   1330 C89A453-9  Z Wa Ni              421 Zh K8 V M3 V
 Ayssthon      1334 A346856-E  Q                    111 Dr B5 III
-Tlaibra       1338 E557726-2    Ag                 215 Zh K7 D
-Jifaofr       1340 C758777-7  Z Ag                 812 Zh F1 V M6 D
-Dlozhti       1402 AA88594-B    Ag Ni              413 Zh F7 D
-Ablnits       1403 C446612-8  Z Ag Ni              223 Zh F2 V M4 V M9 D
+Tlaibra       1338 E557726-2    Ag                 215 Zh K7 V
+Jifaofr       1340 C758777-7  Z Ag                 812 Zh F1 V M6 V
+Dlozhti       1402 AA88594-B    Ag Ni              413 Zh F7 V
+Ablnits       1403 C446612-8  Z Ag Ni              223 Zh F2 V M4 V M9 V
 Tlinzhfrrfr   1406 B242350-D    Lo Ni Po           404 Zh K0 V
-Chtiatstats   1407 B558442-7    Ni                 611 Zh K9 V M9 D
+Chtiatstats   1407 B558442-7    Ni                 611 Zh K9 V M9 V
 Zhdibliav     1409 C87A774-9  Z Wa                 104 Zh F8 V M9 V
 Pechbre'r     1410 B513328-A    Ic Lo Ni           620 Zh F2 II
-CHIEPLANS     1412 B597ABB-C  Z Hi In              925 Zh M3 D M5 D F3 V
+CHIEPLANS     1412 B597ABB-C  Z Hi In              925 Zh F3 V M5 V M3 V
 Tlozhdevr     1421 E364796-5    Ag                 402 Zh G3 V
-Aiv           1422 B8B6639-B    Fl Ni An           223 Zh G7 D M9 D
-Briazdle      1423 A31236A-E    Ic Ni O:1323       104 Zh M2 V M8 D
-MIMKLEFLIEZ   1428 B966A9A-A  Z Hi                 712 Zh F6 D M9 D
-Dalziaash     1431 B556555-B    Ag Ni              204 Zh M4 D
-Itlezhshadr   1435 C544677-5    Ag Ni              401 Zh F2 D
-Dlo'planshvrl 1437 C494516-7    Ag Ni              804 Zh F8 D
+Aiv           1422 B8B6639-B    Fl Ni An           223 Zh G7 V M9 V
+Briazdle      1423 A31236A-E    Ic Ni O:1323       104 Zh M2 V M8 V
+MIMKLEFLIEZ   1428 B966A9A-A  Z Hi                 712 Zh F6 V M9 V
+Dalziaash     1431 B556555-B    Ag Ni              204 Zh M4 V
+Itlezhshadr   1435 C544677-5    Ag Ni              401 Zh F2 V
+Dlo'planshvrl 1437 C494516-7    Ag Ni              804 Zh F8 V
 Nabrchtiz     1501 B23267C-A  Z Na Ni Po           103 Zh M7 V
-Dra'e         1502 D342130-7    Lo Ni Po           900 Zh M8 D
-Kiaavr        1506 A568849-B  Z Ri D2              805 Zh F3 D
+Dra'e         1502 D342130-7    Lo Ni Po           900 Zh M8 V
+Kiaavr        1506 A568849-B  Z Ri D2              805 Zh F3 V
 Chiash        1507 C251325-9    Lo Ni Po           711 Zh M3 V
 BRENZHSTEL    1508 B4139B7-D  Z Ic Hi In Na        403 Zh F9 V
-Ziprdanzh     1509 A949471-D    Ni                 320 Zh M7 V M2 D
-Echiepench    1510 B987655-B    Ag Ni Ri           300 Zh F4 D M1 D
+Ziprdanzh     1509 A949471-D    Ni                 320 Zh M2 V M7 V
+Echiepench    1510 B987655-B    Ag Ni Ri           300 Zh F4 V M1 V
 Vemietl       1512 A686356-D  Z Lo Ni              324 Zh M9 V
 Chtaoz        1514 E221522-8    Ni Po              122 Zh M9 IV M3 V
 Ine'tedl      1517 E875778-6    Ag                 740 Zh M7 IV
 Blotl         1519 A766448-D  Z Ni                 602 Zh K3 V K4 V
-Staantoch     1523 A677554-C    Ag Ni              703 Zh F7 D
-JIAZSHIEPR    1525 C446989-D    Hi In              702 Zh F6 D
-Chtiadrshienz 1526 B566654-A    Ag Ni Ri           602 Zh F4 D
-Fialkatsevr   1528 B445518-A    Ag Ni              820 Zh F9 D
-Qloiz         1529 A877784-B    Ag                 903 Zh F7 V M8 V M7 D
-PRIE          1531 B2339A6-C    Hi Na              604 Zh G7 D
+Staantoch     1523 A677554-C    Ag Ni              703 Zh F7 V
+JIAZSHIEPR    1525 C446989-D    Hi In              702 Zh F6 V
+Chtiadrshienz 1526 B566654-A    Ag Ni Ri           602 Zh F4 V
+Fialkatsevr   1528 B445518-A    Ag Ni              820 Zh F9 V
+Qloiz         1529 A877784-B    Ag                 903 Zh F7 V M8 V M7 V
+PRIE          1531 B2339A6-C    Hi Na              604 Zh G7 V
 Tiezhblibl    1534 A9A6242-D  Z Fl Lo Ni           814 Zh F7 V
-Pledrzdiem    1535 C556589-8    Ag Ni              801 Zh M2 V M1 D
+Pledrzdiem    1535 C556589-8    Ag Ni              801 Zh M1 V M2 V
 QENTSVRI      1538 B84A9BA-C  Z Wa Hi In           623 Zh F1 V
-Zdavlvlal     1539 E564767-1    Ag Ri O:1540       410 Zh M0 V G6 V
-IECHT'VRNTS   1540 A4379AB-E    Hi                 912 Zh G9 D M7 D
+Zdavlvlal     1539 E564767-1    Ag Ri O:1540       410 Zh G6 V M0 V
+IECHT'VRNTS   1540 A4379AB-E    Hi                 912 Zh G9 V M7 V
 Te Zhdok      1602 B424553-B  Z Ni                 915 Zh M0 II
-Tiaklienzi    1604 A48666A-E    Ag Ri Mr           123 Zh A7 D F0 D M2 D
-Nevl          1607 A446779-D    Ag                 524 Zh K4 D
-Tliaqbravets  1613 A88878A-A    Ag Ri D1           700 Zh F9 IV G9 III
-Dlivkebla     1617 A545689-B  Z Ag Ni              222 Zh M3 V K9 V
-Chiech        1618 B55769C-6    Ag Ni              612 Zh M6 V K2 V
+Tiaklienzi    1604 A48666A-E    Ag Ri Mr           123 Zh A7 V F0 V M2 V
+Nevl          1607 A446779-D    Ag                 524 Zh K4 V
+Tliaqbravets  1613 A88878A-A    Ag Ri D1           700 Zh G9 III F9 IV
+Dlivkebla     1617 A545689-B  Z Ag Ni              222 Zh K9 V M3 V
+Chiech        1618 B55769C-6    Ag Ni              612 Zh K2 V M6 V
 TLEVLBLAZIAKR 1620 A466A98-E  Z Hi                 924 Zh M7 V
-LELHTONTSA    1624 B8999BF-C  Z Hi In              802 Zh F1 D M2 D
-Iashfliezh    1625 E574449-6    Ni                 514 Zh G8 D M1 D
+LELHTONTSA    1624 B8999BF-C  Z Hi In              802 Zh F1 V M2 V
+Iashfliezh    1625 E574449-6    Ni                 514 Zh G8 V M1 V
 Shtodli       1626 D481356-8    Lo Ni              800 Zh G9 V
 Edri          1627 E471242-7    Lo Ni              853 Zh F0 V
 Tsadlzhdanch  1628 A6A5500-E    Fl Ni              704 Zh K7 II
 Prelzdial     1631 B346643-7    Ag Ni              301 Zh K6 V
-ACHABLSHTEL   1632 A000ACC-E  Z As Hi In           301 Zh M8 V M3 D
-BETSAPR       1635 C211945-A    Ic Hi In           910 Zh F7 D
+ACHABLSHTEL   1632 A000ACC-E  Z As Hi In           301 Zh M3 V M8 V
+BETSAPR       1635 C211945-A    Ic Hi In           910 Zh F7 V
 Eke           1636 B658755-B    Ag C2              303 Zh F9 V
 Zdiebe        1701 C433203-9    Lo Ni Po           503 Zh G8 III
-LIENCHE       1702 B0009AC-E    As Hi In Na        525 Zh M0 V M3 D
+LIENCHE       1702 B0009AC-E    As Hi In Na        525 Zh M0 V M3 V
 Viatla        1708 D335878-7                       120 Zh F0 V
-Prosial       1713 B56567A-A  Z Ag Ni Ri           324 Zh F3 V M1 D
-Aplavriadl    1715 C373201-8    Lo Ni              505 Zh M3 V M7 D
+Prosial       1713 B56567A-A  Z Ag Ni Ri           324 Zh F3 V M1 V
+Aplavriadl    1715 C373201-8    Lo Ni              505 Zh M3 V M7 V
 Ta Niabr      1718 D97A688-7    Wa Ni              423 Zh F0 V
 ENZJDIVR      1719 C7C599C-B  Z Fl Hi              902 Zh M9 V
 Apre          1720 C330245-B    Lo Ni Po           804 Zh F8 V M8 V
 Afliavl       1721 B300447-C    Va Ni              624 Zh F5 V
-Dri Ats       1722 C145745-8    Ag                 402 Zh M2 D M0 D
+Dri Ats       1722 C145745-8    Ag                 402 Zh M0 V M2 V
 Vravchadl     1725 D845579-7    Ag Ni              102 Zh F2 V M7 V
-EPLZHDEPL     1726 A435987-E  Z Hi                 312 Zh M9 V M0 V
-Vriarzdanz    1727 B344769-B    Ag O:1727          404 Zh F7 D
+EPLZHDEPL     1726 A435987-E  Z Hi                 312 Zh M0 V M9 V
+Vriarzdanz    1727 B344769-B    Ag O:1727          404 Zh F7 V
 Oprinzh       1730 C55878A-7  Z Ag                 902 Zh G4 V M7 V
-Dimkiv        1732 A627446-E    Ni                 823 Zh F3 V M1 D
+Dimkiv        1732 A627446-E    Ni                 823 Zh F3 V M1 V
 A'ats         1735 C450000-8  Z De Ba              901 Zh F0 V
-Idlianj       1736 E7A6361-8    Fl Lo Ni O:1835    211 Zh F3 D
+Idlianj       1736 E7A6361-8    Fl Lo Ni O:1835    211 Zh F3 V
 Iedrif        1739 E447252-7    Lo Ni            U 405 Zh F4 V
 Sele          1740 A535547-D  Z Lo Ni              804 Zh A3 II
 Gentsvri      1801 CA89612-9    Ni Ri            U 411 Zh K5 V
 Fliaqrjdiafl  1807 C36677B-8    Ag Ri              615 Zh F7 V G7 V
 Yurm          1809 A364665-D  Z Ag Ni Ri Mr        423 Cw B4 Ia
-Vabrafl       1813 B513254-A  Z Ic Lo Ni           310 Zh A6 IV F6 D M3 D
+Vabrafl       1813 B513254-A  Z Ic Lo Ni           310 Zh A6 IV F6 V M3 V
 Ieridr        1817 B42145A-D    Ni Po              304 Zh G3 IV
-Ienen         1820 C484510-8    Ag Ni              923 Zh F9 V M7 D
-Jdanzri       1824 B263412-B    Ni                 510 Zh F1 D
+Ienen         1820 C484510-8    Ag Ni              923 Zh F9 V M7 V
+Jdanzri       1824 B263412-B    Ni                 510 Zh F1 V
 Nalkentsbr    1827 D787544-6    Ag Ni              221 Zh F0 V
 Dlanzhtsianzh 1829 CA7A757-A    Wa                 301 Zh F2 V
-SHAAIKA       1830 B744959-D    Hi In              711 Zh F7 V M4 D
-Siair         1832 B274230-C    Lo Ni              403 Zh K0 D
-E'eqlid       1835 E998787-5    Ag                 514 Zh F0 D
+SHAAIKA       1830 B744959-D    Hi In              711 Zh F7 V M4 V
+Siair         1832 B274230-C    Lo Ni              403 Zh K0 V
+E'eqlid       1835 E998787-5    Ag                 514 Zh F0 V
 Praflazh      1837 A547786-B  Z Ag                 305 Zh G6 V
 Val           1839 C320344-9    De Lo Ni Po        304 Zh M6 V
-Fanchebl      1902 C564526-9  Z Ag Ni              804 Zh M4 V M2 D
+Fanchebl      1902 C564526-9  Z Ag Ni              804 Zh M2 V M4 V
 Ta Oshak      1906 C544346-8    Lo Ni              502 Zh K2 V M6 V
-Dlelozh       1907 E667532-6    Ag Ni C1           401 Zh G8 V M6 D
+Dlelozh       1907 E667532-6    Ag Ni C1           401 Zh G8 V M6 V
 Piafleprianz  1912 E213796-7    Ic Na              724 Zh F2 V
-Satjiel       1915 A78A656-E  Z Wa Ni Ri C1        113 Zh F6 V M4 D
+Satjiel       1915 A78A656-E  Z Wa Ni Ri C1        113 Zh F6 V M4 V
 Anzdla        1916 C300100-D    Va Lo Ni           921 Zh M6 V
 CHIVREA       1918 A210975-E  Z Hi In Na           704 Zh M2 V
 TLETDOVR ZEDR 1921 C556AAD-C  Z Hi                 724 Zh G3 V
 Briefr        1923 E749479-5    Ni                 103 Zh G7 V
 Zhdityia      1924 A592220-C    Lo Ni              621 Zh F9 V
 Klinzha       1927 B733586-A    Ni                 610 Zh F9 II
-Tlat          1928 C788579-9    Ag Ni Ri           204 Zh F1 D
+Tlat          1928 C788579-9    Ag Ni Ri           204 Zh F1 V
 Sansniaapr    1929 B435535-B    Ni                 913 Zh A8 III
-IABRBENTS     1931 B676975-C  Z Hi In              910 Zh K1 D
+IABRBENTS     1931 B676975-C  Z Hi In              910 Zh K1 V
 Keshjia       1936 X200000-0    Va Ba            F 014 Zh M6 V
 Ja' Datl      2002 A233788-E    Na Po              801 Zh K1 III
-Perie         2004 BA6A747-A  Z Wa Ri              600 Zh M6 D
-Zhdendeel     2005 C35388C-6    Po                 205 Zh M3 D
-E'madliadr    2006 B336572-C    Ni                 412 Zh A3 D
+Perie         2004 BA6A747-A  Z Wa Ri              600 Zh M6 V
+Zhdendeel     2005 C35388C-6    Po                 205 Zh M3 V
+E'madliadr    2006 B336572-C    Ni                 412 Zh A3 V
 Pinchar       2008 C332504-C    Ni Po              111 Zh F1 V
 Tlenshial     2013 A10058A-E    Va Ni              904 Zh K3 III M8 V
 Jiavraql      2014 C150162-9    De Lo Ni Po O:1915 221 Zh K9 V
 Pradlredrva'  2016 B577798-8    Ag C1              902 Zh F8 V
-FLONZEBRIENZH 2017 A344996-E  Z Hi In Cp           204 Zh M0 V M4 D
-Ple'na        2019 A684511-A  Z Ag Ni              200 Zh F5 V M1 D
-Zhde'iekdlats 2023 A767753-C  Z Ag Ri              102 Zh F8 D
+FLONZEBRIENZH 2017 A344996-E  Z Hi In Cp           204 Zh M0 V M4 V
+Ple'na        2019 A684511-A  Z Ag Ni              200 Zh F5 V M1 V
+Zhde'iekdlats 2023 A767753-C  Z Ag Ri              102 Zh F8 V
 ZDEFRIENTS    2025 A77A999-E  Y Wa Hi In Cp        303 Zh F1 V
-Albetl        2026 C445503-A    Ag Ni              804 Zh F8 V M8 D
+Albetl        2026 C445503-A    Ag Ni              804 Zh F8 V M8 V
 Piezshtopr    2028 C988371-9  Z Lo Ni              201 Zh F9 V M7 V
-Qiash         2029 C884753-8    Ag Ri              604 Zh G9 D
+Qiash         2029 C884753-8    Ag Ri              604 Zh G9 V
 Chtrnsdlad    2031 C76A662-9    Wa Ni Ri O:2132    700 Zh F3 V
-Dievronez     2032 B677361-B    Lo Ni O:2132       105 Zh G3 V M8 V M2 D
-Oythepru      2034 A66586B-C  Q Ri Mr              324 Dr F3 V M4 V M9 D
-Niaqonsr      2037 A7A4555-D  Y Fl Ni              402 Zh M4 D K7 D
+Dievronez     2032 B677361-B    Lo Ni O:2132       105 Zh G3 V M8 V M2 V
+Oythepru      2034 A66586B-C  Q Ri Mr              324 Dr F3 V M4 V M9 V
+Niaqonsr      2037 A7A4555-D  Y Fl Ni              402 Zh K7 V M4 V
 IEZRANSPA     2038 A346A75-E  Z Hi In Cp           514 Zh F0 V
-Ve'tlievro    2040 B644420-9    Ni                 401 Zh F1 D
-Erimonsh      2102 C351687-8    Ni Po              612 Zh F8 D M4 D M8 D
+Ve'tlievro    2040 B644420-9    Ni                 401 Zh F1 V
+Erimonsh      2102 C351687-8    Ni Po              612 Zh F8 V M4 V M8 V
 Diant         2104 C484664-9    Ag Ni Ri O:2203    704 Zh F2 V
 Zdiemsi       2106 B414220-C    Ic Lo Ni           322 Zh M9 V
-Ofchtiaqr     2107 A311526-E  Y Ic Ni              301 Zh M1 V M2 D
-Frad          2108 C6857C7-7    Ag                 612 Zh F7 D
-Ietsianjjal   2109 A484658-D    Ag Ni Ri           913 Zh A9 D
+Ofchtiaqr     2107 A311526-E  Y Ic Ni              301 Zh M1 V M2 V
+Frad          2108 C6857C7-7    Ag                 612 Zh F7 V
+Ietsianjjal   2109 A484658-D    Ag Ni Ri           913 Zh A9 V
 ZDAL          2110 E667999-7    Hi                 801 Zh F2 V
 Ichientsi     2112 C220000-B    De Ba Po           924 Zh F0 II
-Chakrrzh      2117 CAA4136-B    Fl Lo Ni           424 Zh M1 V M1 D
+Chakrrzh      2117 CAA4136-B    Fl Lo Ni           424 Zh M1 V M1 V
 Zdiaeva       2122 C441322-7    Lo Ni Po           502 Zh M6 V
-Vriatlieiesho 2123 B423646-B    Ni Na Po           912 Zh M7 V K4 V
+Vriatlieiesho 2123 B423646-B    Ni Na Po           912 Zh K4 V M7 V
 Prantravli    2127 E322584-8    Ni Po              403 Zh G3 V
 CHTADRO       2132 A96AABE-E    Hi Na              123 Zh G0 V
-Ianchdotliadl 2137 A415333-E    Ic Lo Ni           103 Zh M3 D
-Kliedi        2138 B200355-D    Va Lo Ni           112 Zh M6 D
+Ianchdotliadl 2137 A415333-E    Ic Lo Ni           103 Zh M3 V
+Kliedi        2138 B200355-D    Va Lo Ni           112 Zh M6 V
 Yenz          2140 E4146A5-7    Ic Ni              400 Zh M2 V M4 V
-Bretvela      2201 E88A416-8    Wa Ni              602 Zh F3 D
-IENJEFRODA    2203 A225988-E    Hi In Cp           921 Zh F3 V M9 D
-Jiebrdliesh   2207 E558678-4    Ag Ni              422 Zh F1 D M2 D
+Bretvela      2201 E88A416-8    Wa Ni              602 Zh F3 V
+IENJEFRODA    2203 A225988-E    Hi In Cp           921 Zh F3 V M9 V
+Jiebrdliesh   2207 E558678-4    Ag Ni              422 Zh F1 V M2 V
 Rintazha      2208 E565623-2    Ag Ni            U 402 Zh F2 V
-Fladensh      2210 A76767A-C    Ag Ni Ri           622 Zh K3 D
+Fladensh      2210 A76767A-C    Ag Ni Ri           622 Zh K3 V
 Zhdapatl      2213 E210543-8    Ni                 223 Zh K7 V
 Evvlieanj     2216 C487551-9  Z Ag Ni An           401 Zh F4 V
 BESHENJ FRAZHT2219 A5049A7-E  Z Va Ic Hi In        104 Zh F9 V
 Idlol         2220 E360657-5    De Ni              703 Zh G8 V
 Leqro'prinsta 2221 B460784-A    De Ri              302 Zh M0 V M7 V
 PLONZHREMO    2222 B526ABB-E    Hi In              904 Zh F3 V
-Riatsjansh    2224 E643000-0    Ba Lo Ni Po      U 802 Zh K5 V M8 D
-Qrentsabr     2228 C350726-7  Z De Po              514 Zh F2 D
+Riatsjansh    2224 E643000-0    Ba Lo Ni Po      U 802 Zh K5 V M8 V
+Qrentsabr     2228 C350726-7  Z De Po              514 Zh F2 V
 Aklie         2230 CAA5100-A    Fl Lo Ni           304 Zh F7 V
 Sti'chtiaze   2240 A227555-D  Z Ni                 810 Zh B3 III
-Pranvriav     2302 C595543-5  Z Ag Ni              710 Zh F0 D
-Jitlesh       2305 C343445-9    Ni Po              104 Zh F7 D M7 D
+Pranvriav     2302 C595543-5  Z Ag Ni              710 Zh F0 V
+Jitlesh       2305 C343445-9    Ni Po              104 Zh F7 V M7 V
 ANCHIEF       2310 C424ACF-C    Hi In              401 Zh G0 V
 Zdiafplat     2311 A46988B-D  Y Ri                 103 Zh G4 V
-Kriaz         2315 C200578-9    Va Ni              802 Zh M9 V M4 V
-Bliadrats     2316 A000400-E    As Ni              734 Zh G4 V M5 D
-Denzia        2321 A769432-E  Z Ni                 923 Zh F3 D M0 D
-Piensinzh     2327 C54278B-7  Z Po                 212 Zh F4 D
-Artsi'chto    2328 D788798-5    Ag Ri            U 802 Zh M9 D M8 D
-Dlafchans     2331 C423552-B    Ni Po              601 Zh M4 V M9 D
+Kriaz         2315 C200578-9    Va Ni              802 Zh M4 V M9 V
+Bliadrats     2316 A000400-E    As Ni              734 Zh G4 V M5 V
+Denzia        2321 A769432-E  Z Ni                 923 Zh F3 V M0 V
+Piensinzh     2327 C54278B-7  Z Po                 212 Zh F4 V
+Artsi'chto    2328 D788798-5    Ag Ri            U 802 Zh M8 V M9 V
+Dlafchans     2331 C423552-B    Ni Po              601 Zh M4 V M9 V
 Iaroofl       2333 B311430-C  Z Ic Ni              312 Zh K7 V
 Niyakl        2334 D554523-5    Ag Ni              702 Zh F9 V M2 V
 Ianttlaiam    2402 A767662-B    Ag Ni Ri O:2403    904 Zh K0 II
 Proplvabriench2403 A685756-C  Z Ag Ri              915 Zh K7 V
 Vinzzdefviakl 2405 D975655-7    Ag Ni Ri           302 Zh F7 V M4 V
-ITEDRSHATL    2406 B334A9A-E    Hi                 404 Zh F3 D
+ITEDRSHATL    2406 B334A9A-E    Hi                 404 Zh F3 V
 Petsyabr      2407 E755320-5    Lo Ni An           702 Zh F0 V
-Nebltafenzh   2408 B582458-B  Z Ni                 403 Zh F9 V M0 D
+Nebltafenzh   2408 B582458-B  Z Ni                 403 Zh F9 V M0 V
 Zhdelstatl    2409 E74677A-9    Ag               U 903 Zh F3 V
-Chiezshe      2410 B569351-A    Lo Ni              202 Zh F4 D
+Chiezshe      2410 B569351-A    Lo Ni              202 Zh F4 V
 Diaia         2413 X8C0000-0    De Ba            F 023 Zh K0 IV
-IABLAZIENT    2414 B996ACE-D  Z Hi In              501 Zh F7 V M6 D
+IABLAZIENT    2414 B996ACE-D  Z Hi In              501 Zh F7 V M6 V
 Veprkesh      2416 B669503-B    Ag Ni              603 Zh F1 V
 Zryenz        2420 C746879-7    Ag               U 504 Zh F0 V
 Priaklpa      2422 E8866BA-4    Ag Ni Ri           405 Zh F8 V
-Inshyedr      2424 B464842-A  Z Ri                 500 Zh F8 D
-Vliashoz      2429 D468655-7    Ag Ni Ri           800 Zh K4 D M1 D
-Azzhefrstav   2430 A00087B-D  Z As Na              120 Zh K2 V M0 D
-Enchbiash     2432 C237426-A    Ni                 404 Zh G9 V M3 D
-Iikdla'       2434 A786677-B    Ag Ni Ri D2        600 Zh K3 D
+Inshyedr      2424 B464842-A  Z Ri                 500 Zh F8 V
+Vliashoz      2429 D468655-7    Ag Ni Ri           800 Zh K4 V M1 V
+Azzhefrstav   2430 A00087B-D  Z As Na              120 Zh K2 V M0 V
+Enchbiash     2432 C237426-A    Ni                 404 Zh G9 V M3 V
+Iikdla'       2434 A786677-B    Ag Ni Ri D2        600 Zh K3 V
 QRIANCHOR     2435 A679985-E  Z Hi In              734 Zh F5 V
-Ebrrnch       2438 A360686-C  Z De Ni Ri           824 Zh F9 D
-Javrebr       2501 A52389C-D  Z Na Po              103 Zh G7 V M1 D
+Ebrrnch       2438 A360686-C  Z De Ni Ri           824 Zh F9 V
+Javrebr       2501 A52389C-D  Z Na Po              103 Zh G7 V M1 V
 Vrali         2502 C310667-7    Na Ni O:2501       102 Zh K7 V
 Eyevr         2506 C130434-C    De Ni Po           303 Zh F6 V
-Iaflodiafl    2507 A420356-E  Y De Lo Ni Po        222 Zh M8 V K8 D
+Iaflodiafl    2507 A420356-E  Y De Lo Ni Po        222 Zh K8 V M8 V
 Dlefltiant    2509 C000555-B    As Ni              623 Zh K9 V
-Pansi         2510 X975000-0    Ba Lo Ni         F 500 Zh F2 V M7 D
+Pansi         2510 X975000-0    Ba Lo Ni         F 500 Zh F2 V M7 V
 Rieflyensh    2512 B9B4441-C    Fl Ni              333 Zh M7 V
 Ambrefl       2514 A9D1631-C  Z Fl Ni              814 Zh F9 V
-Chta'ia       2515 C594766-8    Ag O:2615          213 Zh F4 V M1 D
+Chta'ia       2515 C594766-8    Ag O:2615          213 Zh F4 V M1 V
 Jdans         2517 A888797-B    Ag Ri              111 Zh F8 V
-Dlieoviabr    2520 CACA657-C    Wa Fl Ni           800 Zh K6 V M6 D
-Afaents       2522 C240786-8    De Po              900 Zh F7 D
+Dlieoviabr    2520 CACA657-C    Wa Fl Ni           800 Zh K6 V M6 V
+Afaents       2522 C240786-8    De Po              900 Zh F7 V
 Vrie'stiach   2523 C666000-9    Ba               U 304 Zh F8 V
 Nianshia      2526 B584322-B    Lo Ni              500 Zh F9 V
-Ofbieb        2528 B348547-C  Z Ag Ni              123 Zh F0 D
-Manzh         2529 C465731-6    Ag                 504 Zh F5 D M9 D
-Jdizal        2530 C251210-A    Lo Ni Po           403 Zh F3 V M2 D
-Daod          2536 C546210-9    Lo Ni              914 Zh F3 V M9 D
+Ofbieb        2528 B348547-C  Z Ag Ni              123 Zh F0 V
+Manzh         2529 C465731-6    Ag                 504 Zh F5 V M9 V
+Jdizal        2530 C251210-A    Lo Ni Po           403 Zh F3 V M2 V
+Daod          2536 C546210-9    Lo Ni              914 Zh F3 V M9 V
 Fiestiash     2538 A5546A8-A    Ag Ni              110 Zh K5 V
-Vredriazh     2540 C462614-7  Z C1                 603 Zh F7 V M0 D
-Tsiav         2601 C210447-B    Ni                 110 Zh G3 V M3 D
-Zhdievr       2602 D75A533-9    Wa Ni              701 Zh F8 V M0 D
+Vredriazh     2540 C462614-7  Z C1                 603 Zh F7 V M0 V
+Tsiav         2601 C210447-B    Ni                 110 Zh G3 V M3 V
+Zhdievr       2602 D75A533-9    Wa Ni              701 Zh F8 V M0 V
 Azhiebr       2610 C433100-B    Lo Ni              402 Zh G2 V
 Tlolble       2611 A7A4320-E  Z Fl Lo Ni           522 Zh K8 V
 Jol Diadl     2612 C150203-A    De Lo Ni Po        924 Zh M0 V
 IEPKRACHTIABRA2613 C5599CE-8    Hi                 801 Zh F1 V M0 V
-Dizdir        2614 E570778-5    De                 711 Zh F4 D
+Dizdir        2614 E570778-5    De                 711 Zh F4 V
 Zilil         2615 A5688CC-B  Z                    104 Zh K0 V
-Batlia        2619 B140553-D    De Ni Po           603 Zh F4 V M1 D
-Zhdedanjie    2625 C336699-A    Ni                 604 Zh M2 V M4 D
-ATLANTSIA     2628 A577AAA-E    Hi In              724 Zh K8 D M7 D
+Batlia        2619 B140553-D    De Ni Po           603 Zh F4 V M1 V
+Zhdedanjie    2625 C336699-A    Ni                 604 Zh M2 V M4 V
+ATLANTSIA     2628 A577AAA-E    Hi In              724 Zh K8 V M7 V
 Tlavldri      2632 A578595-B    Ag Ni              414 Zh F0 V
-STIENIAZHIR   2636 A444A50-E  Z Hi In Cp           304 Zh G0 V M3 D M4 D
+STIENIAZHIR   2636 A444A50-E  Z Hi In Cp           304 Zh G0 V M3 V M4 V
 Anshfrea      2637 C77A49C-A    Wa Ni              203 Zh F7 V
-Briz          2701 A685797-B    Ag Ri D3           704 Zh F8 V M1 D
+Briz          2701 A685797-B    Ag Ri D3           704 Zh F8 V M1 V
 Arichbrr      2702 A67A8AA-C    Wa                 933 Zh K7 V
-Nial          2703 D461647-5    Ni Ri              834 Zh F9 V M0 D
-Chtopl        2706 C6647BB-7  Z Ag C1              120 Zh G6 V M7 D
-AVRTLAVLOM    2708 C74A98B-C    Wa Hi In           524 Zh F5 D M5 D
+Nial          2703 D461647-5    Ni Ri              834 Zh F9 V M0 V
+Chtopl        2706 C6647BB-7  Z Ag C1              120 Zh G6 V M7 V
+AVRTLAVLOM    2708 C74A98B-C    Wa Hi In           524 Zh F5 V M5 V
 Dlon          2709 E573553-6    Ni               U 504 Zh F8 V
-JESEZYIEN     2710 B7749BF-B    Hi In              613 Zh F9 D
-Viakl         2711 D799536-7    Ni                 505 Zh M9 V M5 D
+JESEZYIEN     2710 B7749BF-B    Hi In              613 Zh F9 V
+Viakl         2711 D799536-7    Ni                 505 Zh M5 V M9 V
 Insia         2712 C98A7B9-A    Wa                 400 Zh G3 V
 Qlachtefl     2714 E7B359B-8    Fl Ni              710 Zh F9 V
-Ochiaza       2716 B851611-C    Wa Ni              214 Zh F8 V M3 D
+Ochiaza       2716 B851611-C    Wa Ni              214 Zh F8 V M3 V
 Jdikliev      2717 B330230-B    De Lo Ni Po        302 Zh F7 IV
-ETLIFEVRO     2718 A777A75-E  Z Hi In              202 Zh G2 D
+ETLIFEVRO     2718 A777A75-E  Z Hi In              202 Zh G2 V
 Zhdant        2719 A6547C8-F  Z Ag An Cx           811 Zh K0 V
 Vlazzhden     2720 C210143-8    Lo Ni              303 Zh G1 IV
 Brevral       2721 E542755-7    Po                 110 Zh G3 V
-Shtiazqliad   2722 C7B5888-9    Fl                 404 Zh F4 D M7 D
+Shtiazqliad   2722 C7B5888-9    Fl                 404 Zh F4 V M7 V
 ZDENCHE       2725 A538972-D  Z Hi                 303 Zh F7 V M0 V
-Vefdel        2726 D7336A5-6    Na Ni Po           900 Zh A3 V K9 D
+Vefdel        2726 D7336A5-6    Na Ni Po           900 Zh A3 V K9 V
 Plel          2727 A99A798-E    Wa                 402 Zh F6 V
-Stiantliepl   2728 E9A4000-0    Fl Ba              804 Zh K2 D
+Stiantliepl   2728 E9A4000-0    Fl Ba              804 Zh K2 V
 Kilsi         2729 CA67653-6    Ag Ni Ri           701 Zh F8 V
-PLELINCHIER   2730 B5859BD-B  Z Hi D0 Cp           925 Zh G1 V M0 V M5 D
-Rminchzha     2733 E444162-5    Lo Ni O:2632       315 Zh G1 D M7 D
+PLELINCHIER   2730 B5859BD-B  Z Hi D0 Cp           925 Zh G1 V M0 V M5 V
+Rminchzha     2733 E444162-5    Lo Ni O:2632       315 Zh G1 V M7 V
 Drajeprplia   2734 A88A756-9    Wa Ri An           404 Zh G4 V
 Enenshe       2737 C2025A8-B    Va Ic Ni           900 Zh M9 III M8 V
 KERNAPLIATL   2739 B767ABF-C  Z Hi                 803 Zh K2 V
-Ieprtipr      2740 E658676-4    Ag Ni            U 301 Zh F9 V M6 D
+Ieprtipr      2740 E658676-4    Ag Ni            U 301 Zh F9 V M6 V
 PLIACHATL     2802 BABA9C7-E  X Fl Hi              802 Zh F5 V
-Tlaj Kie      2803 C223124-B    Lo Ni Po           203 Zh M9 V M8 D
+Tlaj Kie      2803 C223124-B    Lo Ni Po           203 Zh M8 V M9 V
 Plilpiebr     2804 E535685-7    Ni                 423 Zh A6 V K8 V M3 V
 SHTONCHE      2805 A764AED-E    Hi                 604 Zh F0 V
 Viaval        2806 D558353-7    Lo Ni              204 Zh F5 V
@@ -497,85 +497,85 @@ Oshtinz       2816 D644645-6    Ag Ni              104 Zh G7 V
 Diabllianzhel 2818 C538542-9    Ni                 403 Zh A9 II K8 V
 Tlapinsh      2819 B569854-C    Ri                 622 Zh F7 V
 Ezevrtlad     2820 C120000-B    De Ba Po           900 Zh K2 III
-Veliate       2821 A561257-C    Lo Ni              203 Zh F3 D
+Veliate       2821 A561257-C    Lo Ni              203 Zh F3 V
 Dle'chtench   2824 C000874-A    As Na            U 321 Zh F9 IV M4 V
 JDONZH        2827 A000953-E    As Hi In Na        823 Zh G2 III
 Stiechste     2828 B76756A-A    Ag O:2827          502 Zh F7 V
 Iavach        2830 D87A8CB-7    Wa                 802 Zh F9 V
 Vanchletl     2832 B300214-D    Va Lo Ni           512 Zh M2 V
 Branti        2836 B592245-9    Lo Ni              222 Zh F1 V
-Vikredle      2837 D476868-7    O:2737             513 Zh M0 V M4 D
+Vikredle      2837 D476868-7    O:2737             513 Zh M0 V M4 V
 Prablebr      2840 C53866B-8    Ni O:2940          104 Zh K1 V
 Noplidr Ash   2902 C373585-8    Ni                 800 Zh F6 V
-Rqlinsia      2904 B5A1210-B    Fl Lo Ni           903 Zh M5 V M5 D
+Rqlinsia      2904 B5A1210-B    Fl Lo Ni           903 Zh M5 V M5 V
 Ensnelatl     2906 C879223-8  Z Lo Ni              800 Zh F6 V
 Jdanzdia      2911 C7A2558-8  Z Fl Ni              520 Zh F5 V M5 V
 FLOEFLIANSE   2914 C433A55-E    Hi Po              223 Zh K0 V
-Zdanqlad      2915 C622101-B    Lo Ni Po           802 Zh M6 V M5 D
+Zdanqlad      2915 C622101-B    Lo Ni Po           802 Zh M5 V M6 V
 Alchiavrie    2919 B222362-A    Lo Ni Po O:3018    402 Zh M0 V
 RIAPZHIATLENSH2920 A00098A-E  Y As Hi In Na        924 Zh M3 V
-Zhaneiprta    2924 E333223-B    Lo Ni Po           923 Zh M9 V G6 D
-Pripia        2925 C776432-9    Ni                 304 Zh F9 D
-Pliepfliants  2926 A200659-D  Y Va Ni Na           904 Zh M5 V M7 D
-Rinchaedle    2929 E200321-9    Va Lo Ni           202 Zh F8 V M4 D
+Zhaneiprta    2924 E333223-B    Lo Ni Po           923 Zh G6 V M9 V
+Pripia        2925 C776432-9    Ni                 304 Zh F9 V
+Pliepfliants  2926 A200659-D  Y Va Ni Na           904 Zh M5 V M7 V
+Rinchaedle    2929 E200321-9    Va Lo Ni           202 Zh F8 V M4 V
 Tevief        2930 C735586-A    Ni                 200 Zh M8 V
 Viaprjiel     2931 B1308CA-A    De Na Po           213 Zh A9 V G8 V
 Rliad         2936 A795554-E  Y Ni D6              903 Zh F7 V
 Dadlal        2939 EAB9430-9    Fl Ni              813 Zh M2 II M1 V
 TSAVLINSTODR  2940 C5A0ADH-D    De Hi            U 120 Zh G9 V
-ZEMETIAZ      3003 A000952-E  Z As Hi In Na        713 Zh G2 V M1 D
+ZEMETIAZ      3003 A000952-E  Z As Hi In Na        713 Zh G2 V M1 V
 Vrol          3006 C79559C-9    Ag Ni              402 Zh F2 V
-Biachdranch   3008 E5457A6-5    Ag                 902 Zh G8 V M5 D
-CHTABRA       3010 A458974-E  Z Hi Cp              503 Zh F7 D
+Biachdranch   3008 E5457A6-5    Ag                 902 Zh G8 V M5 V
+CHTABRA       3010 A458974-E  Z Hi Cp              503 Zh F7 V
 Alienjne      3014 C3128BD-A  Z Ic Na              900 Zh G3 IV
-Blizatl       3015 C646455-7    Ni               U 604 Zh F3 D M2 D
-Ansdrel       3017 C5546A7-8    Ag Ni              703 Zh F8 V M6 D
+Blizatl       3015 C646455-7    Ni               U 604 Zh F3 V M2 V
+Ansdrel       3017 C5546A7-8    Ag Ni              703 Zh F8 V M6 V
 DRIBR         3018 A2659EA-E  Z Hi An              802 Zh G7 V
-Vlieshstoql   3019 D100336-8    Va Lo Ni           600 Zh G3 V M1 D
-Shrnz         3021 C65A220-B    Wa Lo Ni           510 Zh G9 D
-Jie'ezid      3022 C9D3846-9  Z Fl                 223 Zh G3 V M5 D
+Vlieshstoql   3019 D100336-8    Va Lo Ni           600 Zh G3 V M1 V
+Shrnz         3021 C65A220-B    Wa Lo Ni           510 Zh G9 V
+Jie'ezid      3022 C9D3846-9  Z Fl                 223 Zh G3 V M5 V
 DRITSKANZH    3026 C100978-D    Va Hi In Na      U 904 Zh F1 V
-Ajora         3027 B211301-C    Ic Lo Ni           334 Zh M3 V M8 D
+Ajora         3027 B211301-C    Ic Lo Ni           334 Zh M3 V M8 V
 Daziesavavl   3028 B696874-9  Z                    703 Zh F0 V
 Shansedl      3031 B597559-B  Z Ag Ni              802 Zh F6 IV
-Qlazhdiapoe   3032 C2366A8-9    Ni                 915 Zh M8 V M0 D
+Qlazhdiapoe   3032 C2366A8-9    Ni                 915 Zh M0 V M8 V
 Iekrdechtod   3034 E783223-7    Lo Ni              802 Zh G7 V
-Yiazdabl      3035 C798543-8    Ag                 212 Zh F6 D M7 D
+Yiazdabl      3035 C798543-8    Ag                 212 Zh F6 V M7 V
 Nanjie        3040 C300400-A    Va Ni              401 Zh M3 V
 Jiajsenzh     3101 E303878-8    Va Ic Na           424 Zh F4 V
 Shimpatlmant  3106 E854836-5                       322 Zh F9 V
-Lannens       3108 C661100-A    Lo Ni              623 Zh F7 D M4 D
+Lannens       3108 C661100-A    Lo Ni              623 Zh F7 V M4 V
 Aiantladlinch 3110 E321367-8    Lo Ni Po           410 Zh M4 V
 Shoprbria     3111 E585674-5    Ag Ni Ri         U 525 Zh M0 V
 Eblits        3113 C9C6410-9    Fl Ni              423 Zh K9 II M8 V
-Iabridr       3114 B420535-D    De Ni Po           501 Zh M7 V M4 D
+Iabridr       3114 B420535-D    De Ni Po           501 Zh M4 V M7 V
 Jdozhdafria   3117 A85948A-E  Y Ni                 123 Zh F5 V
-Drodlievrie   3121 A8C69C7-E  Z Fl Hi              211 Zh K6 V M2 D
+Drodlievrie   3121 A8C69C7-E  Z Fl Hi              211 Zh K6 V M2 V
 Abria         3122 B567557-8    Ag Ni              104 Zh F3 V
-Iaranch       3125 A331555-C  Z Ni Po              703 Zh K0 IV M9 D
+Iaranch       3125 A331555-C  Z Ni Po              703 Zh K0 IV M9 V
 Enjpliatafr   3126 B5508A6-9    De Po An           403 Zh G7 V
-Rnchpri       3129 B652779-A    Po                 200 Zh F5 D M3 D
+Rnchpri       3129 B652779-A    Po                 200 Zh F5 V M3 V
 Avlelepal     3132 B210213-B    Lo Ni              810 Zh K7 V
 Flash         3133 C000425-C    As Ni              720 Zh G2 IV M3 V
 Rzaim         3134 E76A7CD-4    Wa Ri              604 Zh B0 V
 IENCHACHTENZ  3140 A200988-E  Z Va Hi In Na        901 Zh M2 V
-Qotlseli      3202 E202652-9    Va Ic Na Ni        303 Zh F0  II
-Ajvench       3203 A400420-C  Z Va Lo Ni           623 Zh M9 V M7 D
+Qotlseli      3202 E202652-9    Va Ic Na Ni        303 Zh F0 II
+Ajvench       3203 A400420-C  Z Va Lo Ni           623 Zh M7 V M9 V
 Peshia        3205 C562311-9    Lo Ni              104 Zh G9 V
-ELOQLEZDEV    3208 C6969BB-A    Hi In              904 Zh F0 D
+ELOQLEZDEV    3208 C6969BB-A    Hi In              904 Zh F0 V
 Ietsplash     3209 C7B0623-9    De Ni              105 Zh F2 V
 Vemepl Qlivr  3211 E000120-9    As Lo Ni           524 Zh F7 V
 Eklcha        3212 D565796-5    Ag Ri              404 Zh G0 V
-STEVLOASH     3213 D570999-6    Hi In              203 Zh F8 D
-Jenkints      3214 B468454-C  Z Ni D4              920 Zh M0 D M4 D
-Ovotsanj      3217 A000522-E  Z As Ni              215 Zh M3 V M1 D
+STEVLOASH     3213 D570999-6    Hi In              203 Zh F8 V
+Jenkints      3214 B468454-C  Z Ni D4              920 Zh M0 V M4 V
+Ovotsanj      3217 A000522-E  Z As Ni              215 Zh M1 V M3 V
 Kriat         3219 C200456-C    Va Ni              101 Zh F2 V
-Te'iavr       3220 C7676BA-8    Ag Ni              304 Zh F5 V M7 D
+Te'iavr       3220 C7676BA-8    Ag Ni              304 Zh F5 V M7 V
 Ashash        3222 D769623-7    Ni                 302 Zh G2 V
 Zi'evl        3233 B652537-A  Z Ni Po              613 Zh F8 V
-Jabraiadr     3236 D646354-7  Z Lo Ni              202 Zh K1 D
+Jabraiadr     3236 D646354-7  Z Lo Ni              202 Zh K1 V
 Brovriashtipr 3237 C956302-8    Lo Ni              900 Zh F0 V
-Desidri       3239 C452644-9    Ni Po              404 Zh F3 V M2 D
+Desidri       3239 C452644-9    Ni Po              404 Zh F3 V M2 V
 #**************************************************************************
 #Notes Section
 #=============


### PR DESCRIPTION
Clean up stellar data in M1105 Zhdant

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is swapped into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).