### PR TITLE
Fix stellar data in Undeveloped Sectors, round 4

### DIFF
--- a/res/Sectors/M1105/Aerenfors.sec
+++ b/res/Sectors/M1105/Aerenfors.sec
@@ -44,7 +44,7 @@ Chebchienj    1102 C644446-5    Ni                 134 Zh     F4V M6V
 Tleflchefr    1402 D6B0000-0    Ba De Lo Ni        005 Zh     F4V M4V
 Draqtazdal    1602 C575973-A    Hi In              921 Zh     F4V 
 Stedriazh     1702 B460443-9    De Ni           U  803 Zh     F6V M7V
-Vlebrrebr     1902 B9A5455-8  Z Fl Ni              904 Zh     M4V M1V
+Vlebrrebr     1902 B9A5455-8  Z Fl Ni              904 Zh     M1V M4V
 Kaekrni'a     2002 C989775-4    Ri                 411 Zh     F9V 
 Konchchozh    2202 B464566-C    Ag Ni              501 Zh     F3V 
 Otsche        2402 E7689A7-3    Hi In           U  615 Zh     M4V M5V
@@ -82,7 +82,7 @@ Tleche        2304 A410731-B  Z Na                 604 Zh     F7V
 Nittlo        2404 C877667-7    Ag Ni              403 Zh     F9V M7V
 Tletsiet      2604 C97A463-6    Ni Wa              700 Zh     M7V 
 Enzhiazhi     2704 C000443-C    As Ni              723 Zh     K5V M0V
-Zhaetla       2804 C9A4000-0    Ba Fl Lo Ni        003 Zh     M7V M4V M7V
+Zhaetla       2804 C9A4000-0    Ba Fl Lo Ni        003 Zh     M4V M7V M7V
 Enzhbria'     2904 C331410-8    Ni Po              403 Zh     K9V 
 Zdiejste'pri  3104 B65A589-A    Ni Wa              201 Zh     F4V 
 Jiazpezhdekl  0105 C000740-8    As Na              300 Zh     M0V M6V
@@ -129,7 +129,7 @@ Noibriefla    2307 E639458-A    Ni                 614 Zh     G7V
 Jdevlkofr     2507 A24789B-A                       310 Zh     F5V M1V
 Iadra         3107 B67157B-6  Z Ni                 103 Zh     F8V 
 Eddents       0208 C8A9565-8    Fl Ni              402 Zh     M5V M5V
-Chabe         0508 C3427A9-5    Po                 609 Zh     K5V F7V M1V
+Chabe         0508 C3427A9-5    Po                 609 Zh     F7V K5V M1V
 A'via         0608 D8B3000-0    Ba Fl Lo Ni     U  004 Zh     M7V 
 Stetsie       0908 A000769-B  Z As Na              202 Zh     K5III 
 Naiakr        1208 C855414-8    Ni                 602 Zh     F0V M6V
@@ -161,8 +161,8 @@ Savrjezhopr   1910 D150497-5  Z De Ni Po           803 Zh     F1V
 Oatlplekr     2110 D311424-7    Ic Ni              918 Zh     F7V M5V
 Atpie         2210 X6558A6-0                    F  713 Zh     F2V 
 Eiaa          2410 C433432-7    Ni Po              420 Zh     M8III M3V
-Ribliblidlie  2510 C1009BD-9  Z Hi Na Va           710 Zh     F7D M5V
-Iansjeqplibl  3210 C534433-6    Ni                 704 Zh     G1V M4D M6V
+Ribliblidlie  2510 C1009BD-9  Z Hi Na Va           710 Zh     F7V M5V
+Iansjeqplibl  3210 C534433-6    Ni                 704 Zh     G1V M4V M6V
 Krienjchtitl  0611 C266874-7    Ri                 302 Zh     M0V 
 Iebret        0911 C4357CD-6                       800 Zh     A8V 
 Qlizhstiadl   1211 C443652-A    Ag Ni Po           702 Zh     F5V 
@@ -200,15 +200,15 @@ Tariatiapl    2513 C535543-6    Ni                 314 Zh     G7IV M4V
 Iarozhich     2913 D7859DF-5  Z Hi In           U  623 Zh     F7V 
 Aidr          0314 C546000-0    Ba Lo Ni           014 Zh     F4V K1V
 Fiablpoch     0714 B110684-D  Z Na Ni              113 Zh     F1V 
-Anzeb         1214 B401661-A  Z Ic Na Ni Va        302 Zh     M6V M5V
+Anzeb         1214 B401661-A  Z Ic Na Ni Va        302 Zh     M5V M6V
 Aplenstla'    1714 C100427-9    Ni Va              613 Zh     K1V 
 Siro          1814 E333000-0    Ba Lo Ni Po        000 Zh     A8V 
 Azobatlen     1914 C130642-8    De Na Ni Po        802 Zh     M3V 
 Zdia'ipia     2014 D585544-3    Ag Ni              104 Zh     G5V 
 Praklzhets    2114 C8A4000-0    Ba Fl Lo Ni        005 Zh     G3V M0V
 Ste'enz       3214 C889485-8    Ni                 302 Zh     F9V M2V
-Zhdeflmitsop  0215 C635000-0  Z Ba Lo Ni           023 Zh     M6V M4V
-Abfladiesh    0315 D689698-2    Ni Ri              307 Zh     M8V M0V
+Zhdeflmitsop  0215 C635000-0  Z Ba Lo Ni           023 Zh     M4V M6V
+Abfladiesh    0315 D689698-2    Ni Ri              307 Zh     M0V M8V
 Zhdifrzher    1115 C595588-6    Ag Ni              103 Zh     F6V M0V
 Naklzifen     1615 E310000-0    Ba Lo Ni           014 Zh     G4V M3V
 Chifipryitl   1815 C988542-6  Z Ag Ni              902 Zh     F5V 
@@ -220,10 +220,10 @@ Fra'i         3015 A876773-B  Z Ag                 601 Zh     M8V
 Enzdaa        0416 CAD6968-A    Fl Hi In           204 Zh     G9V M8V
 Ieeodlyipr    0616 A797766-C  Z Ag                 403 Zh     F7V 
 Zhdialitl     1116 C888554-6  Z Ag Ni              802 Zh     G0V M1V
-Qrisheiae     2016 E638452-7    Ni                 406 Zh     M1V M0V
+Qrisheiae     2016 E638452-7    Ni                 406 Zh     M0V M1V
 Itzhinshnia   2116 A362521-C  Z Ni                 724 Zh     F5V M7V
 Chtili        2416 B100887-C    Na Va           U  900 Zh     G1V 
-Idriedriie    2916 B300847-A  Z Na Va              206 Zh     F4D M1V
+Idriedriie    2916 B300847-A  Z Na Va              206 Zh     F4V M1V
 Eshibr        3216 C110462-B    Ni                 401 Zh     F5V 
 Aqltsizh      0117 C9B5000-0  Z Ba Fl Lo Ni        004 Zh     M1V 
 Iaa           0417 C585625-8  Z Ag Ni              714 Zh     F5V M4V 
@@ -256,7 +256,7 @@ Chierfl       0619 C648553-8  Z Ag Ni              413 Zh     F6V F6V
 Jaflatl       0719 D140000-0  Z Ba De Lo Ni Po     003 Zh     F5V 
 Eientdliar    1119 E364424-4    Ni              U  803 Zh     F4V M0V
 Kleliashfefr  1319 C756996-A    Hi In              200 Zh     F4V 
-Ii            1519 C9D6666-8    Fl Ni              425 Zh     M4V M2V
+Ii            1519 C9D6666-8    Fl Ni              425 Zh     M2V M4V
 Siarpledr     2019 C410545-8  Z Ni                 102 Zh     K0V 
 Iklzhdel      2119 C888416-8    Ni                 504 Zh     F0V 
 Shtateienj    2219 C5577B9-8    Ag                 211 Zh     F2V 
@@ -265,12 +265,12 @@ Zheblal       2719 B865455-7    Ni                 203 Zh     F0V
 Yiefrablatl   2819 C765615-8  Z Ag Ni              902 Zh     M4V 
 Bliavzhats    3019 C563448-6    Ni                 516 Zh     F2V M2V
 Yoni          0620 A474467-C    Ni                 404 Zh     F8V 
-Ieapratl      0720 C100000-0  Z Ba Lo Ni Va        008 Zh     M2V M7V M0V 
+Ieapratl      0720 C100000-0  Z Ba Lo Ni Va        008 Zh     M0V M7V M2V
 Viezdiernol   0820 C000798-B  Z As Na              400 Zh     M2V M4V
 Etlplibrfaf   1220 A464435-E    Ni                 104 Zh     G7V 
 Prianaf       1520 XA99000-0    Ba Lo Ni        F  003 Zh     F3V M7V
 Eziait        1920 B538755-9                    U  213 Zh     M5III M8V
-Eshtiatle     2220 D434433-7    Ni                 207 Zh     M4V M1V
+Eshtiatle     2220 D434433-7    Ni                 207 Zh     M1V M4V
 Blietlitl     2520 E636000-0    Ba Lo Ni           005 Zh     M1V M3V 
 Edlstabr      2920 B83A444-9    Ni Wa              302 Zh     M2V 
 Ije           3020 B100423-A    Ni Va              603 Zh     M0V 
@@ -286,7 +286,7 @@ Zhdieredians  1921 A66747A-9    Ni                 510 Zh     K4V M1V
 Drakldli'     2221 A500440-D    Ni Va              412 Zh     F6V 
 Edrkrazh      2421 D665484-6  Z Ni                 404 Zh     G2V M5V M5V
 Driplshtol    2521 C564468-8    Ni                 805 Zh     G9V 
-Eal           2721 B526643-A    Ni                 225 Zh     M7V M4V
+Eal           2721 B526643-A    Ni                 225 Zh     M4V M7V
 Zhdashensh    0222 B110644-C    Na Ni              113 Zh     M5V 
 Narrkizh      0722 A8B6430-A  Z Fl Ni              826 Zh     A9V M2V 
 Eplzhach      0822 D778000-0    Ba Lo Ni           010 Zh     F3V 
@@ -297,9 +297,9 @@ Jdishseeiavr  1822 B404898-8    Ic Va              404 Zh     F7V
 Shiafliats    2022 C100585-9  Z Ni Va              504 Zh     M7V 
 Ekradr        2622 CAB98B8-9  Z Fl                 424 Zh     G2V 
 Ibltedr       0623 C55368A-7    Ag Ni Po           800 Zh     K9V 
-Iepldriantie  0723 A43356B-C    Ni Po              304 Zh     M5V M1V
+Iepldriantie  0723 A43356B-C    Ni Po              304 Zh     M1V M5V
 Pejrnzielrfl  0923 E575000-0    Ba Lo Ni           003 Zh     F3V 
-Dranshia      1123 C615679-7    Ic Ni              515 Zh     M5V K2V 
+Dranshia      1123 C615679-7    Ic Ni              515 Zh     K2V M5V
 Antjaqr       1423 C4319AA-9  Z Hi In Na Po        604 Zh     K4V 
 Eyiiafr       1623 A150854-D  Z De Po              310 Zh     F9V 
 Flarebrvif    1723 C130498-C  Z De Ni Po           602 Zh     K5V 
@@ -320,7 +320,7 @@ Nililvirzid   0125 C367400-A    Ni                 905 Zh     K0V
 Eplyilchtar   0225 A642420-D    Ni Po              821 Zh     F6V M4V
 Ibe           0825 C00047A-7    As Ni              310 Zh     M6V 
 Aprenzh       0925 C220457-C    De Ni Po           400 Zh     M4V 
-Idral         1025 C40255A-A    Ic Ni Va           700 Zh     M4V M2V
+Idral         1025 C40255A-A    Ic Ni Va           700 Zh     M2V M4V
 Ieablfifr     1625 C646A86-A  Z Hi In              523 Zh     F7V 
 Ieasets       1725 A655552-B  Z Ag Ni              811 Zh     F6V M6V
 Iashefezh     1925 C545567-6  Z Ag Ni              716 Zh     F4V M4V
@@ -334,13 +334,13 @@ Inshchens     1426 C110586-9    Ni                 202 Zh     M0V
 Shiatlatlti   1626 A340489-D    De Ni Po           802 Zh     F4V M4V
 Iedlaklkop    1926 X400000-0    Ba Lo Ni Va     F  003 Zh     M7V 
 Shtekliaizh   2126 C657ABE-8    Hi In              200 Zh     M3V 
-Droklieof     2726 E120587-9    De Ni Po        U  802 Zh     M8V M3V
+Droklieof     2726 E120587-9    De Ni Po        U  802 Zh     M3V M8V
 Idlancheoe    3226 E321000-0    Ba Lo Ni Po        024 Zh     G0V 
 Ivoprej       0127 E778864-5                       704 Zh     G1V 
 Alebiatl      0227 C6529A8-A    Hi In Po           224 Zh     G9V M0V
 Daplqrebl     0327 C35579A-5    Ag                 105 Zh     F2V M8V
 Anjzdobri     0427 C7A5000-0  Z Ba Fl Lo Ni     U  021 Zh     F1V 
-Ashapchiedr   0727 C448500-8    Ag Ni              617 Zh     F3V M0D M7V
+Ashapchiedr   0727 C448500-8    Ag Ni              617 Zh     F3V M0V M7V
 Ajapdriabl    0827 C426000-0    Ba Lo Ni           024 Zh     K9V 
 Ieltrrfrefle  1327 B7A1500-8  Z Fl Ni              704 Zh     G5V M2V
 Jetssob       1727 D5A2000-0    Ba Fl Lo Ni        011 Zh     M1V 
@@ -348,7 +348,7 @@ Diekryadr     1927 E797000-0    Ba Lo Ni        U  000 Zh     F3V
 Echriedr      2127 C788866-5    Ri                 126 Zh     F2V M7V
 Echedr        2527 X79AA98-7    Hi In Wa        F  911 Zh     F9V M1V
 Aprejef       2627 E110463-8    Ni                 115 Zh     F6V 
-Ifdaklzhiqr   2827 D000410-A  Z As Ni              202 Zh     M7V M6V
+Ifdaklzhiqr   2827 D000410-A  Z As Ni              202 Zh     M6V M7V
 Siefreansh    2927 C437968-7  Z Hi In              501 Zh     F9V 
 Dadtatletl    3027 C542000-0    Ba Lo Ni Po        003 Zh     F7V 
 Shiejia       3227 C5A0000-0    Ba De Lo Ni        020 Zh     M6V 
@@ -380,9 +380,9 @@ Jdontabea     2530 C110421-B  Z Ni                 503 Zh     G2V
 Esanch        2630 B766766-A    Ag Ri              903 Zh     M4V 
 Blatlensh     0131 C373577-6  Z Ag Ni              207 Zh     F9V M5V
 Adobl         0831 D1008BD-9  Z Na Va              301 Zh     F5V 
-Enzipltir     1231 C435536-B    Ni                 204 Zh     M1V M0V
+Enzipltir     1231 C435536-B    Ni                 204 Zh     M0V M1V
 Intfra        1631 D73A420-7  Z Ni Wa           U  612 Zh     K5V M5V
-Iero          1931 E223000-0    Ba Lo Ni Po     U  012 Zh     M6V M1V
+Iero          1931 E223000-0    Ba Lo Ni Po     U  012 Zh     M1V M6V
 Staqrdlach    2131 D7B3000-0    Ba Fl Lo Ni        020 Zh     G2II 
 Sinskobro     2431 C240465-A    De Ni Po           202 Zh     F4V M5V
 Nianzechensh  2931 C886878-6    Ri                 502 Zh     F5V 
@@ -390,16 +390,16 @@ Enzhdriqr     3231 CAA2511-8    Fl Ni              822 Zh     M6V
 Fliezant      0332 C235446-B    Ni                 700 Zh     M3V 
 Qiabliere     0432 C522000-0    Ba Lo Ni Po        013 Zh     M1V 
 Enzhvrintze   0532 B7B37A8-A    Fl                 922 Zh     M0V 
-Driavbrotl    0832 B561766-6  Z Ri                 303 Zh     F9V M4D F9V 
+Driavbrotl    0832 B561766-6  Z Ri                 303 Zh     F9V M4V F9V
 Adlots        0932 D62A411-7    Ni Wa              503 Zh     M7V 
 Sievlapr      1132 B522467-8  Z Ni Po              723 Zh     F7IV 
 Iantsariaint  1232 E788466-5    Ni                 300 Zh     F2V 
 Vriadiant     1332 C97A411-8    Ni Wa              513 Zh     F9V M1V
 Iajzhditl     1432 D565633-2    Ag Ni              302 Zh     F9V 
 Ieflaprdebl   1532 D9A4000-0    Ba Fl Lo Ni     U  002 Zh     M3V 
-Tlrklolinsoj  3232 B341523-A  Z Ni Po              204 Zh     M5V M1V
+Tlrklolinsoj  3232 B341523-A  Z Ni Po              204 Zh     M1V M5V
 Aplpia        0233 D647774-6    Ag                 200 Zh     F0V M5V
-Stieriebr     0433 C000422-8    As Ni              705 Zh     M4V M2V
+Stieriebr     0433 C000422-8    As Ni              705 Zh     M2V M4V
 Klianschtie   0933 C445477-5    Ni                 801 Zh     F9V 
 Seklchted     1033 D72A765-8    Wa                 213 Zh     M1V 
 Chteqjedr     1933 C8A0678-9    De Ni              700 Zh     M0V M3V
@@ -416,7 +416,7 @@ Iatlar        1334 C758497-6    Ni                 611 Zh     F2V
 Chtiplchtadl  1534 C996532-7    Ag Ni              104 Zh     F6V 
 Ekrniebia     1634 C876000-0  Z Ba Lo Ni           013 Zh     F8V 
 Iakiltakr     1734 B653556-A    Ag Ni Po           710 Zh     F2V 
-Jatsripl      2734 C211444-7  Z Ic Ni              604 Zh     M6V M1V
+Jatsripl      2734 C211444-7  Z Ic Ni              604 Zh     M1V M6V
 Chtenjiatse   3034 C7A299B-9    Fl Hi In           905 Zh     F2V 
 Iklzhdevl     0135 C410886-A    Na                 504 Zh     F6V 
 Beshitia      0435 E946463-7    Ni                 612 Zh     F2V 
@@ -424,15 +424,15 @@ Keqbie'       0535 C666647-7    Ag Ni Ri        U  304 Zh     F3V M2V
 Patshel       0735 A311411-E  Z Ic Ni              903 Zh     A2IV 
 Zhdialiaianj  0935 D647975-8    Hi In              202 Zh     F9V M6V
 Voshiapr      1035 E869547-4    Ni                 204 Zh     F5V 
-Vientanz      1735 B302675-8  Z Ic Na Ni Va        625 Zh     M8V M6V
+Vientanz      1735 B302675-8  Z Ic Na Ni Va        625 Zh     M6V M8V
 Chtiflkat     1835 C8C8556-A    Fl Ni              104 Zh     M2V 
 Viadlbrints   2135 E7A2000-0    Ba Fl Lo Ni        003 Zh     M1V M2V
 Dansinzdlaf   2835 BAC6465-9    Fl Ni              202 Zh     M5V 
 Zhedzarchebr  3135 B88A9BA-A  Z Hi In Wa           512 Zh     F0V 
 Zhdedipens    0136 C130422-A  Z De Ni Po        U  517 Zh     G8V M3V 
-Vekrier       0436 C537668-7    Ni                 500 Zh     M8V M6V
-Apeshprent    0536 C77A410-A    Ni Wa              606 Zh     M8V M1V
-Vrietlchajel  1336 D203000-0  Z Ba Ic Lo Ni Va     034 Zh     M2V M1V 
+Vekrier       0436 C537668-7    Ni                 500 Zh     M6V M8V
+Apeshprent    0536 C77A410-A    Ni Wa              606 Zh     M1V M8V
+Vrietlchajel  1336 D203000-0  Z Ba Ic Lo Ni Va     034 Zh     M1V M2V
 Biarchalo     2136 C5358BG-7  Z                    416 Zh     F7V M2V
 Avone         2236 C543000-0    Ba Lo Ni Po        014 Zh     K7V M4V
 Ofraladetl    2536 C40296A-A    Hi Ic Na Va        405 Zh     F6V M4V
@@ -441,7 +441,7 @@ Ratlkid       3136 C8B2000-0    Ba Fl Lo Ni        004 Zh     M4V
 Jieqladzhdor  0237 C300434-9    Ni Va              606 Zh     M1V M7V
 Iadripl       0637 C858437-6    Ni                 404 Zh     G7V 
 Fida          0837 C598463-9    Ni                 502 Zh     G2V 
-Iade          1137 B410435-D    Ni                 904 Zh     G4V M8V 
+Iade          1137 B410435-D    Ni                 904 Zh     G4V M8V
 Stabash       1637 D320000-0    Ba De Lo Ni Po     010 Zh     M3III 
 Itlsinji'     1837 D9A5459-8    Fl Ni              911 Zh     G3V 
 Piebflefatl   2037 E898553-7    Ag Ni              613 Zh     F0V 
@@ -452,7 +452,7 @@ Brievltliabl  0138 D664440-2  Z Ni                 200 Zh     F1V
 Bieprvrapr    0238 A212551-E  Z Ic Ni              413 Zh     F9V 
 Ebranie       0338 C490669-8    De Ni              102 Zh     F1V 
 Ietliadryebr  0538 X375000-0    Ba Lo Ni        F  005 Zh     M0V 
-Ponshia       0638 C7B1000-0    Ba Fl Lo Ni        003 Zh     A0IV M2D M8V M8V
+Ponshia       0638 C7B1000-0    Ba Fl Lo Ni        003 Zh     A0IV M2V M8V M8V
 Fachdrent     1038 E459755-5                       402 Zh     K8V M8V
 Jiejebr       1238 C997400-6    Ni                 816 Zh     G3V M6V
 Zaprienchiae  1338 C657888-5  Z                    710 Zh     F7V 
@@ -464,7 +464,7 @@ Estiblfiesh   2838 C15089B-9  Z De Po              413 Zh     F9V
 Tlonsestivr   3038 E546955-6    Hi In              400 Zh     F3V 
 Jielblafchaj  3138 E400466-8    Ni Va              500 Zh     M1V 
 Itsipiazekr   0139 C7B6000-0  Z Ba Fl Lo Ni     U  007 Zh     M0V M8V 
-Plevlchiebr   0239 C728400-9    Ni                 502 Zh     M8V M7V
+Plevlchiebr   0239 C728400-9    Ni                 502 Zh     M7V M8V
 Elpriva       0839 C110446-B    Ni                 224 Zh     F5V 
 Apla          0939 B647449-8  Z Ni                 923 Zh     F4V 
 Drechiaqenz   1039 B410462-A    Ni                 301 Zh     M2V 
@@ -482,7 +482,7 @@ Zieblji       0640 C988898-3    Ri              U  811 Zh     F6V M0V
 Iavrpiliepl   0740 D440420-7  Z De Ni Po           203 Zh     F4V M7V
 Zajinianj     0840 C615468-8  Z Ic Ni              803 Zh     G3V 
 Iejiaddevr    1140 C887ACB-C    Hi In              234 Zh     F1V M4V
-Ieazienzh     1740 B625658-7  Z Ni                 502 Zh     M7V M3V 
+Ieazienzh     1740 B625658-7  Z Ni                 502 Zh     M3V M7V
 Etievrianch   1940 E8877BG-2    Ag                 602 Zh     F1V 
 Eshvajel      2440 C527485-8    Ni                 701 Zh     G3V M2V
 Chansiklatli  2540 C576513-9    Ag Ni              801 Zh     M7V 

--- a/res/Sectors/M1105/Finggvakhou.sec
+++ b/res/Sectors/M1105/Finggvakhou.sec
@@ -10,111 +10,111 @@ Finggvakhou
 #----------   ---- ---------  - --------------- -  --- -- --- -
 .             0601 X372000-0    Ba Lo Ni           002 --     G2V 
 .             0801 X110000-0    Ba Lo Ni           002 --     M4V 
-.             2001 X364000-0    Ba Lo Ni           015 --     F6V M4D M3D 
+.             2001 X364000-0    Ba Lo Ni           015 --     F6V M4V M3V
 .             2201 X473000-0    Ba Lo Ni           014 --     K4V 
 .             2301 X7A7000-0    Ba Fl Lo Ni        021 --     G9V 
-.             0202 X414000-0    Ba Ic Lo Ni        002 --     M5V M7V 
+.             0202 X414000-0    Ba Ic Lo Ni        002 --     M5V M7V
 .             0302 X300000-0    Ba Lo Ni Va        011 --     G4V 
-.             0602 X356000-0    Ba Lo Ni           005 --     F7V M8D 
-.             1002 X000000-0    As Ba Lo Ni        000 --     M3D M7D 
+.             0602 X356000-0    Ba Lo Ni           005 --     F7V M8V
+.             1002 X000000-0    As Ba Lo Ni        000 --     M3V M7V
 .             1102 X110000-0    Ba Lo Ni           000 --     M2V 
-.             1402 X777000-0    Ba Lo Ni           021 --     F8V M2D 
+.             1402 X777000-0    Ba Lo Ni           021 --     F8V M2V
 .             1902 X550000-0    Ba De Lo Ni Po     002 --     F3V 
-.             2402 X9C8000-0    Ba Fl Lo Ni        022 --     G9V M1D 
+.             2402 X9C8000-0    Ba Fl Lo Ni        022 --     G9V M1V
 .             0103 X67A000-0    Ba Lo Ni Wa        013 --     F7V 
-.             0303 X9D1000-0    Ba Fl Lo Ni        006 --     M1V M0D 
+.             0303 X9D1000-0    Ba Fl Lo Ni        006 --     M0V M1V
 .             1103 X9D6000-0    Ba Fl Lo Ni        004 --     M7V 
 .             1403 X553000-0    Ba Lo Ni Po        000 --     F9V 
 .             1503 X898000-0    Ba Lo Ni           004 --     F3V 
-.             1803 X596000-0    Ba Lo Ni           013 --     M5V M1V 
-.             2503 X425000-0    Ba Lo Ni           014 --     F3V M4D 
+.             1803 X596000-0    Ba Lo Ni           013 --     M1V M5V
+.             2503 X425000-0    Ba Lo Ni           014 --     F3V M4V
 .             0604 X564000-0    Ba Lo Ni           003 --     F0V 
 .             0804 X225000-0    Ba Lo Ni           002 --     K6V 
 .             1004 X000000-0    As Ba Lo Ni        010 --     M2V 
 .             2604 X462000-0    Ba Lo Ni           002 --     G1V 
-.             0505 X688000-0    Ba Lo Ni           001 --     F9V M5D 
-.             1005 X653000-0    Ba Lo Ni Po        016 --     G5V M3D 
+.             0505 X688000-0    Ba Lo Ni           001 --     F9V M5V
+.             1005 X653000-0    Ba Lo Ni Po        016 --     G5V M3V
 .             1205 X427000-0    Ba Lo Ni           003 --     K6V 
 .             1805 X573000-0    Ba Lo Ni           004 --     F5V 
-.             1905 X210000-0    Ba Lo Ni           004 --     M7V M3D 
+.             1905 X210000-0    Ba Lo Ni           004 --     M3V M7V
 .             2005 X678000-0    Ba Lo Ni           003 --     F4V 
 .             2605 X427000-0    Ba Lo Ni           004 --     M1V 
 .             2805 X333000-0    Ba Lo Ni Po        004 --     M6V 
 .             3105 X768000-0    Ba Lo Ni           003 --     K1V 
 .             0406 X110000-0    Ba Lo Ni           003 --     M1V 
-.             0606 X643000-0    Ba Lo Ni Po        007 --     F7V M7D 
+.             0606 X643000-0    Ba Lo Ni Po        007 --     F7V M7V
 .             1006 X100000-0    Ba Lo Ni Va        002 --     M0V 
 .             1906 X100000-0    Ba Lo Ni Va        002 --     K1IV 
 .             2106 X62A000-0    Ba Lo Ni Wa        001 --     F7II 
 .             3106 X787000-0    Ba Lo Ni           004 --     F2V 
-.             0107 X74A000-0    Ba Lo Ni Wa        012 --     F8V M2D 
+.             0107 X74A000-0    Ba Lo Ni Wa        012 --     F8V M2V
 .             0207 X310000-0    Ba Lo Ni           000 --     F6V 
 .             0507 XA97000-0    Ba Lo Ni           003 --     F6V 
-.             0807 X430000-0    Ba De Lo Ni Po     025 --     F7V M1D 
-.             0907 X455000-0    Ba Lo Ni           002 --     F4V M5D 
+.             0807 X430000-0    Ba De Lo Ni Po     025 --     F7V M1V
+.             0907 X455000-0    Ba Lo Ni           002 --     F4V M5V
 .             1007 X855000-0    Ba Lo Ni           000 --     F9V 
 .             1807 X545000-0    Ba Lo Ni           012 --     F3V 
-.             2207 X5A0000-0    Ba De Lo Ni        011 --     F5V M5D 
+.             2207 X5A0000-0    Ba De Lo Ni        011 --     F5V M5V
 .             2507 X120000-0    Ba De Lo Ni Po     002 --     M1V 
-.             2607 X322000-0    Ba Lo Ni Po        017 --     K6V M0D 
+.             2607 X322000-0    Ba Lo Ni Po        017 --     K6V M0V
 .             0108 X586000-0    Ba Lo Ni           002 --     F1V F1V 
-.             0308 X7A0000-0    Ba De Lo Ni        038 --     K5V M7D 
+.             0308 X7A0000-0    Ba De Lo Ni        038 --     K5V M7V
 .             0408 X410000-0    Ba Lo Ni           004 --     M1V 
-.             0708 X551000-0    Ba Lo Ni Po        004 --     M3V M7D 
-.             0808 X561000-0    Ba Lo Ni           004 --     F3V M1D 
-.             1208 X783000-0    Ba Lo Ni           018 --     F7V M1D 
-.             1308 X580000-0    Ba De Lo Ni        021 --     G3V M3D 
+.             0708 X551000-0    Ba Lo Ni Po        004 --     M3V M7V
+.             0808 X561000-0    Ba Lo Ni           004 --     F3V M1V
+.             1208 X783000-0    Ba Lo Ni           018 --     F7V M1V
+.             1308 X580000-0    Ba De Lo Ni        021 --     G3V M3V
 .             1608 X332000-0    Ba Lo Ni Po        001 --     M3V 
 .             2008 X678000-0    Ba Lo Ni           004 --     F1V 
-.             2108 X666000-0    Ba Lo Ni           026 --     F3V M5D 
+.             2108 X666000-0    Ba Lo Ni           026 --     F3V M5V
 .             2408 X443000-0    Ba Lo Ni Po        005 --     F9V 
-.             0109 X648000-0    Ba Lo Ni           002 --     F1V M3D 
-.             0409 X334000-0    Ba Lo Ni           021 --     M8V M4D 
-.             1009 X9E7000-0    Ba Fl Lo Ni        026 --     M3V M0D M6D 
-.             1109 X000000-0    As Ba Lo Ni        000 --     M1V M3D 
+.             0109 X648000-0    Ba Lo Ni           002 --     F1V M3V
+.             0409 X334000-0    Ba Lo Ni           021 --     M4V M8V
+.             1009 X9E7000-0    Ba Fl Lo Ni        026 --     M0V M3V M6V
+.             1109 X000000-0    As Ba Lo Ni        000 --     M1V M3V
 .             1709 X548000-0    Ba Lo Ni           001 --     F7V 
 .             2309 X443000-0    Ba Lo Ni Po        011 --     F3V 
 .             2409 X453000-0    Ba Lo Ni Po        002 --     F3V 
-.             2709 X232000-0    Ba Lo Ni Po        014 --     K9V M3D 
-.             3009 X575000-0    Ba Lo Ni           014 --     M3V M3D 
-.             0410 X211000-0    Ba Ic Lo Ni        025 --     F3V M8D 
+.             2709 X232000-0    Ba Lo Ni Po        014 --     K9V M3V
+.             3009 X575000-0    Ba Lo Ni           014 --     M3V M3V
+.             0410 X211000-0    Ba Ic Lo Ni        025 --     F3V M8V
 .             0810 X310000-0    Ba Lo Ni           010 --     K3V 
 .             1210 X545000-0    Ba Lo Ni           012 --     F5V 
 .             1710 X9B6000-0    Ba Fl Lo Ni        005 --     M1V 
 .             1910 X999000-0    Ba Lo Ni           013 --     F7V 
 .             3010 X426000-0    Ba Lo Ni           012 --     F0V 
-.             3110 X6A0000-0    Ba De Lo Ni        002 --     M8V M7D 
-.             0311 X88A000-0    Ba Lo Ni Wa        012 --     F0V M2D 
-.             0811 X110000-0    Ba Lo Ni           002 --     G5V M4D 
+.             3110 X6A0000-0    Ba De Lo Ni        002 --     M7V M8V
+.             0311 X88A000-0    Ba Lo Ni Wa        012 --     F0V M2V
+.             0811 X110000-0    Ba Lo Ni           002 --     G5V M4V
 .             1211 X271000-0    Ba Lo Ni           021 --     F4V 
 .             2211 X535000-0    Ba Lo Ni           002 --     G7V 
 .             2411 X677000-0    Ba Lo Ni           033 --     G5V 
 .             2611 X689000-0    Ba Lo Ni           000 --     M2V 
-.             2711 X6A5000-0    Ba Fl Lo Ni        004 --     M5V M3D 
-.             3011 X675000-0    Ba Lo Ni           004 --     F3V M3D 
+.             2711 X6A5000-0    Ba Fl Lo Ni        004 --     M3V M5V
+.             3011 X675000-0    Ba Lo Ni           004 --     F3V M3V
 .             0412 X793000-0    Ba Lo Ni           010 --     F2V 
-.             1812 X767000-0    Ba Lo Ni           003 --     F0V M3D 
+.             1812 X767000-0    Ba Lo Ni           003 --     F0V M3V
 .             2312 X969000-0    Ba Lo Ni           010 --     M0V 
 .             2512 X8A2000-0    Ba Fl Lo Ni        013 --     G7V 
-.             2912 X669000-0    Ba Lo Ni           002 --     F6V M3D 
+.             2912 X669000-0    Ba Lo Ni           002 --     F6V M3V
 .             3212 X9D8000-0    Ba Fl Lo Ni        000 --     M5V 
 .             0113 X988000-0    Ba Lo Ni           004 --     F0V 
 .             0313 X557000-0    Ba Lo Ni           014 --     G2V 
 .             0513 X571000-0    Ba Lo Ni           001 --     K0V 
 .             1013 X668000-0    Ba Lo Ni           003 --     M6V 
-.             1613 X55A000-0    Ba Lo Ni Wa        007 --     M8V M2D 
+.             1613 X55A000-0    Ba Lo Ni Wa        007 --     M2V M8V
 .             2313 X788000-0    Ba Lo Ni           010 --     G7V 
 .             2613 X584000-0    Ba Lo Ni           004 --     F0V 
 .             2713 X513000-0    Ba Ic Lo Ni        004 --     M3V 
 .             2913 X9B7000-0    Ba Fl Lo Ni        001 --     M8V 
-.             3113 X444000-0    Ba Lo Ni           016 --     F6V M5D 
+.             3113 X444000-0    Ba Lo Ni           016 --     F6V M5V
 .             0514 X511000-0    Ba Ic Lo Ni        001 --     F8V 
 .             0814 X542000-0    Ba Lo Ni Po        002 --     F2V 
-.             1014 X342000-0    Ba Lo Ni Po        001 --     F4V M8D 
+.             1014 X342000-0    Ba Lo Ni Po        001 --     F4V M8V
 .             1114 X346000-0    Ba Lo Ni           011 --     F0V 
-.             1214 X9C3000-0    Ba Fl Lo Ni        002 --     M4V M8D 
-.             1814 X457000-0    Ba Lo Ni           001 --     F1V M1D 
-.             2014 X370000-0    Ba De Lo Ni        005 --     G4V M6D 
+.             1214 X9C3000-0    Ba Fl Lo Ni        002 --     M4V M8V
+.             1814 X457000-0    Ba Lo Ni           001 --     F1V M1V
+.             2014 X370000-0    Ba De Lo Ni        005 --     G4V M6V
 .             2414 X545000-0    Ba Lo Ni           000 --     F0V 
 .             2714 X457000-0    Ba Lo Ni           013 --     F8V 
 .             2814 X433000-0    Ba Lo Ni Po        012 --     G2II 
@@ -124,27 +124,27 @@ Finggvakhou
 .             0915 X665000-0    Ba Lo Ni           014 --     F0V 
 .             2615 X75A000-0    Ba Lo Ni Wa        012 --     F0V 
 .             2815 X7B0000-0    Ba De Lo Ni        023 --     F0III 
-.             0216 X451000-0    Ba Lo Ni Po        014 --     F2V M0D 
+.             0216 X451000-0    Ba Lo Ni Po        014 --     F2V M0V
 .             1116 X8B2000-0    Ba Fl Lo Ni        001 --     K3V 
 .             1616 XAD2000-0    Ba Fl Lo Ni        003 --     M7V 
-.             1916 X356000-0    Ba Lo Ni           003 --     F4V M8D 
+.             1916 X356000-0    Ba Lo Ni           003 --     F4V M8V
 .             2016 X320000-0    Ba De Lo Ni Po     011 --     M4V 
-.             0217 X110000-0    Ba Lo Ni           003 --     K2V M0D 
-.             1617 X310000-0    Ba Lo Ni           003 --     M8V M4D 
+.             0217 X110000-0    Ba Lo Ni           003 --     K2V M0V
+.             1617 X310000-0    Ba Lo Ni           003 --     M4V M8V
 .             1917 X344000-0    Ba Lo Ni           002 --     F3V 
-.             2017 X333000-0    Ba Lo Ni Po        002 --     M5V M0D 
+.             2017 X333000-0    Ba Lo Ni Po        002 --     M5V M0V
 .             2317 X575000-0    Ba Lo Ni           000 --     F4V 
 .             2617 X322000-0    Ba Lo Ni Po        004 --     M7V 
-.             0318 X402000-0    Ba Ic Lo Ni Va     015 --     M7V M1D 
-.             0618 X356000-0    Ba Lo Ni           005 --     F5V M8D 
+.             0318 X402000-0    Ba Ic Lo Ni Va     015 --     M1V M7V
+.             0618 X356000-0    Ba Lo Ni           005 --     F5V M8V
 .             0918 X496000-0    Ba Lo Ni           004 --     K6V 
-.             1218 X612000-0    Ba Ic Lo Ni        006 --     M5V M4D 
+.             1218 X612000-0    Ba Ic Lo Ni        006 --     M4V M5V
 .             1418 X544000-0    Ba Lo Ni           014 --     K3V 
 .             1818 X100000-0    Ba Lo Ni Va        003 --     M0V 
 .             2918 X576000-0    Ba Lo Ni           000 --     F7V 
 .             3118 X586000-0    Ba Lo Ni           001 --     F3V 
 .             3218 X878000-0    Ba Lo Ni           012 --     F7V 
-.             0119 X788000-0    Ba Lo Ni           015 --     F2V M5D 
+.             0119 X788000-0    Ba Lo Ni           015 --     F2V M5V
 .             0819 X500000-0    Ba Lo Ni Va        014 --     M7V 
 .             2319 X100000-0    Ba Lo Ni Va        001 --     M5V 
 .             0120 X453000-0    Ba Lo Ni Po        004 --     K6V 
@@ -153,162 +153,162 @@ Finggvakhou
 .             0720 XA8A000-0    Ba Lo Ni Wa        011 --     F4V 
 .             0920 X337000-0    Ba Lo Ni           003 --     G3V 
 .             1320 X699000-0    Ba Lo Ni           010 --     F1V 
-.             1420 X7A2000-0    Ba Fl Lo Ni        006 --     G1V M4D 
-.             1820 X9C3000-0    Ba Fl Lo Ni        006 --     G9V M2D 
+.             1420 X7A2000-0    Ba Fl Lo Ni        006 --     G1V M4V
+.             1820 X9C3000-0    Ba Fl Lo Ni        006 --     G9V M2V
 .             2220 X746000-0    Ba Lo Ni           014 --     F9V 
-.             3120 X432000-0    Ba Lo Ni Po        020 --     M6III M5D 
-.             3220 X887000-0    Ba Lo Ni           005 --     F5V M0D 
+.             3120 X432000-0    Ba Lo Ni Po        020 --     M6III M5V
+.             3220 X887000-0    Ba Lo Ni           005 --     F5V M0V
 .             0121 X976000-0    Ba Lo Ni           020 --     G8V 
-.             0321 X474000-0    Ba Lo Ni           015 --     G5V M3D 
+.             0321 X474000-0    Ba Lo Ni           015 --     G5V M3V
 .             1421 X200000-0    Ba Lo Ni Va        004 --     M7V 
 .             1521 X654000-0    Ba Lo Ni           002 --     F1V 
-.             1721 X230000-0    Ba De Lo Ni Po     002 --     M7V M2D 
+.             1721 X230000-0    Ba De Lo Ni Po     002 --     M2V M7V
 .             2421 X651000-0    Ba Lo Ni Po        012 --     F5V M0V 
 .             2621 X542000-0    Ba Lo Ni Po        002 --     F6V 
-.             0222 X9D2000-0    Ba Fl Lo Ni        001 --     M1V M3D 
+.             0222 X9D2000-0    Ba Fl Lo Ni        001 --     M1V M3V
 .             0322 X453000-0    Ba Lo Ni Po        005 --     F9V 
-.             0722 X262000-0    Ba Lo Ni           022 --     F5V M8D 
-.             0822 X9D6000-0    Ba Fl Lo Ni        016 --     M8V M0V 
+.             0722 X262000-0    Ba Lo Ni           022 --     F5V M8V
+.             0822 X9D6000-0    Ba Fl Lo Ni        016 --     M0V M8V
 .             1722 X140000-0    Ba De Lo Ni Po     001 --     F3V 
 .             2022 X8C2000-0    Ba Fl Lo Ni        002 --     F6V 
-.             2122 X355000-0    Ba Lo Ni           02A --     F1V M7D M6D 
+.             2122 X355000-0    Ba Lo Ni           02A --     F1V M7V M6V
 .             2522 X000000-0    As Ba Lo Ni        003 --     F4III 
 .             2922 X120000-0    Ba De Lo Ni Po     020 --     K5II 
-.             3122 X200000-0    Ba Lo Ni Va        008 --     M7V M4D 
+.             3122 X200000-0    Ba Lo Ni Va        008 --     M4V M7V
 .             0223 X439000-0    Ba Lo Ni           013 --     K0V 
 .             0723 X100000-0    Ba Lo Ni Va        003 --     M5V 
 .             1123 X755000-0    Ba Lo Ni           003 --     F9V 
-.             1223 X343000-0    Ba Lo Ni Po        004 --     M8V M1D 
-.             2523 X110000-0    Ba Lo Ni           004 --     M2V M2D 
+.             1223 X343000-0    Ba Lo Ni Po        004 --     M1V M8V
+.             2523 X110000-0    Ba Lo Ni           004 --     M2V M2V
 .             2723 X423000-0    Ba Lo Ni Po        004 --     M5III 
-.             3023 X548000-0    Ba Lo Ni           003 --     F1V M4D 
-.             3123 X370000-0    Ba De Lo Ni        024 --     F6V M0D 
-.             0124 X8C5000-0    Ba Fl Lo Ni        002 --     M5V M2D 
+.             3023 X548000-0    Ba Lo Ni           003 --     F1V M4V
+.             3123 X370000-0    Ba De Lo Ni        024 --     F6V M0V
+.             0124 X8C5000-0    Ba Fl Lo Ni        002 --     M2V M5V
 .             0224 X789000-0    Ba Lo Ni           001 --     F2V 
-.             0624 X678000-0    Ba Lo Ni           004 --     F5V M5D 
+.             0624 X678000-0    Ba Lo Ni           004 --     F5V M5V
 .             1324 X697000-0    Ba Lo Ni           002 --     F8V 
 .             1624 X556000-0    Ba Lo Ni           004 --     M7V 
 .             1724 X335000-0    Ba Lo Ni           003 --     M6V 
 .             2324 X546000-0    Ba Lo Ni           003 --     F1V 
 .             2424 X454000-0    Ba Lo Ni           024 --     F6V 
 .             2924 X54A000-0    Ba Lo Ni Wa        012 --     F9V 
-.             3024 X345000-0    Ba Lo Ni           015 --     F7V M1D 
+.             3024 X345000-0    Ba Lo Ni           015 --     F7V M1V
 .             0725 X7C2000-0    Ba Fl Lo Ni        003 --     M4V 
 .             0825 X656000-0    Ba Lo Ni           000 --     G6V 
-.             1825 X565000-0    Ba Lo Ni           000 --     F8V M8D 
+.             1825 X565000-0    Ba Lo Ni           000 --     F8V M8V
 .             2025 X200000-0    Ba Lo Ni Va        000 --     F4V 
 .             3125 X682000-0    Ba Lo Ni           010 --     K2V 
-.             1026 X776000-0    Ba Lo Ni           003 --     F8V M6D 
-.             2026 X200000-0    Ba Lo Ni Va        002 --     F7V M6D 
+.             1026 X776000-0    Ba Lo Ni           003 --     F8V M6V
+.             2026 X200000-0    Ba Lo Ni Va        002 --     F7V M6V
 .             2426 X400000-0    Ba Lo Ni Va        000 --     M1V 
 .             2826 X788000-0    Ba Lo Ni           003 --     F3V 
 .             0327 X335000-0    Ba Lo Ni           005 --     M4V 
-.             1127 X7B2000-0    Ba Fl Lo Ni        020 --     A4V M1D 
+.             1127 X7B2000-0    Ba Fl Lo Ni        020 --     A4V M1V
 .             2427 X223000-0    Ba Lo Ni Po        001 --     K5V 
-.             2627 XA89000-0    Ba Lo Ni           004 --     F7V M4D 
+.             2627 XA89000-0    Ba Lo Ni           004 --     F7V M4V
 .             2927 X769000-0    Ba Lo Ni           024 --     F4V 
-.             0228 X948000-0    Ba Lo Ni           002 --     F4V M0D 
-.             0828 X756000-0    Ba Lo Ni           004 --     F7V M3D 
-.             1628 X687000-0    Ba Lo Ni           000 --     F4V M8D 
-.             1728 X8D0000-0    Ba De Lo Ni        004 --     K7V M5V 
+.             0228 X948000-0    Ba Lo Ni           002 --     F4V M0V
+.             0828 X756000-0    Ba Lo Ni           004 --     F7V M3V
+.             1628 X687000-0    Ba Lo Ni           000 --     F4V M8V
+.             1728 X8D0000-0    Ba De Lo Ni        004 --     K7V M5V
 .             2328 X437000-0    Ba Lo Ni           001 --     K0V 
 .             2428 X442000-0    Ba Lo Ni Po        023 --     F5V 
 .             3028 X536000-0    Ba Lo Ni           005 --     K0V 
-.             0329 X454000-0    Ba Lo Ni           013 --     F2V M2V 
+.             0329 X454000-0    Ba Lo Ni           013 --     F2V M2V
 .             0529 X689000-0    Ba Lo Ni           004 --     F3V 
 .             0829 X346000-0    Ba Lo Ni           004 --     M5V 
-.             1229 X471000-0    Ba Lo Ni           003 --     F8V M2D 
+.             1229 X471000-0    Ba Lo Ni           003 --     F8V M2V
 .             1729 X100000-0    Ba Lo Ni Va        003 --     M4V 
-.             1829 X589000-0    Ba Lo Ni           002 --     M1V M0D 
-.             2329 X97A000-0    Ba Lo Ni Wa        003 --     F3V M4D 
-.             2529 X8B2000-0    Ba Fl Lo Ni        004 --     M4V M6D 
+.             1829 X589000-0    Ba Lo Ni           002 --     M0V M1V
+.             2329 X97A000-0    Ba Lo Ni Wa        003 --     F3V M4V
+.             2529 X8B2000-0    Ba Fl Lo Ni        004 --     M4V M6V
 .             2629 X340000-0    Ba De Lo Ni Po     003 --     F5V 
-.             3129 X300000-0    Ba Lo Ni Va        003 --     F1V M8D 
+.             3129 X300000-0    Ba Lo Ni Va        003 --     F1V M8V
 .             3229 X6A0000-0    Ba De Lo Ni        013 --     G2V 
 .             0330 X886000-0    Ba Lo Ni           011 --     M7V 
-.             0730 XAB5000-0    Ba Fl Lo Ni        004 --     M7V M1V 
+.             0730 XAB5000-0    Ba Fl Lo Ni        004 --     M1V M7V
 .             0930 X643000-0    Ba Lo Ni Po        014 --     M8V 
-.             1530 X884000-0    Ba Lo Ni           003 --     F8V M7V 
+.             1530 X884000-0    Ba Lo Ni           003 --     F8V M7V
 .             1630 X695000-0    Ba Lo Ni           001 --     K1V 
 .             1930 XA58000-0    Ba Lo Ni           021 --     F4V 
-.             2230 X737000-0    Ba Lo Ni           018 --     M6V M8D 
-.             2930 X254000-0    Ba Lo Ni           002 --     F7V M2D 
+.             2230 X737000-0    Ba Lo Ni           018 --     M6V M8V
+.             2930 X254000-0    Ba Lo Ni           002 --     F7V M2V
 .             0331 X7A3000-0    Ba Fl Lo Ni        011 --     K6V 
-.             0531 X687000-0    Ba Lo Ni           002 --     F7V M5D 
-.             0931 X576000-0    Ba Lo Ni           003 --     F7V M7D 
+.             0531 X687000-0    Ba Lo Ni           002 --     F7V M5V
+.             0931 X576000-0    Ba Lo Ni           003 --     F7V M7V
 .             1931 X669000-0    Ba Lo Ni           001 --     M2V 
 .             3031 X64A000-0    Ba Lo Ni Wa        003 --     F9V 
-.             0832 X566000-0    Ba Lo Ni           023 --     F7V M6D 
-.             1032 X7C0000-0    Ba De Lo Ni        006 --     K9V M1D 
+.             0832 X566000-0    Ba Lo Ni           023 --     F7V M6V
+.             1032 X7C0000-0    Ba De Lo Ni        006 --     K9V M1V
 .             1232 X567000-0    Ba Lo Ni           013 --     F5V 
 .             1332 X300000-0    Ba Lo Ni Va        004 --     F7V 
-.             1932 X441000-0    Ba Lo Ni Po        042 --     F4V M7D 
-.             2432 X768000-0    Ba Lo Ni           002 --     F9V M8D 
-.             3232 X304000-0    Ba Ic Lo Ni Va     01A --     M3V M1V F7D 
+.             1932 X441000-0    Ba Lo Ni Po        042 --     F4V M7V
+.             2432 X768000-0    Ba Lo Ni           002 --     F9V M8V
+.             3232 X304000-0    Ba Ic Lo Ni Va     01A --     F7V M1V M3V
 .             0333 X846000-0    Ba Lo Ni           003 --     F0V 
 .             1333 X311000-0    Ba Ic Lo Ni        003 --     M8V 
-.             1533 X100000-0    Ba Lo Ni Va        004 --     M0V M6D 
+.             1533 X100000-0    Ba Lo Ni Va        004 --     M0V M6V
 .             1633 X130000-0    Ba De Lo Ni Po     002 --     K1V 
 .             1933 X641000-0    Ba Lo Ni Po        011 --     G8V 
 .             0134 X420000-0    Ba De Lo Ni Po     004 --     M4V 
 .             0234 X442000-0    Ba Lo Ni Po        004 --     F8V 
 .             1034 X324000-0    Ba Lo Ni           003 --     M7V 
-.             1134 X763000-0    Ba Lo Ni           002 --     F5V M8D 
+.             1134 X763000-0    Ba Lo Ni           002 --     F5V M8V
 .             1434 X200000-0    Ba Lo Ni Va        003 --     A3V 
 .             1834 X465000-0    Ba Lo Ni           003 --     G6V 
-.             1934 X654000-0    Ba Lo Ni           004 --     M5V M1D 
-.             2734 X310000-0    Ba Lo Ni           004 --     M8V M8V 
-.             0435 X649000-0    Ba Lo Ni           013 --     F4V M7D 
-.             1135 X567000-0    Ba Lo Ni           002 --     F2V M2D 
-.             1435 X9B3000-0    Ba Fl Lo Ni        002 --     M3V M2D M4V 
-.             1535 X785000-0    Ba Lo Ni           000 --     F9V M3D 
+.             1934 X654000-0    Ba Lo Ni           004 --     M1V M5V
+.             2734 X310000-0    Ba Lo Ni           004 --     M8V M8V
+.             0435 X649000-0    Ba Lo Ni           013 --     F4V M7V
+.             1135 X567000-0    Ba Lo Ni           002 --     F2V M2V
+.             1435 X9B3000-0    Ba Fl Lo Ni        002 --     M2V M3V M4V
+.             1535 X785000-0    Ba Lo Ni           000 --     F9V M3V
 .             1835 X694000-0    Ba Lo Ni           002 --     F5V 
 .             1935 X230000-0    Ba De Lo Ni Po     004 --     F3V 
 .             2135 X7A2000-0    Ba Fl Lo Ni        000 --     K0IV 
 .             2335 X100000-0    Ba Lo Ni Va        003 --     G8V 
-.             2435 X450000-0    Ba De Lo Ni Po     003 --     F5V M2D 
-.             2835 X989000-0    Ba Lo Ni           002 --     F7V M2D 
+.             2435 X450000-0    Ba De Lo Ni Po     003 --     F5V M2V
+.             2835 X989000-0    Ba Lo Ni           002 --     F7V M2V
 .             2935 X455000-0    Ba Lo Ni           000 --     G0V 
-.             3135 X839000-0    Ba Lo Ni           014 --     G6V M7D 
+.             3135 X839000-0    Ba Lo Ni           014 --     G6V M7V
 .             3235 X355000-0    Ba Lo Ni           002 --     F1V 
-.             0636 X428000-0    Ba Lo Ni           006 --     K8V M8D 
+.             0636 X428000-0    Ba Lo Ni           006 --     K8V M8V
 .             0836 X302000-0    Ba Ic Lo Ni Va     000 --     F6V 
-.             0936 X856000-0    Ba Lo Ni           000 --     F3V M0D 
+.             0936 X856000-0    Ba Lo Ni           000 --     F3V M0V
 .             1036 X454000-0    Ba Lo Ni           003 --     F0V 
 .             1236 XAA7000-0    Ba Fl Lo Ni        001 --     F9V 
 .             1436 X100000-0    Ba Lo Ni Va        002 --     A5V 
-.             1636 X676000-0    Ba Lo Ni           004 --     F5V M3D 
+.             1636 X676000-0    Ba Lo Ni           004 --     F5V M3V
 .             2136 X324000-0    Ba Lo Ni           003 --     K9II M4V 
-.             2236 X547000-0    Ba Lo Ni           015 --     F8V M0D 
+.             2236 X547000-0    Ba Lo Ni           015 --     F8V M0V
 .             2336 X547000-0    Ba Lo Ni           002 --     G2V 
 .             3036 X591000-0    Ba Lo Ni           000 --     G6V 
-.             1137 X8B6000-0    Ba Fl Lo Ni        002 --     M5V M4V M1V 
-.             1237 X461000-0    Ba Lo Ni           014 --     F8V M0V M0D 
-.             1737 X769000-0    Ba Lo Ni           013 --     G0V M1D 
-.             2537 X431000-0    Ba Lo Ni Po        000 --     M1V M8D 
+.             1137 X8B6000-0    Ba Fl Lo Ni        002 --     M1V M4V M5V
+.             1237 X461000-0    Ba Lo Ni           014 --     F8V M0V M0V
+.             1737 X769000-0    Ba Lo Ni           013 --     G0V M1V
+.             2537 X431000-0    Ba Lo Ni Po        000 --     M1V M8V
 .             3137 X782000-0    Ba Lo Ni           001 --     G0V 
 .             0438 X446000-0    Ba Lo Ni           004 --     M0V 
-.             0638 X212000-0    Ba Ic Lo Ni        014 --     G2V M3D 
+.             0638 X212000-0    Ba Ic Lo Ni        014 --     G2V M3V
 .             0738 X746000-0    Ba Lo Ni           002 --     M4V 
 .             0938 X55A000-0    Ba Lo Ni Wa        013 --     F6V 
 .             1038 X874000-0    Ba Lo Ni           002 --     M3V 
 .             1338 X495000-0    Ba Lo Ni           000 --     F8V 
-.             1438 X9A3000-0    Ba Fl Lo Ni        004 --     M0V M5D 
-.             1538 X869000-0    Ba Lo Ni           001 --     M4V M1D 
+.             1438 X9A3000-0    Ba Fl Lo Ni        004 --     M0V M5V
+.             1538 X869000-0    Ba Lo Ni           001 --     M1V M4V
 .             2238 X580000-0    Ba De Lo Ni        023 --     G7V 
 .             3038 X464000-0    Ba Lo Ni           003 --     F5V 
-.             3238 X546000-0    Ba Lo Ni           011 --     F8V M2D 
-.             0339 X655000-0    Ba Lo Ni           001 --     F9V M4D 
+.             3238 X546000-0    Ba Lo Ni           011 --     F8V M2V
+.             0339 X655000-0    Ba Lo Ni           001 --     F9V M4V
 .             0439 X655000-0    Ba Lo Ni           004 --     F8V 
-.             0739 X469000-0    Ba Lo Ni           007 --     K2V M1D 
-.             0839 X98A000-0    Ba Lo Ni Wa        002 --     F4V M5D 
-.             1239 X481000-0    Ba Lo Ni           025 --     K5V M1D 
+.             0739 X469000-0    Ba Lo Ni           007 --     K2V M1V
+.             0839 X98A000-0    Ba Lo Ni Wa        002 --     F4V M5V
+.             1239 X481000-0    Ba Lo Ni           025 --     K5V M1V
 .             1539 X565000-0    Ba Lo Ni           003 --     F7V 
 .             1839 X330000-0    Ba De Lo Ni Po     005 --     G9V 
-.             2239 X776000-0    Ba Lo Ni           016 --     F6V M7D F0V M2D 
+.             2239 X776000-0    Ba Lo Ni           016 --     F0V M7V F6V M2V
 .             2739 X443000-0    Ba Lo Ni Po        000 --     F4V 
 .             2939 X679000-0    Ba Lo Ni           012 --     F3V 
 .             3139 X110000-0    Ba Lo Ni           002 --     M6V 
 .             0540 X200000-0    Ba Lo Ni Va        012 --     K2V 
-.             2740 X97A000-0    Ba Lo Ni Wa        012 --     F6V M3D 
+.             2740 X97A000-0    Ba Lo Ni Wa        012 --     F6V M3V
 .             2940 X212000-0    Ba Ic Lo Ni        000 --     M3V 

--- a/res/Sectors/M1105/Gelath.sec
+++ b/res/Sectors/M1105/Gelath.sec
@@ -14,31 +14,31 @@ Gelath
 #--------1---------2---------3---------4---------5---------6---
 #PlanetName   Loc. UPP Code   B   Notes         Z  PBG Al LRX *
 #----------   ---- ---------  - --------------- -  --- -- --- -
-Thaekkhon     0201 B658201-A  G Lo Ni              504 Va     F0V M0D 
-Gaerrar       0301 C00047C-6    As Ni              105 Va     M6D 
+Thaekkhon     0201 B658201-A  G Lo Ni              504 Va     F0V M0V
+Gaerrar       0301 C00047C-6    As Ni              105 Va     M6V
 Gvuksoul      0501 E200334-5    Lo Ni Va           613 Va     K0V 
 Segvuer       0601 A768644-B  G Ag Ni Ri           301 Va     M2V 
 Kerrghoul     1001 B130520-B    De Ni Po           302 Va     M0V 
 Ligadhell     1101 C57326A-3    Lo Ni              300 Va     K0V 
 Kuksdarsors   1701 E200412-7  C Ni Va              303 Va     M0V 
-Voksghors     1801 E575358-5  C Lo Ni              504 Va     G2V M1D 
+Voksghors     1801 E575358-5  C Lo Ni              504 Va     G2V M1V
 Ngaellaen     2301 D563454-1  C Ni                 922 Va     F4V 
 Fogighz       2401 B676755-9  G Ag                 802 Va     K4V 
-Songoenougz   2601 C567844-4    Ri                 104 Va     F8V M5D 
+Songoenougz   2601 C567844-4    Ri                 104 Va     F8V M5V
 Ghoughue      2901 B345572-9    Ag Ni              603 Va     F8V 
 Aevueghztoz   0102 E958103-3    Lo Ni              413 Va     F3V 
 Ghugzorr      0202 C30068D-E  K Na Ni Va           220 KO     M3V 
 K'grghu       0402 C545364-E    Lo Ni              902 KO     M5V 
-Vokskhon      0602 A689535-A  C Ni                 725 Va     F5V M3D 
-Kua           0802 C8746A6-F    Ag Ni              322 KO     F3V M0D 
-Gheksaesag    1002 B200330-B  G Lo Ni Va           909 Va     M1V M5D K5V 
+Vokskhon      0602 A689535-A  C Ni                 725 Va     F5V M3V
+Kua           0802 C8746A6-F    Ag Ni              322 KO     F3V M0V
+Gheksaesag    1002 B200330-B  G Lo Ni Va           909 Va     M1V M5V K5V
 Dzagzsurrgh   1102 X686566-0  C Ag Ni              812 Va     F0V 
 N'rr'r        1402 D594200-7  K Lo Ni              612 KO     F9V 
-Verrghoukh    1902 C572568-7    Ni                 818 Va     G2V M7D 
+Verrghoukh    1902 C572568-7    Ni                 818 Va     G2V M7V
 Llezugz       2302 C000424-8    As Ni              102 Va     M5V 
-Kaegnakengoz  2402 D9A4369-3  C Fl Lo Ni           714 Va     M5V M6V M3D 
-Orksaerrgaer  2602 C556524-4    Ag Ni              904 Va     F1V M1D 
-Ezaksgvakhs   2702 C88A520-6    Ni Wa              503 Va     F7V M7D 
+Kaegnakengoz  2402 D9A4369-3  C Fl Lo Ni           714 Va     M5V M6V M3V
+Orksaerrgaer  2602 C556524-4    Ag Ni              904 Va     F1V M1V
+Ezaksgvakhs   2702 C88A520-6    Ni Wa              503 Va     F7V M7V
 Knukskurrig   3202 B888463-5  G Ni                 103 Va     F0V 
 Nuumir        0203 B000650-F  O As Na Ni           302 KO     M6V 
 Eekrikixik    0403 D300346-A  K Lo Ni Va           102 KO     G1V 
@@ -46,110 +46,110 @@ Urriit'rr     0503 B350434-D  O De Ni Po           812 KO     F7V
 Ruooma        0903 C656525-D  K Ag Ni              805 KO     K0V 
 Kirutar       1003 B9C4799-F  K Fl                 304 KO     F8V M4V 
 Kkiki         1303 C300200-E  K Lo Ni Va           300 KO     M3V 
-Gniiniir      1403 B410687-D  K Na Ni              602 KO     M0V M4D 
+Gniiniir      1403 B410687-D  K Na Ni              602 KO     M0V M4V
 Ksalloghuek   1803 D250310-5    De Lo Ni Po        902 Va     M4V 
-Gurvugz       1903 E457698-6    Ag Ni              404 Va     F7V M3D 
-Dueksaeng     2003 B200401-9    Ni Va              404 Va     M4V M1D 
-Ghekhoutharr  2203 B310647-A  G Na Ni              600 Va     M1V M3D 
+Gurvugz       1903 E457698-6    Ag Ni              404 Va     F7V M3V
+Dueksaeng     2003 B200401-9    Ni Va              404 Va     M1V M4V
+Ghekhoutharr  2203 B310647-A  G Na Ni              600 Va     M1V M3V
 Kugorsirrg    2303 B452200-7  H Lo Ni Po           715 Va     K8V 
 Garag         2403 E544103-3    Lo Ni              113 Va     F2V 
 Gukhsorr      2703 C437665-5    Ni                 902 Va     M6V 
-Gekfokh       3003 D76977B-2                       702 Va     F3V M6D 
-Thogagung     3203 C53889B-7                       400 Va     F5V M0D 
+Gekfokh       3003 D76977B-2                       702 Va     F3V M6V
+Thogagung     3203 C53889B-7                       400 Va     F5V M0V
 !!gr'iikang   0204 C1209B7-F  K De Hi In Na Po     902 KO     F1V 
 Ku!!kighaal   0504 A000320-D  K As Lo Ni           103 KO     F9III K4V 
 Aat Nokr K'ng 0704 C655000-B  O Ba Lo Ni           203 KO     F1V 
-!!rit         1204 C254242-B  K Lo Ni              915 KO     M5V M0D 
-Oo!'r         1304 CA96234-B    Lo Ni              203 KO     F2V M2D 
-Aanuureerr!k  1704 C7787BC-F  K Ag                 801 KO     M4V M7D 
-Koeganggvag   1904 B58A468-A    Ni Wa              305 Va     F7V M5D 
+!!rit         1204 C254242-B  K Lo Ni              915 KO     M0V M5V
+Oo!'r         1304 CA96234-B    Lo Ni              203 KO     F2V M2V
+Aanuureerr!k  1704 C7787BC-F  K Ag                 801 KO     M4V M7V
+Koeganggvag   1904 B58A468-A    Ni Wa              305 Va     F7V M5V
 Khorotsekhel  2004 C346554-B    Ag Ni              211 Va     F3V 
 Thaegun       2104 E588795-2  C Ag Ri              214 Va     F6V 
-Ngasokkuz     2204 C796000-5    Ba Lo Ni           203 Va     F7V M2D 
+Ngasokkuz     2204 C796000-5    Ba Lo Ni           203 Va     F7V M2V
 Gvueltie      2304 E888677-4    Ag Ni              901 Va     G3V 
 Gzangularr    2904 BAA5976-D    Fl Hi In           200 Va     F3V 
 Kivuerzgvok   3104 C328789-5                       505 Va     F5V M4V 
 Sorrurrgar    3204 B443879-7    Po                 500 Va     F0V 
 Lilil         0205 E300657-A    Na Ni Va           104 KO     G1V 
-Nane          0405 C320362-D  K De Lo Ni Po        104 KO     M0V M5D 
-Gnigh'kr'guu  0505 C47456A-C  K Ag Ni              604 KO     F9V M6D 
+Nane          0405 C320362-D  K De Lo Ni Po        104 KO     M0V M5V
+Gnigh'kr'guu  0505 C47456A-C  K Ag Ni              604 KO     F9V M6V
 Gniikib       0805 X6A0462-0    De Ni              305 KO     M3V 
-Riruur!'murr  1205 C5A38BD-E  K Fl                 403 KO     F5V M6D 
-Kritiiruung   1705 C100223-C    Lo Ni Va           402 KO     M5V M1V 
-Raengtaeng    2105 C330521-5  C De Ni Po           902 Va     M6V M1D 
+Riruur!'murr  1205 C5A38BD-E  K Fl                 403 KO     F5V M6V
+Kritiiruung   1705 C100223-C    Lo Ni Va           402 KO     M1V M5V
+Raengtaeng    2105 C330521-5  C De Ni Po           902 Va     M1V M6V
 Guerskouz     2705 C330585-5    De Ni Po           403 Va     K6V 
-Fozoekh       2905 C552676-4  C Ni Po              421 Va     F5V M7D 
-Foenong       3005 C300001-7  G Lo Ni Va           311 Va     M1V M1D 
+Fozoekh       2905 C552676-4  C Ni Po              421 Va     F5V M7V
+Foenong       3005 C300001-7  G Lo Ni Va           311 Va     M1V M1V
 Kharok        3105 B57778A-9  G Ag                 404 Va     G3V 
-Ur!nuunguur   0306 C140100-B  K De Lo Ni Po        614 KO     F1V M7D 
-Rroonigirim   0406 E566747-A    Ag Ri              822 KO     F8V M1D 
+Ur!nuunguur   0306 C140100-B  K De Lo Ni Po        614 KO     F1V M7V
+Rroonigirim   0406 E566747-A    Ag Ri              822 KO     F8V M1V
 Krix!l!'r'p   0506 C666344-C  K Lo Ni              901 KO     F1V 
 Grigmiir'm    0606 C9AA776-D  O Fl Wa              602 KO     M6V 
-Kur'gh!l      0806 B776312-E  K Lo Ni              314 KO     G0V M4D 
+Kur'gh!l      0806 B776312-E  K Lo Ni              314 KO     G0V M4V
 Griruukr      0906 E985454-B  K Ni                 300 KO     F4V 
-Kreengit'kr   1006 B200234-E    Lo Ni Va           412 KO     M3V M6D 
-Inaar         1206 X878542-1    Ag Ni              305 KO     F6V M3D M4V 
+Kreengit'kr   1006 B200234-E    Lo Ni Va           412 KO     M3V M6V
+Inaar         1206 X878542-1    Ag Ni              305 KO     F6V M3V M4V
 Neghoorrik    1806 E3307CE-F  K De Na Po           101 KO     M5V 
-Gnafe         2006 D323872-5    Na Po              212 Va     F9V M1D 
-Thugae        2206 E637697-1    Ni                 504 Va     M1V M0V M4D 
-Dungkhak      2306 E22336A-5  C Lo Ni Po           902 Va     F6V M8D 
-Rarulguerr    2506 B75A877-B  G Wa                 403 Va     F4V M8D 
+Gnafe         2006 D323872-5    Na Po              212 Va     F9V M1V
+Thugae        2206 E637697-1    Ni                 504 Va     M1V M0V M4V
+Dungkhak      2306 E22336A-5  C Lo Ni Po           902 Va     F6V M8V
+Rarulguerr    2506 B75A877-B  G Wa                 403 Va     F4V M8V
 Vaegrokae     2706 B885865-4  G Ri                 703 Va     M2V 
 Gaksaoegkaeg  3006 A8A5873-A  G Fl                 811 Va     F2V 
 Gzatharuz     3206 C00066A-5    As Na Ni           910 Va     M4II K7V 
 Gn!r'kk'ok    0807 E223000-A  K Ba Lo Ni Po        902 KO     M0V 
 N!r'          1007 C42766A-E  K Ni                 904 KO     M1V 
-Gr'r!         1107 C000555-B  K As Ni              205 KO     F5IV M7D 
-Poonooruur    1607 A224796-F  O                    405 KO     M5V M5D 
-R'krugh       1707 BA8A203-F  O Lo Ni Wa           900 KO     K0V M3D 
+Gr'r!         1107 C000555-B  K As Ni              205 KO     F5IV M7V
+Poonooruur    1607 A224796-F  O                    405 KO     M5V M5V
+R'krugh       1707 BA8A203-F  O Lo Ni Wa           900 KO     K0V M3V
 Ksokae        2007 C9A5A75-C    Fl Hi In           201 Va     F4V 
 Gzaedors      2107 A223400-B  G Ni Po              102 Va     M0V 
 Gudhaerrghon  2207 C87848D-5    Ni                 200 Va     F9V 
 Rudhkorsdael  2507 B301858-B    Ic Na Va           303 Va     K5V 
 Gaersfezforr  2707 D432100-8  C Lo Ni Po           704 Va     M4II 
-Rrugzazighz   3007 C86A322-6  G Lo Ni Wa           314 Va     F2V M7D 
-Ksughzorall   3107 D564403-5  H Ni                 301 Va     F8V M3D F0V 
-Lakrux        0508 C547555-E    Ag Ni              403 KO     F7V M7D 
-L!grikr't     0808 E100005-8    Lo Ni Va           314 KO     M3V M7D 
+Rrugzazighz   3007 C86A322-6  G Lo Ni Wa           314 Va     F2V M7V
+Ksughzorall   3107 D564403-5  H Ni                 301 Va     F8V M3V F0V
+Lakrux        0508 C547555-E    Ag Ni              403 KO     F7V M7V
+L!grikr't     0808 E100005-8    Lo Ni Va           314 KO     M3V M7V
 Kku!!raan     1008 C772785-E  K                    903 KO     F1V 
-Kignuux!'r    1108 E584200-C  K Lo Ni              200 KO     F7V M8D 
-Booghiir      1708 C335677-D  O Ni                 101 KO     K3V M5D 
+Kignuux!'r    1108 E584200-C  K Lo Ni              200 KO     F7V M8V
+Booghiir      1708 C335677-D  O Ni                 101 KO     K3V M5V
 Gvoedzue      2008 A160115-D  G De Lo Ni           203 Va     F7V 
 Kegaedhegh    2108 C8B5516-3    Fl Ni              713 Va     F5IV 
 Rorrdholkok   2308 C446575-5    Ag Ni              102 Va     F1V 
-Rrouruen      2808 B100446-A  G Ni Va              416 Va     M7V M6D M6D 
+Rrouruen      2808 B100446-A  G Ni Va              416 Va     M7V M6V M6V
 Ghiug         2908 B89A7A9-B  G Wa                 501 Va     F5V 
 Gniku         0309 C440766-F    De Po              500 KO     F5V 
 K'gaar        0509 C743233-D  K Lo Ni Po           802 KO     F0V 
-Riirrik!kuk   1309 E200000-8    Ba Lo Ni Va        901 KO     M5V M5D 
-Lupi          1609 C200000-9  K Ba Lo Ni Va        801 KO     M5V M6D 
-Reekeex'      1709 E410100-8  K Lo Ni              900 KO     F6V M8D 
+Riirrik!kuk   1309 E200000-8    Ba Lo Ni Va        901 KO     M5V M5V
+Lupi          1609 C200000-9  K Ba Lo Ni Va        801 KO     M5V M6V
+Reekeex'      1709 E410100-8  K Lo Ni              900 KO     F6V M8V
 Teetaarr'ng   1809 C4429BB-F  K Hi In Po           212 KO     F9V 
 Kuroeku       2109 A785000-9  G Ba Lo Ni           310 Va     M4V 
 Ruedouroes    2209 B867321-4    Lo Ni              701 Va     F5V 
-Aenforrghodh  2309 D688677-0  C Ag Ni              608 Va     M2V M3D 
+Aenforrghodh  2309 D688677-0  C Ag Ni              608 Va     M2V M3V
 Tutheziks     2709 D241452-6    Ni Po              304 Va     M6V 
-Zouzangrerz   2809 C7A5230-6  G Fl Lo Ni           602 Va     M8V M7D 
+Zouzangrerz   2809 C7A5230-6  G Fl Lo Ni           602 Va     M7V M8V
 Lurrngoek     2909 B467111-B    Lo Ni              421 Va     F1V 
 Aruughop      0210 C1309CB-F  K De Hi In Na Po     400 KO     K9V 
-Akukrureb     0510 C663565-F  O Ag Ni              943 KO     F0V M5D 
+Akukrureb     0510 C663565-F  O Ag Ni              943 KO     F0V M5V
 N'kaxk        0710 B347566-D    Ag Ni              823 KO     G1V 
 Koxamikr!'p   0910 A485789-F  K Ag Ri              622 KO     F8V 
 G'xroonguuk   1210 X4249EF-2  K Hi In              700 KO     F0V 
 Ug!           1510 D888320-7  O Lo Ni              203 KO     F6V 
-Lexkooga      1710 E550130-C    De Lo Ni Po        613 KO     F2V M0D 
-Utakeerin     0311 D759751-F  K                    804 KO     F3V M7D 
-Kamookr       0411 D222534-D  K Ni Po              706 KO     M6V M1D 
+Lexkooga      1710 E550130-C    De Lo Ni Po        613 KO     F2V M0V
+Utakeerin     0311 D759751-F  K                    804 KO     F3V M7V
+Kamookr       0411 D222534-D  K Ni Po              706 KO     M1V M6V
 Gnareek       1011 C4845AC-F  K Ag Ni              100 KO     F8V 
 Kixax         1311 C110777-E  K Na                 113 KO     M2V 
-Kaengughdhue  1711 CAC6556-4  C Fl Ni              804 Va     K7V M3D 
+Kaengughdhue  1711 CAC6556-4  C Fl Ni              804 Va     K7V M3V
 Dagzan        2211 A465210-C  G Lo Ni              311 Va     F5V 
 Nazril        2511 C200265-9  C Lo Ni Va           816 Va     M4V M5V M2V 
 Tokaax        0212 C847753-C  K Ag                 100 KO     G8V 
 Kughaat!      0412 E6A37CC-A    Fl                 210 KO     F8V 
-X'eegakr'     1212 B110200-F  O Lo Ni              104 KO     F0V M3D 
+X'eegakr'     1212 B110200-F  O Lo Ni              104 KO     F0V M3V
 Kukirr        1312 E593534-A  K Ag Ni              810 KO     F2V 
-Krilighuto    1412 C579459-E  K Ni                 826 KO     M5V M7D 
+Krilighuto    1412 C579459-E  K Ni                 826 KO     M5V M7V
 Faelzang      1612 C545477-4  G Ni                 614 Va     F9V 
 Relukhs       1712 E2449DC-3    Hi In              123 Va     F1V 
 Gzoekfael     3112 C736259-8    Lo Ni              823 Va     F2IV 
@@ -159,115 +159,115 @@ Iktuat        0613 C8959BB-D  K Hi In              801 KO     F6V
 Ukurukr!t     0913 CA9A579-B  O Ni Wa              601 KO     F9V 
 Rritix        1113 D773400-E  K Ni                 123 KO     G6V 
 R!ri          1213 C463100-A  K Lo Ni              521 KO     M2V 
-Uurgrekul     1413 A254630-F  K Ag Ni              406 KO     M3V M6D 
+Uurgrekul     1413 A254630-F  K Ag Ni              406 KO     M3V M6V
 Kirook        1513 C532533-D  K Ni Po              615 KO     G1V 
 Voungsurs     1613 C65467C-6    Ag Ni              602 Va     G9V 
 Zarrdaerr     0114 E466856-2  C Ri                 603 Va     F0V 
 Kritur        0314 A445223-F  K Lo Ni              502 KO     F6V 
 R'rmaaeeg     0814 B2408B9-F  O De Po              213 KO     F9V 
-Gh!m!!        1014 C52A547-F  O Ni Wa              604 KO     M3V M8D 
+Gh!m!!        1014 C52A547-F  O Ni Wa              604 KO     M3V M8V
 Kir!!iix      1414 C00088A-F  K As Na              300 KO     G0V 
 Doaghz        1614 E57586B-3                       512 Va     G9V 
-R!rat         0315 D400114-C  K Lo Ni Va           315 KO     M3V F6V M1D 
+R!rat         0315 D400114-C  K Lo Ni Va           315 KO     M3V F6V M1V
 Lupok         0715 D346662-B  K Ag Ni              704 KO     F0V 
-Rukr'         0815 C444632-F  K Ag Ni              612 KO     F8V M3D 
-N'k'rr!!rii   1015 A552764-F  K Po                 526 KO     F9V M5D 
+Rukr'         0815 C444632-F  K Ag Ni              612 KO     F8V M3V
+N'k'rr!!rii   1015 A552764-F  K Po                 526 KO     F9V M5V
 Vugaeer       2115 B462872-7  G                    900 Va     G1V 
 Gvokokhksal   0116 B232522-8    Ni Po              202 Va     M2V 
 Lluknoers     0216 C324455-7  C Ni                 601 Va     M6V 
 Mighur'r      0316 C130322-E  K De Lo Ni Po        701 KO     K9V 
 Garrut        0616 C839555-B    Ni                 902 KO     G4V 
-Rokik'kul     0916 B310754-F  K Na                 826 KO     K7V M8D M4II M6D 
+Rokik'kul     0916 B310754-F  K Na                 826 KO     K7V M8V M4II M6V
 Zougedor      0717 E553667-2  C Ag Ni Po           610 Va     K2V 
-Kfountuell    1117 E65A876-3    Wa                 900 Va     M4V M8D 
-T!reerit      1417 C263586-F  O Ag Ni              504 KO     F2V M4D 
+Kfountuell    1117 E65A876-3    Wa                 900 Va     M4V M8V
+T!reerit      1417 C263586-F  O Ag Ni              504 KO     F2V M4V
 Ksorrgtith    0418 D677555-5    Ag Ni              102 Va     G0V 
 Kougakir      0718 B8B4000-8  G Ba Fl Lo Ni        801 Va     M5V 
 Rarakh        0818 C467442-9    Ni                 312 Va     K0V 
 Ueoughan      0918 C694500-8  G Ag Ni              200 Va     F9V 
-Dhorroetue    1118 E200533-6    Ni Va              314 Va     M7V M4D 
+Dhorroetue    1118 E200533-6    Ni Va              314 Va     M4V M7V
 Invoegh       0219 E989878-4  C                    722 Va     F7V 
 Uethaghakue   0419 B310555-C  G Ni                 803 Va     M3V 
 Ifatsousokhs  0519 C24368C-4    Ag Ni Po           901 Va     F1V 
-Gaedho        0619 B777001-5    Lo Ni              333 Va     F0V M6D 
+Gaedho        0619 B777001-5    Lo Ni              333 Va     F0V M6V
 Naefae        0719 C947202-3    Lo Ni              103 Va     F7V 
 Vouraevoe     1019 E526521-5  C Ni                 520 Va     M1V 
 .             2919 X777000-0    Ba Lo Ni           002 --     F3V 
 Uekhaeth      0120 CA99003-7    Lo Ni              536 Va     F0V M1V F4V 
 Dhaegvananul  0220 C514779-7  G Ic                 813 Va     G9V 
-Dovae         0320 C8C3968-7  C Fl Hi In           102 Va     M1V M2D 
-Llokno        0420 C776777-6    Ag                 107 Va     F6V M0D 
+Dovae         0320 C8C3968-7  C Fl Hi In           102 Va     M1V M2V
+Llokno        0420 C776777-6    Ag                 107 Va     F6V M0V
 Zongdhaeghz   0520 B353578-9    Ag Ni Po           202 Va     M7V 
-Raedhkfaeng   0620 B4499BD-A    Hi In              416 Va     F2V M5D M3D 
+Raedhkfaeng   0620 B4499BD-A    Hi In              416 Va     F2V M5V M3V
 Nitengixag    1720 D3557BA-B  K Ag                 605 KO     F8V F2V 
 .             2320 X224000-0    Ba Lo Ni           002 --     F7V 
 N!ak          2721 B777457-E  K Ni                 702 Kk     F3V 
 Tl!geer       2821 E547666-B    Ag Ni              100 Kk     F1V 
 L!oomiixgruu  2921 E140200-B    De Lo Ni Po        500 Kk     F2V 
-Gaaiireen!k   1822 C355988-E  K Hi In              504 KO     K3V M7D 
-Xr!kreriit    2622 C566788-F  K Ag Ri              133 Kk     F1V M7D 
+Gaaiireen!k   1822 C355988-E  K Hi In              504 KO     K3V M7V
+Xr!kreriit    2622 C566788-F  K Ag Ri              133 Kk     F1V M7V
 Uurrur        2722 C8495AF-B  K Ni                 103 Kk     M3V 
 N'luut        2822 B412263-F  K Ic Lo Ni           901 Kk     M7V 
 Kikreghar     3022 C523531-D  K Ni Po              502 Kk     G7V 
 Kk'ren        3122 C76A9BB-D  K Hi In Wa           504 Kk     F9V 
-!xaatxu       2623 C243557-F  K Ag Ni Po           203 Kk     F0V M3V 
+!xaatxu       2623 C243557-F  K Ag Ni Po           203 Kk     F0V M3V
 Koon!rruu     3123 D568983-F  K Hi In              404 Kk     F9V 
 Gheetaakra    3223 X878523-5    Ag Ni              213 Kk     F7V 
 Naateerr      2724 C8B48A9-F    Fl                 723 Kk     G5V 
 .             1225 X8A6000-0    Ba Fl Lo Ni        003 --     G6IV K6V 
-B!t!rr        2025 E646657-C    Ag Ni              711 KO     F5V M5D 
+B!t!rr        2025 E646657-C    Ag Ni              711 KO     F5V M5V
 Luk'rr'koor   2525 C8D0316-9  O De Lo Ni           101 Kk     M1V 
-Kuxom         2725 A85A565-F  O Ni Wa              801 Kk     F7V M2D 
-Kurrooru      2825 B448755-F    Ag                 902 Kk     F0V M3D 
-Xw'krara      3025 C110536-F    Ni                 125 Kk     M0V M1D 
-Krengxupix    3125 B10077B-F  K Na Va              717 Kk     K0V M1D 
-Rux!n!l       3225 C456533-E  O Ag Ni              504 Kk     F9V M8D 
-.             1226 X666000-0    Ba Lo Ni           020 --     M0V M2D 
-Griigrul'     2826 C898443-F    Ni                 432 Kk     F3V M4D 
-Iir'li        2926 C797003-A  K Lo Ni              318 Kk     K2V M1V 
-G'koooogr     3026 A58889B-F  K Ri                 901 Kk     F8V M6D 
-Laauruu       3126 D231656-B    Na Ni Po           804 Kk     G9V M6V 
-Xin'keei      3226 C648424-F  K Ni                 531 Kk     F2V M6D 
+Kuxom         2725 A85A565-F  O Ni Wa              801 Kk     F7V M2V
+Kurrooru      2825 B448755-F    Ag                 902 Kk     F0V M3V
+Xw'krara      3025 C110536-F    Ni                 125 Kk     M0V M1V
+Krengxupix    3125 B10077B-F  K Na Va              717 Kk     K0V M1V
+Rux!n!l       3225 C456533-E  O Ag Ni              504 Kk     F9V M8V
+.             1226 X666000-0    Ba Lo Ni           020 --     M0V M2V
+Griigrul'     2826 C898443-F    Ni                 432 Kk     F3V M4V
+Iir'li        2926 C797003-A  K Lo Ni              318 Kk     K2V M1V
+G'koooogr     3026 A58889B-F  K Ri                 901 Kk     F8V M6V
+Laauruu       3126 D231656-B    Na Ni Po           804 Kk     G9V M6V
+Xin'keei      3226 C648424-F  K Ni                 531 Kk     F2V M6V
 K!ub!krxk!xk  2327 E534120-A  K Lo Ni              100 Kk     M4V 
-'kr'k         2627 C210885-F  K Na                 510 Kk     F2V M0D 
+'kr'k         2627 C210885-F  K Na                 510 Kk     F2V M0V
 Nukeera       2727 C413457-B  O Ic Ni              801 Kk     M8V 
 Raakoo        2827 B6A5679-F  O Fl Ni              302 Kk     F7IV M4V 
 Nooki         3127 D8A9466-C  O Fl Ni              404 Kk     K0V M4V 
 Ghikrooxkip   3227 B242669-D  K Ni Po              402 Kk     G6V 
 .             1128 X639000-0    Ba Lo Ni           002 --     F7V 
 K'raal        2228 C658749-F  K Ag                 312 Kk     K6V 
-Keekubaarika  2528 C559648-F  O Ni                 811 Kk     F0V M0D M3D 
-Kookuukeek    2628 C342656-E  K Ni Po              502 Kk     M2V M4D 
+Keekubaarika  2528 C559648-F  O Ni                 811 Kk     F0V M0V M3V
+Kookuukeek    2628 C342656-E  K Ni Po              502 Kk     M2V M4V
 Kkeek!axaa    2728 B869677-D  O Ni Ri              101 Kk     F0V 
 Kreekelee     2828 B7C3665-F  K Fl Ni              203 Kk     G1III 
 Rooxkxt'ip!!  3228 E884000-8  K Ba Lo Ni           122 Kk     F3V 
-Kieerree      2129 C9B5877-E  K Fl                 535 Kk     F2V M3D 
-Ghaare        2229 D476333-A  K Lo Ni              607 Kk     F6V M8D 
-Roteer        2329 C456546-F  K Ag Ni              802 Kk     F9V M5D 
-'kreeki       2529 C547232-D  O Lo Ni              302 Kk     F7V M3D 
+Kieerree      2129 C9B5877-E  K Fl                 535 Kk     F2V M3V
+Ghaare        2229 D476333-A  K Lo Ni              607 Kk     F6V M8V
+Roteer        2329 C456546-F  K Ag Ni              802 Kk     F9V M5V
+'kreeki       2529 C547232-D  O Lo Ni              302 Kk     F7V M3V
 Kak't'bee     2729 C24188C-F  K Po                 323 Kk     F3V 
-Enireerakr    2929 C555759-D    Ag                 601 Kk     F8V M5V 
+Enireerakr    2929 C555759-D    Ag                 601 Kk     F8V M5V
 Teghii        3129 C8B2384-A  K Fl Lo Ni           504 Kk     K5V 
-R!tag!        1830 B6B06AF-F  O De Ni              800 Kk     M3V M6D 
+R!tag!        1830 B6B06AF-F  O De Ni              800 Kk     M3V M6V
 Turutikerr    2030 A590378-F  K De Lo Ni           804 Kk     K4V 
 Eema'l't      2130 C8D1210-9    Fl Lo Ni           532 Kk     F7V 
 Riibukun      2330 C885767-F  O Ag Ri              805 Kk     F9V 
 Naniin'nee    2630 C54389A-E  O Po                 612 Kk     F5V 
 Geep!k        2730 X53A669-4    Ni Wa              803 Kk     M0V 
-Krikooxi      2930 B584567-D  O Ag Ni              603 Kk     G1V M6D 
+Krikooxi      2930 B584567-D  O Ag Ni              603 Kk     G1V M6V
 Kr!!keek      3130 C767511-C  K Ag Ni              404 Kk     F3V 
 Krumatero     1531 C696356-C  K Lo Ni              502 Kk     M1V 
-K'rruuegni    1631 C88A769-F    Ri Wa              221 Kk     G9V M0D 
-Ekegaa        2031 C68669A-B  K Ag Ni Ri           713 Kk     F8V M2D 
+K'rruuegni    1631 C88A769-F    Ri Wa              221 Kk     G9V M0V
+Ekegaa        2031 C68669A-B  K Ag Ni Ri           713 Kk     F8V M2V
 Gzaxxreerr    2231 E344410-C  K Ni                 810 Kk     F5V 
 Exwuk         2531 D400227-B  K Lo Ni Va           103 Kk     M0V 
 Giit'gh'k     2731 C140431-E  K De Ni Po           413 Kk     F2V 
-Re'           2831 C581ABB-F  K Hi In              404 Kk     M7V M3D 
-Kuug!tukel't  2931 C766ABC-F  K Hi In              500 Kk     F0V M6D 
+Re'           2831 C581ABB-F  K Hi In              404 Kk     M3V M7V
+Kuug!tukel't  2931 C766ABC-F  K Hi In              500 Kk     F0V M6V
 Gaanughol!r   3031 E20077B-C  K Na Va              320 Kk     F2V 
-Ukreeta'kr    3231 D412A84-B    Hi Ic Na           616 Kk     F7V M7D 
-Uukeker       1432 C8B0100-C  K De Lo Ni           503 Kk     M7V M4V 
-Kk!tekraa     1532 D768453-B  K Ni                 311 Kk     F4V M4D 
+Ukreeta'kr    3231 D412A84-B    Hi Ic Na           616 Kk     F7V M7V
+Uukeker       1432 C8B0100-C  K De Lo Ni           503 Kk     M4V M7V
+Kk!tekraa     1532 D768453-B  K Ni                 311 Kk     F4V M4V
 Urr'rroo'     2132 B642534-F  K Ni Po              213 Kk     K0V 
 Xitur'krooxa  2232 C77A720-E  K Wa                 103 Kk     K2V 
 Nikrikrung    2332 A375842-F  K                    411 Kk     F0V 
@@ -275,86 +275,86 @@ Rikrir'k      2432 C648611-F    Ag Ni              111 Kk     M3V
 Kteexktiluri  2732 D758000-A  O Ba Lo Ni           611 Kk     F0V 
 Legnaikel'm   1433 B6A0000-D  O Ba De Lo Ni        810 Kk     M3V 
 Kigh!         1533 C510532-E  O Ni                 502 Kk     M5V 
-Kr'eeraat     1933 C346200-D  K Lo Ni              519 Kk     F4V M1D F6V M7D 
-!tuuk         2033 D585300-B  O Lo Ni              405 Kk     F8V M3D 
+Kr'eeraat     1933 C346200-D  K Lo Ni              519 Kk     F4V M1V F6V M7V
+!tuuk         2033 D585300-B  O Lo Ni              405 Kk     F8V M3V
 K'eekeloorr   2133 B100473-F  K Ni Va              901 Kk     M1V 
 Iker          2233 C638200-B  K Lo Ni              300 Kk     M3III 
 Greex'l'ng    2533 C89A788-F    Wa                 112 Kk     F1V 
 Laarxti       2833 C9B6000-A  K Ba Fl Lo Ni        925 Kk     F9V 
 Kiikiitaar    2933 B343610-F  O Ag Ni Po           602 Kk     M6V 
-Paeemugn!'    3233 C78A561-F  K Ni Wa              52B Kk     K6V M8D M7D 
-.             1034 X723000-0    Ba Lo Ni Po        005 --     M8V M6D 
+Paeemugn!'    3233 C78A561-F  K Ni Wa              52B Kk     K6V M8V M7V
+.             1034 X723000-0    Ba Lo Ni Po        005 --     M6V M8V
 Ilurgh'       1434 B5107A7-F  K Na                 904 Kk     K5V 
 Kreeirrik     1534 E634AAB-F  K Hi In              500 Kk     G4V 
 Krukiit'gr'l  1634 A210323-D    Lo Ni              904 Kk     K6V 
 Ookrem!!      1734 C77A553-B    Ni Wa              720 Kk     F3V 
-Gn'tur        2034 E548563-A  K Ag Ni              234 Kk     F1V M5D 
-Ooxukuur      2234 A584352-D  K Lo Ni              314 Kk     F6V M2D 
-Eexariixam    2434 B213545-F  O Ic Ni              308 Kk     M7V M3D 
-Kikkuur       2534 B552876-E  O Po                 214 Kk     F9V M3D 
+Gn'tur        2034 E548563-A  K Ag Ni              234 Kk     F1V M5V
+Ooxukuur      2234 A584352-D  K Lo Ni              314 Kk     F6V M2V
+Eexariixam    2434 B213545-F  O Ic Ni              308 Kk     M3V M7V
+Kikkuur       2534 B552876-E  O Po                 214 Kk     F9V M3V
 Kraanuri      2834 C333545-C    Ni Po              513 Kk     G5III M1V 
 K'an          2934 X200657-2  K Na Ni Va           700 Kk     F9V 
 Eeg'gnegn'n   3234 C474864-F  K                    520 Kk     F4V 
-.             1135 X200000-0    Ba Lo Ni Va        002 --     M6V M2V 
-Xiteekreexk   1335 D100ACC-B  O Hi Na Va           114 Kk     M0D 
+.             1135 X200000-0    Ba Lo Ni Va        002 --     M2V M6V 
+Xiteekreexk   1335 D100ACC-B  O Hi Na Va           114 Kk     M0V
 N!kraakr'kr   1535 E84958B-D  K Ni                 524 Kk     F3V 
-Inegii        1635 A896785-F  O Ag                 107 Kk     F6V M7D 
+Inegii        1635 A896785-F  O Ag                 107 Kk     F6V M7V
 Ikaarr        1835 B858658-F  K Ag Ni              100 Kk     F9V 
 Keek'ngkrii   2135 C110435-D  K Ni                 214 Kk     M0V 
 X!t'nuu       2235 D400166-C    Lo Ni Va           603 Kk     M3III 
-Ekukriru      2435 B000854-E  K As Na              404 Kk     F9D 
-Kr'iirul      2635 C332410-E  O Ni Po              304 Kk     M2V M4D 
-K'ing'        2835 C340899-E  O De Po              105 Kk     F0V M6D 
+Ekukriru      2435 B000854-E  K As Na              404 Kk     F9V
+Kr'iirul      2635 C332410-E  O Ni Po              304 Kk     M2V M4V
+K'ing'        2835 C340899-E  O De Po              105 Kk     F0V M6V
 Kekuung       3035 B3347B9-F                       204 Kk     K0V M5V 
 Keenuunkri    3135 D000300-8  O As Lo Ni           511 Kk     K3V 
 Eegr'rrekr    3235 C88A001-B  K Lo Ni Wa           405 Kk     F2V 
-Kioor'rkoor   1436 A468120-F  K Lo Ni              500 Kk     F6V M5D 
-Etiim         1536 C441400-F  K Ni Po              504 Kk     F3V M8D 
+Kioor'rkoor   1436 A468120-F  K Lo Ni              500 Kk     F6V M5V
+Etiim         1536 C441400-F  K Ni Po              504 Kk     F3V M8V
 Xtool!'neek   1636 C978530-D  O Ag Ni              505 Kk     F3V 
 Kaeenolengat  1936 B896524-D  O Ag Ni              922 Kk     K8V 
-Taamoo        2036 B87989A-F  K                    704 Kk     G3V M6D 
+Taamoo        2036 B87989A-F  K                    704 Kk     G3V M6V
 Raambaama     2236 C300356-A  K Lo Ni Va           503 Kk     K3V 
-Gnignuu       2336 B7B4798-F  K Fl                 702 Kk     M3V M3D 
+Gnignuu       2336 B7B4798-F  K Fl                 702 Kk     M3V M3V
 Truk'         2436 D979632-D    Ni                 612 Kk     F1V 
-Xaraam        2536 B522766-E  K Na Po              805 Kk     M7V M6D 
+Xaraam        2536 B522766-E  K Na Po              805 Kk     M6V M7V
 K!'kuutak'    2736 E67A8DE-D    Wa                 303 Kk     F0V 
 Gn'rr'rrxwe   2936 E321642-D  K Na Ni Po           701 Kk     M6V 
-R'r't         3236 E788648-A    Ag Ni Ri           308 Kk     M1V M3D 
+R'r't         3236 E788648-A    Ag Ni Ri           308 Kk     M1V M3V
 Eekuuing      1337 C401586-D  K Ic Ni Va           314 Kk     M8V 
 Rrooniix'ter  1437 D464003-B  K Lo Ni              600 Kk     F0V 
 Kuitemam't    1937 C786300-E  O Lo Ni              702 Kk     F4V 
-Tulee         2137 D745512-9  K Ag Ni              812 Kk     F7V M3D 
-Neeiiteek     2437 C665545-B  K Ag Ni              608 Kk     K8V M3D 
+Tulee         2137 D745512-9  K Ag Ni              812 Kk     F7V M3V
+Neeiiteek     2437 C665545-B  K Ag Ni              608 Kk     K8V M3V
 Hkegr!r       2837 D9B6796-A  K Fl                 400 Kk     M4V 
-Ut'gh'aar'n   2937 B88A698-F  O Ni Ri Wa           920 Kk     F0V M1D 
-Gnil'         3137 B304865-F    Ic Va              502 Kk     M0V M2D 
+Ut'gh'aar'n   2937 B88A698-F  O Ni Ri Wa           920 Kk     F0V M1V
+Gnil'         3137 B304865-F    Ic Va              502 Kk     M0V M2V
 !gooxkxk!x    3237 C100778-D  K Na Va              910 Kk     F1V 
-Kraraamioor   1838 C528522-D    Ni                 800 Kk     M5V M5D 
+Kraraamioor   1838 C528522-D    Ni                 800 Kk     M5V M5V
 Ur'nek'r      2238 E140567-9    De Ni Po           904 Kk     M5V 
-Ghuriirr      2338 C110686-D  K Na Ni              902 Kk     M4V M4D 
+Ghuriirr      2338 C110686-D  K Na Ni              902 Kk     M4V M4V
 Gn!kugr'laat  2538 E452988-F  K Hi In Po           813 Kk     F6V 
-'kr'k!kruror  2738 B69A556-E  K Ni Wa              734 Kk     F8V M4D 
-K'x!!         2938 C442478-E    Ni Po              302 Kk     G2V M2D 
-Grer!m'       3038 C96A364-C    Lo Ni Wa           327 Kk     F2V M0D 
+'kr'k!kruror  2738 B69A556-E  K Ni Wa              734 Kk     F8V M4V
+K'x!!         2938 C442478-E    Ni Po              302 Kk     G2V M2V
+Grer!m'       3038 C96A364-C    Lo Ni Wa           327 Kk     F2V M0V
 Tuurrengii    1339 C875102-E  K Lo Ni              800 Kk     F3V 
-X'kuukin      1439 A765A98-F  O Hi In              101 Kk     G0V M8D 
+X'kuukin      1439 A765A98-F  O Hi In              101 Kk     G0V M8V
 Keengirik     1539 C978625-B  K Ag Ni              802 Kk     F5V 
 'nakr!        1839 C431232-C  K Lo Ni Po           200 Kk     G2IV 
-Ikuuk         1939 D77879D-E  K Ag                 216 Kk     F7V M7D M7D 
+Ikuuk         1939 D77879D-E  K Ag                 216 Kk     F7V M7V M7V
 Gn'rr!!l      2139 D332665-C    Na Ni Po           900 Kk     M2V 
 Gh!n't        2239 C755130-D  K Lo Ni              713 Kk     F0V 
 Aak'kreekoo   2339 B555646-F  O Ag Ni              413 Kk     F9V M8V 
 Lukr'gr'ka    2439 E441572-9  K Ni Po              514 Kk     G6V 
 T!rrroogaur   2639 E0007BB-D  K As Na              300 Kk     M6V 
 Gr'gag        2839 B74A200-C  O Lo Ni Wa           304 Kk     F5V 
-Kierik        2939 D7A5500-9  K Fl Ni              400 Kk     M1III G7D 
-Releloon'k    3239 C423A97-D  K Hi In Na Po        404 Kk     F0V M5D 
-Ghinuleekik   1740 E380221-B  K De Lo Ni           716 Kk     G3V M5D 
-K'leereek'r   1940 C5649AB-F  K Hi In              700 Kk     M8V M6D 
+Kierik        2939 D7A5500-9  K Fl Ni              400 Kk     M1III G7V
+Releloon'k    3239 C423A97-D  K Hi In Na Po        404 Kk     F0V M5V
+Ghinuleekik   1740 E380221-B  K De Lo Ni           716 Kk     G3V M5V
+K'leereek'r   1940 C5649AB-F  K Hi In              700 Kk     M6V M8V
 Kii'!p        2240 C240978-E  K De Hi In Po        605 Kk     M1V 
 Iixeerririgr  2340 C463798-F  O Ag Ri              804 Kk     K1V 
-Miik'tax      2440 D355543-E  K Ag Ni              203 Kk     F1V M0D 
+Miik'tax      2440 D355543-E  K Ag Ni              203 Kk     F1V M0V
 Gnakukuneti   2640 E676324-B    Lo Ni              502 Kk     G8V 
-Etiikraa      2740 C598776-F  O Ag                 716 Kk     F7V M8D M1D 
-Ungukar       2840 C575699-E  K Ag Ni              201 Kk     F0V M8D 
-Hkuk!r!!      3040 C420551-E  K De Ni Po           302 Kk     M4V M7D 
+Etiikraa      2740 C598776-F  O Ag                 716 Kk     F7V M8V M1V
+Ungukar       2840 C575699-E  K Ag Ni              201 Kk     F0V M8V
+Hkuk!r!!      3040 C420551-E  K De Ni Po           302 Kk     M4V M7V

--- a/res/Sectors/M1105/Gh1hken.sec
+++ b/res/Sectors/M1105/Gh1hken.sec
@@ -15,158 +15,158 @@ Gh!hken
 #PlanetName   Loc. UPP Code   B   Notes         Z  PBG Al LRX *
 #----------   ---- ---------  - --------------- -  --- -- --- -
 Ghixkuur'x    1101 B658201-F  K Lo Ni              500 Kk     F9V 
-Itermii       1201 C432667-F  K Na Ni Po           225 Kk     K7V M0D K8V 
+Itermii       1201 C432667-F  K Na Ni Po           225 Kk     K7V M0V K8V
 I!'xoor       1301 C658301-D    Lo Ni              402 Kk     F3V 
 Ookeerreb     1601 C340642-B  K De Ni Po           511 Kk     F9V 
-'xkii'reen    1701 BAD9494-F  K Fl Ni              904 Kk     F2V M5D 
+'xkii'reen    1701 BAD9494-F  K Fl Ni              904 Kk     F2V M5V
 Ulukux        1901 B564546-E  K Ag Ni              101 Kk     F4V 
-Eexar         2001 B220102-E  O De Lo Ni Po        701 Kk     M5V M5D 
+Eexar         2001 B220102-E  O De Lo Ni Po        701 Kk     M5V M5V
 Kix!'opuuxk   2101 D9A6345-8  K Fl Lo Ni           702 Kk     G2V 
-Neeek'bli     2301 B564341-F  O Lo Ni              804 Kk     F5V M8D 
+Neeek'bli     2301 B564341-F  O Lo Ni              804 Kk     F5V M8V
 Kiir'         2701 A575756-F  O Ag                 102 Kk     M0V 
 Enaam         2801 C864454-E  O Ni                 203 Kk     K2V 
 Eilum'r       2901 CAA9577-F  O Fl Ni              600 Kk     M6V 
 Tukrulaakr    3101 C541235-C  K Lo Ni Po           416 Kk     F7V M5V 
 Trumiikik     1002 C644565-F  O Ag Ni              703 KC     F8V 
-Eerraameet    1302 B345752-E  O Ag                 115 Kk     F1V M1D 
+Eerraameet    1302 B345752-E  O Ag                 115 Kk     F1V M1V
 Angekruurum   2302 C521311-D  O Lo Ni Po           502 Kk     M2V 
-Ghaanoorirer  2402 C879534-F  K Ni                 524 Kk     F6V M0D F3V 
-Gr'!mhk'ng    2802 E8B3976-E    Fl Hi In           203 Kk     F1V M1D 
-K'xul'rr      2902 D411522-B  K Ic Ni              604 Kk     M0V M1D 
-!'xkuroxk     1003 C9B0338-9  K De Lo Ni           313 KC     G8V M1D 
-L'teen        1103 C696400-D  O Ni                 604 KC     F6V M4D 
+Ghaanoorirer  2402 C879534-F  K Ni                 524 Kk     F6V M0V F3V
+Gr'!mhk'ng    2802 E8B3976-E    Fl Hi In           203 Kk     F1V M1V
+K'xul'rr      2902 D411522-B  K Ic Ni              604 Kk     M0V M1V
+!'xkuroxk     1003 C9B0338-9  K De Lo Ni           313 KC     G8V M1V
+L'teen        1103 C696400-D  O Ni                 604 KC     F6V M4V
 Uroouugor     1603 C446415-B  O Ni                 400 K1     F5V 
 Ekaa          1703 A23315A-F  K Lo Ni Po           202 K1     G7IV M5V 
 Ixooghu       1803 C000ADE-E  K As Hi Na           803 K1     F9V 
 Kr!'ban'kii   1903 C895A7A-E  K Hi In              303 K1     F8V 
-Uriimak       2003 A510466-F  K Ni                 506 K1     M4V M3D 
-R'n'gambi     2103 B79A735-F    Wa                 400 K1     F0V M1D 
-Mb'krurrooxk  2303 E6A2236-9  K Fl Lo Ni           500 Kk     M6V M3D 
+Uriimak       2003 A510466-F  K Ni                 506 K1     M3V M4V
+R'n'gambi     2103 B79A735-F    Wa                 400 K1     F0V M1V
+Mb'krurrooxk  2303 E6A2236-9  K Fl Lo Ni           500 Kk     M3V M6V
 Gnookaaraak   2403 B667223-B  K Lo Ni              400 Kk     F0V 
 Xr'rrur!'een  2603 CA86000-A  O Ba Lo Ni           704 Kk     F7V 
 Riukul        2803 C95A7A6-F  O Wa                 312 Kk     G4V 
 K'tk!tlaakun  3103 D576100-9  K Lo Ni              703 Kk     F8V 
 Kruuneetlaa   3203 D796312-8    Lo Ni              202 Kk     F4V 
 Hkookrimirr   1104 C969220-D  O Lo Ni              813 KC     F8V 
-Iikrok'       1204 A985753-F  K Ag Ri              102 KC     K7V M0D 
-Kreoor'xk     1304 A886586-F  K Ag Ni              604 KC     F6V M2D 
+Iikrok'       1204 A985753-F  K Ag Ri              102 KC     K7V M0V
+Kreoor'xk     1304 A886586-F  K Ag Ni              604 KC     F6V M2V
 Iim!          1404 D231000-8  K Ba Lo Ni Po        900 KC     G2V 
-Hk'!!         1704 C895120-B  K Lo Ni              401 K1     M0V M4D 
+Hk'!!         1704 C895120-B  K Lo Ni              401 K1     M0V M4V
 Ghinaaxkaak   1804 C56168B-F    Ni Ri              702 K1     F6V 
-Gn'ukak!      1904 C42466B-F    Ni                 303 K1     M4V M1D 
+Gn'ukak!      1904 C42466B-F    Ni                 303 K1     M1V M4V
 L'rukaner     2004 A521403-F  O Ni Po              703 K1     A7V 
 Rre'krit      2204 C300667-F  K Na Ni Va           501 K1     M1V 
 Tu!'nam       2804 C444126-B  K Lo Ni              900 Kk     F3V 
 Koomb!mb'     3104 C72748C-F  K Ni                 703 Kk     M2V 
 Gheeriiin     3204 D457240-8    Lo Ni              701 Kk     M0V 
-Krikeer'mb'x  1205 C874687-D  O Ag Ni              705 KC     F2V M7D 
-Utieng        1305 C00088C-F  O As Na              412 KC     M6D 
+Krikeer'mb'x  1205 C874687-D  O Ag Ni              705 KC     F2V M7V
+Utieng        1305 C00088C-F  O As Na              412 KC     M6V
 Kaatakiimiik  1605 E58269C-C    Ni Ri              724 K1     F0V 
-Gnungoolik    1705 C3108A9-F  O Na                 603 K1     F0V M3D 
+Gnungoolik    1705 C3108A9-F  O Na                 603 K1     F0V M3V
 Elugrarum     1905 E997513-A  K Ag Ni              202 K1     F2V 
 Rik'k'rit     2005 DAA5540-A  K Fl Ni              102 K1     F6V 
 Kr'aaghekr    2105 D485100-A    Lo Ni              102 K1     F5V 
-Keaaketlirr   2405 C345137-C  O Lo Ni              316 Kk     F1V M7D 
+Keaaketlirr   2405 C345137-C  O Lo Ni              316 Kk     F1V M7V
 Kaaliikreek   2505 D74557A-E    Ag Ni              924 Kk     F8V 
 Xkimb'kax     2905 C524646-C  K Ni                 414 Kk     F4V 
 Tarerrut      3005 E745772-C  K Ag                 326 Kk     F7V M0V 
-Kiroorix      1006 B4347AB-F  K                    802 KC     K4V M8D 
-Nurrariik     1206 C410200-D  K Lo Ni              700 KC     M4V M6D 
+Kiroorix      1006 B4347AB-F  K                    802 KC     K4V M8V
+Nurrariik     1206 C410200-D  K Lo Ni              700 KC     M4V M6V
 Xurraangu     1506 B648597-F  O Ag Ni              823 K1     F2V 
 Urigr         1906 C354856-F  K                    720 K1     F0V 
 Rookurexkiin  2006 D5A4110-7    Fl Lo Ni           713 K1     M2V 
 K!ng!'m       2106 E581421-E  K Ni                 100 K1     K0V 
 Krakin'knuu   2306 D35268D-B  K Ni Po              713 Kk     F5V 
-Otang'r       2406 A8C2622-F  K Fl Ni              801 Kk     M5V M5D 
+Otang'r       2406 A8C2622-F  K Fl Ni              801 Kk     M5V M5V
 Amoorr'krum   2506 E591200-7  K Lo Ni              323 Kk     K5V 
-Runikr'kr'    2606 EAE4322-A    Fl Lo Ni           101 Kk     F8V M0D 
+Runikr'kr'    2606 EAE4322-A    Fl Lo Ni           101 Kk     F8V M0V
 Laka          2706 C62A648-B  K Ni Wa              700 Kk     M0V 
-X'kriik       2806 B361322-E  K Lo Ni              102 Kk     F3V M8D 
+X'kriik       2806 B361322-E  K Lo Ni              102 Kk     F3V M8V
 Xiikr!        3106 C88A776-D    Ri Wa              712 Kk     F1V 
-Ekar          3206 C565322-A  O Lo Ni              811 Kk     K0V M5D 
-'xug          1107 C696664-F    Ag Ni              715 KC     F6V M2D 
+Ekar          3206 C565322-A  O Lo Ni              811 Kk     K0V M5V
+'xug          1107 C696664-F    Ag Ni              715 KC     F6V M2V
 Kiixrerukii   1207 C645262-A  O Lo Ni              501 KC     F8V 
 Gn'kk'kkot    1407 C224336-C  K Lo Ni              223 KC     M5V M6V 
-Hkior         1607 C675457-C  K Ni                 200 K1     M3V M4D 
+Hkior         1607 C675457-C  K Ni                 200 K1     M3V M4V
 Naak!li       1707 E434799-B                       810 K1     F3V 
 Toniing       1907 B526433-F  K Ni                 610 K1     A2V 
 Krelgz'kal    2007 B100731-F  O Na Va              613 K1     M5V 
-Nooket        2107 D433312-7  O Lo Ni Po           406 K1     M8V M5D 
-Te!'krirru    2207 B55649B-E  K Ni                 404 K1     F4V M1D 
-Kikeer        2307 A386651-F  K Ag Ni Ri           512 Kk     F6V M2D 
+Nooket        2107 D433312-7  O Lo Ni Po           406 K1     M5V M8V
+Te!'krirru    2207 B55649B-E  K Ni                 404 K1     F4V M1V
+Kikeer        2307 A386651-F  K Ag Ni Ri           512 Kk     F6V M2V
 Eekoongukikr  2907 C210000-C  K Ba Lo Ni           913 Kk     K7V 
 K!xk'ng'l     3207 B411598-E  K Ic Ni              104 Kk     K0IV G5V 
 Tigiike       1008 E475883-E                       300 KC     K2V 
 Kr'beooruur   1108 BAC4478-F  O Fl Ni              501 KC     M5V 
-Mbituroo      1208 EAB2410-9  K Fl Ni              604 KC     M0V M3D 
+Mbituroo      1208 EAB2410-9  K Fl Ni              604 KC     M0V M3V
 Gn'gnuugnuu   1308 C584534-F  K Ag Ni              703 KC     G1V 
-Naagh!n'g     1508 C995449-F    Ni                 202 KC     F3V M2D 
-'riik!        1708 C464455-E  O Ni                 213 K1     F0V M8D 
+Naagh!n'g     1508 C995449-F    Ni                 202 KC     F3V M2V
+'riik!        1708 C464455-E  O Ni                 213 K1     F0V M8V
 K'xiip'       1908 C220764-F  K De Na Po           302 K1     M0III 
 Xkook'r       2208 D426573-C  O Ni                 602 K1     M5V 
 Xingiekrix    2508 D203423-D  O Ic Ni Va           803 Kk     G4V 
-Er'rareut     2608 C89A415-C  K Ni Wa              500 Kk     F2V M3D 
+Er'rareut     2608 C89A415-C  K Ni Wa              500 Kk     F2V M3V
 Oghaxuxkor    2708 B4145A9-F  K Ic Ni              614 Kk     M0V M2V 
 Ikorti        2808 C5447BA-C  K Ag                 302 Kk     F4V 
 Ingikekr'r'   2908 E475456-C  K Ni                 401 Kk     F1V 
 'pixeekr      3208 C423551-B  O Ni Po              905 Kk     M2V 
 Remab!'rii    1509 C3466AB-D  O Ag Ni              600 KC     F8V 
-Ki'!t         1609 E958431-9    Ni                 105 KC     K1V M1D 
+Ki'!t         1609 E958431-9    Ni                 105 KC     K1V M1V
 Tuukul        1709 C300352-A  K Lo Ni Va           100 K1     F0V 
 K'mireer      1809 A776267-F  K Lo Ni              402 K1     F9V 
 !kuxk!kr!'    2109 C7A1559-C  O Fl Ni              902 K1     M0V 
 Ghaningung    2309 A846622-F  O Ag Ni              414 Kk     F8V 
-'             2409 CAEA110-B  K Fl Lo Ni Wa        204 Kk     M6V M1D 
+'             2409 CAEA110-B  K Fl Lo Ni Wa        204 Kk     M1V M6V
 T'kr          3109 C734897-C  O                    810 Kk     F2V 
 T'im          3209 B140898-F  O De Po              912 Kk     F7V 
 Nukag!'ruur   1010 C555310-D  K Lo Ni              803 KC     F1V 
-K'noo         1310 C324340-C  K Lo Ni              906 KC     M3V M1D 
+K'noo         1310 C324340-C  K Lo Ni              906 KC     M3V M1V
 Mimuukaare    1410 C000420-F  K As Ni              800 KC     M3III 
 Gniimbak!m    1510 C437778-C  O                    703 KC     M6V 
 Kt'eexkeer    1810 A200137-F  O Lo Ni Va           502 K1     M8V 
 Lagrooriik    1910 B673101-E  K Lo Ni              204 K1     G8V 
 Aarrrarraak   2410 C735956-D  K Hi In              112 Kk     F2V 
-Xt'rim        2510 D8C18B9-D  O Fl                 213 Kk     F5V M2D 
-Leekri        2710 C453632-E  K Ag Ni Po           406 Kk     F7V M7D 
+Xt'rim        2510 D8C18B9-D  O Fl                 213 Kk     F5V M2V
+Leekri        2710 C453632-E  K Ag Ni Po           406 Kk     F7V M7V
 K'hkibe       0911 A9C1322-E  K Fl Lo Ni           801 KC     M7V 
-Onoom!'gre!'  1111 B421987-F  K Hi In Na Po        300 KC     M5V M7D 
+Onoom!'gre!'  1111 B421987-F  K Hi In Na Po        300 KC     M5V M7V
 Ux!'lurr      1211 C62676A-F  O                    603 KC     A4V 
 Xeetee        1311 B6A5878-F    Fl                 312 KC     F1V 
-K!'rib        1411 E6489BE-C  K Hi In              811 KC     F1V M3D 
-Ukrunaeir     1611 B6A4333-E  K Fl Lo Ni           905 KC     M5V M6D 
+K!'rib        1411 E6489BE-C  K Hi In              811 KC     F1V M3V
+Ukrunaeir     1611 B6A4333-E  K Fl Lo Ni           905 KC     M5V M6V
 Nitingeerr    1711 CAC4115-E  O Fl Lo Ni           410 KC     M4V 
-Neekalaoor    1811 B140768-F  K De Po              814 KC     F0V M5D 
+Neekalaoor    1811 B140768-F  K De Po              814 KC     F0V M5V
 Iigritiirru   1911 E400489-C  K Ni Va              603 KC     K8V 
-Ungem         2011 C343003-B  K Lo Ni Po           312 KC     F2V M3D 
-Niik!n!l      2211 C8B8432-C  K Fl Ni              722 K2     M4III M4D 
+Ungem         2011 C343003-B  K Lo Ni Po           312 KC     F2V M3V
+Niik!n!l      2211 C8B8432-C  K Fl Ni              722 K2     M4III M4V
 Biihkookaax   2711 D326200-9  K Lo Ni              601 Kk     F1V 
 N!krakke      3011 A67A576-F  K Ni Wa              900 Kk     F7V 
-Noonoorexk    3211 B210553-F  O Ni                 918 Kk     G2V M3D 
-Krir'x        0912 B768000-C  K Ba Lo Ni           400 KC     F5V M3D 
-Rereuul       1112 C310652-F  K Na Ni              803 KC     A8V M1D 
+Noonoorexk    3211 B210553-F  O Ni                 918 Kk     G2V M3V
+Krir'x        0912 B768000-C  K Ba Lo Ni           400 KC     F5V M3V
+Rereuul       1112 C310652-F  K Na Ni              803 KC     A8V M1V
 K'xeerroor'r  1212 C593200-E  K Lo Ni              923 KC     F2V 
-Kiikiixak     1312 X6A2995-3    Fl Hi In           905 KC     F6V M1D 
-'ker!k'nuur   1612 B551144-E  K Lo Ni Po           427 KC     F2V M0D 
-Eek!rr        1712 C1308C9-F  O De Na Po           116 KC     F7V M5D 
+Kiikiixak     1312 X6A2995-3    Fl Hi In           905 KC     F6V M1V
+'ker!k'nuur   1612 B551144-E  K Lo Ni Po           427 KC     F2V M0V
+Eek!rr        1712 C1308C9-F  O De Na Po           116 KC     F7V M5V
 Kruururrekr   1912 C360321-E    De Lo Ni           903 KC     F2V 
 Uboor'n       2212 E9B58CB-B    Fl                 313 K2     G5V 
-Kuruurii      2312 X1109DH-4  K Hi Na              903 K2     F6V M3D 
+Kuruurii      2312 X1109DH-4  K Hi Na              903 K2     F6V M3V
 K'r't         2512 AAA6511-F  K Fl Ni              303 Kk     G9V 
 Krikxug!kr'   2812 C0007CC-D    As Na              804 Kk     K6V 
-At'gn'        2912 A9C5545-F  O Fl Ni              704 Kk     G1V M3D 
-Iik!'kaa      0513 C79A300-9  O Lo Ni Wa           904 KC     M8V M8D 
-Akrukarin     0913 C310620-F  K Na Ni              124 KC     F9V M8D 
-Tlit'x        1213 E425664-D    Ni                 316 KC     M7III M1V G9D 
-K!keera       1313 D454340-9  K Lo Ni              610 KC     F0V M4D 
-Urr!ngir      1513 E431521-9  K Ni Po              905 KC     F2V M8D 
+At'gn'        2912 A9C5545-F  O Fl Ni              704 Kk     G1V M3V
+Iik!'kaa      0513 C79A300-9  O Lo Ni Wa           904 KC     M8V M8V
+Akrukarin     0913 C310620-F  K Na Ni              124 KC     F9V M8V
+Tlit'x        1213 E425664-D    Ni                 316 KC     M7III M1V G9V
+K!keera       1313 D454340-9  K Lo Ni              610 KC     F0V M4V
+Urr!ngir      1513 E431521-9  K Ni Po              905 KC     F2V M8V
 Nariireex     1713 C130145-E  K De Lo Ni Po        610 KC     M1V 
-Kel!regr      1913 A662433-F  K Ni                 823 KC     F6V M0D 
+Kel!regr      1913 A662433-F  K Ni                 823 KC     F6V M0V
 K'run         2213 C527343-E  O Lo Ni              204 K2     K9V K1V 
-'r!ngirr      2513 C310566-F  K Ni                 604 Kk     M6V M5D 
+'r!ngirr      2513 C310566-F  K Ni                 604 Kk     M6V M5V
 Eelmb!kkex    2713 C756559-D  K Ag Ni              702 Kk     F5V 
 Kriirig       2813 C787300-B    Lo Ni              604 Kk     F3V 
 Taaa          2913 A745678-F  O Ag Ni              213 Kk     K3V 
-Ar'k'xkrr!'t  3013 X5A0765-3    De                 723 Kk     A5V M7D 
+Ar'k'xkrr!'t  3013 X5A0765-3    De                 723 Kk     A5V M7V
 Eegeeg        3113 C95A235-A  O Lo Ni Wa           504 Kk     F0V 
 Itl'truu      0914 E634664-C  K Ni                 304 KC     M0V 
 Irriiroo      1014 A443777-F  O Ag Po              911 KC     F8V 
@@ -174,181 +174,181 @@ Ihku          1114 E675220-7  K Lo Ni              202 KC     F0V
 Riituxk       1214 B655302-C  K Lo Ni              802 KC     F2V 
 Xtuiik'gh     1414 C633542-B  K Ni Po              600 KC     F2V 
 Ukrinuuxaak   1514 E542988-F  K Hi In Po           502 KC     F7V 
-Xriir!'kruk   1614 C340456-F  O De Ni Po           916 KC     F0V M3D 
+Xriir!'kruk   1614 C340456-F  O De Ni Po           916 KC     F0V M3V
 Kriitl're     1814 D140220-B  K De Lo Ni Po        500 KC     K8V 
 !'it          2014 A9E6358-D  K Fl Lo Ni           703 K2     M8V 
 Loor'tiik     2114 C573558-D  O Ag Ni              211 K2     F0V 
-Gniireror     2214 D571768-D  K                    135 K2     F8V M3D 
+Gniireror     2214 D571768-D  K                    135 K2     F8V M3V
 Ghemakrik     2314 E691856-A  K                    720 K2     F0V 
-Eetur         2414 B331699-F  K Na Ni Po           731 K2     M1V M4D 
+Eetur         2414 B331699-F  K Na Ni Po           731 K2     M1V M4V
 Leekurkrirr   2514 C45558A-F    Ag Ni              914 Kk     F3V 
 T'grakr       2714 C899589-D    Ni                 511 Kk     F2V 
 Lighiit       3014 A9B9779-F    Fl                 803 Kk     G8II 
-Iirr'b!kr     3114 C662101-B  O Lo Ni              503 Kk     M7V M8D 
+Iirr'b!kr     3114 C662101-B  O Lo Ni              503 Kk     M7V M8V
 Kakiighhkuuk  1115 B9B7420-F  K Fl Ni              112 KC     F7V 
 Aarkruurrek   1315 E684245-8    Lo Ni              600 KC     F9V 
-Taaghakuup    1415 D221000-B  K Ba Lo Ni Po        721 KC     M4V M6D 
-Xtux'x        1615 A433445-F  K Ni Po              806 KC     M3V M6D 
+Taaghakuup    1415 D221000-B  K Ba Lo Ni Po        721 KC     M4V M6V
+Xtux'x        1615 A433445-F  K Ni Po              806 KC     M3V M6V
 Kamokub       1715 C5429A9-F  O Hi In Po           214 KC     G7V 
-Reebi         2015 C202411-C  O Ic Ni Va           915 K2     K5V M6D 
+Reebi         2015 C202411-C  O Ic Ni Va           915 K2     K5V M6V
 Kier!!k'nup   2315 C777247-B  O Lo Ni              600 K2     K7V 
 Xukikru       2415 B561587-E  K Ni                 513 K2     F8V 
-Kooruuleexk   2515 X7A5558-0  K Fl Ni              703 Kk     K3V M7D 
+Kooruuleexk   2515 X7A5558-0  K Fl Ni              703 Kk     K3V M7V
 Irur'p        2615 A4039A6-F  K Hi Ic Na Va        720 Kk     F4V 
 Lubilugan     2815 C2009CC-F    Hi Na Va           513 Kk     G6V 
-Kiiul'luni    2915 C400412-E  K Ni Va              304 Kk     M4V M1D 
-K'r'g'rr      1016 C54136A-E  O Lo Ni Po           302 KC     F6V M5D 
-K'nurrir      1116 C67A556-B  O Ni Wa              904 KC     F7V M1D 
+Kiiul'luni    2915 C400412-E  K Ni Va              304 Kk     M1V M4V
+K'r'g'rr      1016 C54136A-E  O Lo Ni Po           302 KC     F6V M5V
+K'nurrir      1116 C67A556-B  O Ni Wa              904 KC     F7V M1V
 'loonguegarr  1216 DAA3461-9  O Fl Ni              304 KC     K9II 
 Gzuune        1316 C646647-D  O Ag Ni              404 KC     F4V 
-Kuugh'g'r     1416 C470442-D    De Ni              404 KC     F0V M1D 
+Kuugh'g'r     1416 C470442-D    De Ni              404 KC     F0V M1V
 Kuurrun       1716 C73A458-C  K Ni Wa              402 KC     M5V 
 Xtairin'b     1816 B457655-F  K Ag Ni              402 KC     K8V 
 'k'krik       1916 E86A654-D  K Ni Ri Wa           122 KC     F3V 
 !'luum'       2116 E526532-E  K Ni                 501 K2     M6V 
 Raaru         2716 C448634-D  K Ag Ni              300 Kk     F6V 
-Tlaagr!kro    3016 B777786-F  K Ag                 404 Kk     F8V M8D 
+Tlaagr!kro    3016 B777786-F  K Ag                 404 Kk     F8V M8V
 Kr'krxke      3216 B97A613-F    Ni Wa              905 Kk     F3V 
 Koongeratu    1117 E3647A7-A    Ag Ri              513 KC     F0V 
 Iikruurreet   1317 E697414-C    Ni                 620 KC     M0V 
 Luutuuri      1417 E7B4867-B  K Fl                 514 KC     F2V 
-Kr!rriiitang  2017 C410322-A  K Lo Ni              124 K2     F4V M7D 
-Nutiikr!gu    2117 D561467-E  K Ni                 212 K2     F7V M2D 
-Ekr'ng'       2417 E7358BB-C  K                    103 K2     F6V M2D 
-Akerorun      2517 D310485-B  O Ni                 815 K2     M4V M1D 
+Kr!rriiitang  2017 C410322-A  K Lo Ni              124 K2     F4V M7V
+Nutiikr!gu    2117 D561467-E  K Ni                 212 K2     F7V M2V
+Ekr'ng'       2417 E7358BB-C  K                    103 K2     F6V M2V
+Akerorun      2517 D310485-B  O Ni                 815 K2     M1V M4V
 Ura!g         2617 C439433-E    Ni                 302 K2     M3V K7V 
 Eerug         2817 C351354-D  O Lo Ni Po           801 Kk     F8V 
-Rrong'        3017 C6A57B9-F  K Fl                 204 Kk     K1V M6D 
+Rrong'        3017 C6A57B9-F  K Fl                 204 Kk     K1V M6V
 K'ng't        3217 B579110-D  O Lo Ni              310 Kk     F2V 
-Ghooetun      1618 B73A303-C  K Lo Ni Wa           902 KC     G1V M5D 
+Ghooetun      1618 B73A303-C  K Lo Ni Wa           902 KC     G1V M5V
 Krunger       1918 B541301-C  K Lo Ni Po           900 KC     G2V 
 Mim'k         2218 B547520-D  K Ag Ni              413 K2     M5V 
-Tikr't        2318 A767343-E  K Lo Ni              404 K2     F9V M7D 
+Tikr't        2318 A767343-E  K Lo Ni              404 K2     F9V M7V
 Eer'ngeg      2518 B352230-F  K Lo Ni Po           502 K2     K5V 
 Ukur          2618 E536320-B  K Lo Ni              120 K2     A4V 
-B!'triru      3118 C586A9B-F  K Hi In              905 Kk     F1V M6D 
-R'enuk'krik   3218 C466568-B    Ag Ni              906 Kk     K0V M2D 
-Kriil!        1119 C356251-9  K Lo Ni              905 K3     F7V M3D 
+B!'triru      3118 C586A9B-F  K Hi In              905 Kk     F1V M6V
+R'enuk'krik   3218 C466568-B    Ag Ni              906 Kk     K0V M2V
+Kriil!        1119 C356251-9  K Lo Ni              905 K3     F7V M3V
 Riigaatokrit  1319 B210245-E  K Lo Ni              902 K3     F9V 
 Kragh!'r      1519 D5569A7-F    Hi In              204 KC     F8V 
 'tuxt'gh!rr   1919 C246525-C  K Ag Ni              102 KC     F3V 
-Unub          2119 E856432-A  K Ni                 421 K2     F3V M6D 
-Niipii        2419 B7B546A-F  K Fl Ni              904 K2     G5V K4D 
+Unub          2119 E856432-A  K Ni                 421 K2     F3V M6V
+Niipii        2419 B7B546A-F  K Fl Ni              904 K2     G5V K4V
 Ooxkarr       2519 C898432-F    Ni                 113 K2     F6V 
-L'bi          2619 C3109A6-E  K Hi Na              703 K2     F9V M2D 
+L'bi          2619 C3109A6-E  K Hi Na              703 K2     F9V M2V
 !kekr         3019 A56559B-F  K Ag Ni              604 Kk     F2V 
 T'gagr        1220 CAB7534-F  K Fl Ni              910 K3     K4II 
-Uupik         1320 C88A624-F  K Ni Ri Wa           806 K3     F6V M8D 
-Uurexkiix     1420 C9C9331-B    Fl Lo Ni           112 K3     M6V M1D 
+Uupik         1320 C88A624-F  K Ni Ri Wa           806 K3     F6V M8V
+Uurexkiix     1420 C9C9331-B    Fl Lo Ni           112 K3     M1V M6V
 Kipiikr       1720 E110455-9  K Ni                 211 KC     M2II 
 Eeg!r         1820 A654524-F  O Ag Ni              102 KC     M8V 
 K!nganguuk    2120 C365966-E    Hi In              504 K2     K6V 
-Tilugneneeng  2220 B444685-D  O Ag Ni              316 K2     F6V M3D 
-Rr'rtii       2320 B410001-F  K Lo Ni              201 K2     M8V M4D 
-Gnalukraaxk   2420 C434437-C  K Ni                 603 K2     M2V M1D 
+Tilugneneeng  2220 B444685-D  O Ag Ni              316 K2     F6V M3V
+Rr'rtii       2320 B410001-F  K Lo Ni              201 K2     M4V M8V
+Gnalukraaxk   2420 C434437-C  K Ni                 603 K2     M2V M1V
 K'kilok       2520 E555577-E    Ag Ni              721 K2     F0V 
 Nir'tlu       2620 C6A1676-B  K Fl Ni              702 K2     F8V 
 Krurr'rnu     2720 C877278-E  K Lo Ni              400 K2     M8V 
-Eghu          3120 C796334-9  K Lo Ni              712 Kk     F3V M0D 
+Eghu          3120 C796334-9  K Lo Ni              712 Kk     F3V M0V
 .             0421 X669000-0    Ba Lo Ni           001 --     G2V 
 Tl!'xeb       1321 B200454-F    Ni Va              223 K3     M8V 
 Ukraarii      1521 E9996BD-D  K Ni                 113 K3     M6V 
-Keeghe        1621 C888342-D  K Lo Ni              913 K3     F5V M4D 
+Keeghe        1621 C888342-D  K Lo Ni              913 K3     F5V M4V
 Xaaltlaa      1821 C3305A8-B  K De Ni Po           104 KC     G4V 
-Hkeek!'k      1921 B7A2865-F  O Fl                 702 KC     F6V M3D 
+Hkeek!'k      1921 B7A2865-F  O Fl                 702 KC     F6V M3V
 Kituin'       2021 C545761-F  K Ag                 204 K2     F3V 
-Luunerr       2121 E367204-9  K Lo Ni              805 K2     K3V M3D 
+Luunerr       2121 E367204-9  K Lo Ni              805 K2     K3V M3V
 K'keekik      2221 E694111-C    Lo Ni              202 K2     K8V 
 Iirriik'kr'l  2321 E785310-8    Lo Ni              703 K2     M3V 
 Eroor!r'      2621 C000003-E  K As Lo Ni           600 K2     M1III 
 N'x'ki        2921 A866556-F  K Ag Ni              900 Kk     M1V 
-R'rrukukrugh  3121 B427200-F  K Lo Ni              300 Kk     F5V M5D 
-Raarraa       1322 B7B2ADB-F  K Fl Hi In           213 K3     F9V M8D 
+R'rrukukrugh  3121 B427200-F  K Lo Ni              300 Kk     F5V M5V
+Raarraa       1322 B7B2ADB-F  K Fl Hi In           213 K3     F9V M8V
 Uurrooriirr   1522 B000101-B  O As Lo Ni           803 K3     K1V 
-Uur!!t        1822 CA7A577-E    Ni Wa              113 KC     F2V M3D 
+Uur!!t        1822 CA7A577-E    Ni Wa              113 KC     F2V M3V
 Kuliikrikukr  2222 C772559-C  O Ni                 704 K2     F1V 
-Iinegiiurirr  2322 D200677-9  K Na Ni Va           600 K2     F9V M0D 
-M!l!!g        2422 C6669BD-F  K Hi In              906 K2     F5V M6D 
+Iinegiiurirr  2322 D200677-9  K Na Ni Va           600 K2     F9V M0V
+M!l!!g        2422 C6669BD-F  K Hi In              906 K2     F5V M6V
 Taloor        2522 C542895-F    Po                 900 K2     F8V 
 Uk'ruuk       2722 C224537-D  O Ni                 315 K2     G9III M4V 
-K!'teenoo     2822 C789412-B  K Ni                 504 Kk     F8V M3D 
+K!'teenoo     2822 C789412-B  K Ni                 504 Kk     F8V M3V
 Kruraaken     3122 C547697-F  K Ag Ni              903 Kk     F8V 
 Iirr!'rr'k    1123 E312236-7  K Ic Lo Ni           724 K3     K8V 
 R'raarr!'rr   1223 A264552-F    Ag Ni              204 K3     G3V 
 Uuxiirirr     1323 D628520-9  K Ni                 600 K3     A3V 
-Xaaerur       1623 A555655-F  K Ag Ni              201 K3     F9V M7D 
+Xaaerur       1623 A555655-F  K Ag Ni              201 K3     F9V M7V
 Hkurni        1823 B512366-D  K Ic Lo Ni           112 KC     G3V 
 Kroo!'r!k     1923 C0008B7-D    As Na              200 K2     F3V 
-Kukieg        2223 C100778-F    Na Va              604 K2     M6D 
-Kimbeer!      2623 C444633-F  K Ag Ni              604 K2     G1V M6D 
+Kukieg        2223 C100778-F    Na Va              604 K2     M6V
+Kimbeer!      2623 C444633-F  K Ag Ni              604 K2     G1V M6V
 Uleenug       2723 B00056A-F  K As Ni              904 K2     K6V 
-Iiriixix      2923 C7996A9-D  O Ni                 134 Kk     F7V M7D 
+Iiriixix      2923 C7996A9-D  O Ni                 134 Kk     F7V M7V
 Gut'ktee      3123 X200630-3    Na Ni Va           601 Kk     A9V 
-T'ooriuk'k    3223 C555746-C  K Ag                 704 Kk     M5V M8D 
+T'ooriuk'k    3223 C555746-C  K Ag                 704 Kk     M5V M8V
 'kikrurr      1324 D899ADC-D  K Hi In              803 K3     F1V 
-Axkeenii      1424 C200532-F  K Ni Va              402 K3     K9V M1D 
+Axkeenii      1424 C200532-F  K Ni Va              402 K3     K9V M1V
 !x'b          1524 E979564-9  K Ni                 514 K3     F6V 
 Xtuteekee     1624 B55478B-F  K Ag                 404 K3     F4V 
-Et'rrii       1924 B775764-F  K Ag                 408 K2     F3V M5D 
+Et'rrii       1924 B775764-F  K Ag                 408 K2     F3V M5V
 Gnotiixekr    2224 C120573-D    De Ni Po           412 K2     M3V 
 Oorurriig'    2424 B31078A-F  O Na                 904 K2     F2V 
 Gz'nugnakr    2824 D552987-C  K Hi In Po           803 Kk     F1V 
-Kr'ook'k      2924 C679866-C  O                    924 Kk     F7V M3D M3D 
+Kr'ook'k      2924 C679866-C  O                    924 Kk     F7V M3V M3V
 Ktuk'buubuk   3124 C657567-F  O Ag Ni              103 Kk     K7V 
 Rrak!         1225 C7A4788-E  O Fl                 700 K3     M3V 
-Nuuteelr'in   1325 C7C4000-B  K Ba Fl Lo Ni        412 K3     F2V M3D 
+Nuuteelr'in   1325 C7C4000-B  K Ba Fl Lo Ni        412 K3     F2V M3V
 Nuukriik      1425 AA9A438-F  K Ni Wa              902 K3     F5V 
-Urreexk       1525 C211246-C  K Ic Lo Ni           903 K3     F7V M7D 
-'t'krkinuu    1725 C695433-D  K Ni                 717 K3     F9V M5D 
-Krik'rekret   1825 C76459B-D  K Ag Ni              803 K2     F1V M3D 
-'ni           1925 C255424-E  K Ni                 203 K2     F4V M2D F4V 
+Urreexk       1525 C211246-C  K Ic Lo Ni           903 K3     F7V M7V
+'t'krkinuu    1725 C695433-D  K Ni                 717 K3     F9V M5V
+Krik'rekret   1825 C76459B-D  K Ag Ni              803 K2     F1V M3V
+'ni           1925 C255424-E  K Ni                 203 K2     F4V M2V F4V
 Ghiirkukix    2525 C679543-D  O Ni                 604 K2     F2V 
 Kriihkina     2825 D444555-D  K Ag Ni              903 Kk     F2V 
 Nikaariig     2925 C667257-C    Lo Ni              602 Kk     F5V F9V 
 Xkeexukr'kra  3025 A463202-E  K Lo Ni              502 Kk     F9V 
-Rooraaxun!    3125 C370254-A    De Lo Ni           704 Kk     F1V M0D 
+Rooraaxun!    3125 C370254-A    De Lo Ni           704 Kk     F1V M0V
 Kiinar        1026 A347640-F  K Ag Ni              801 K3     F4V 
 K!'kroor      1426 D100202-8    Lo Ni Va           105 K3     M0V M1V 
-Xtexr'n'ko    1526 A254456-F  K Ni                 500 K3     M2V M5D 
+Xtexr'n'ko    1526 A254456-F  K Ni                 500 K3     M2V M5V
 Xramb'        1626 D5446AF-A  K Ag Ni              501 K3     G4V 
-Trerriku      1826 E977000-8    Ba Lo Ni           322 K2     K9V M8D 
+Trerriku      1826 E977000-8    Ba Lo Ni           322 K2     K9V M8V
 Gn'kreereer   1926 B561840-F  O Ri                 201 K2     G7V 
-K'kaan        2026 CA959BC-F  O Hi In              303 K2     F0V M8D 
+K'kaan        2026 CA959BC-F  O Hi In              303 K2     F0V M8V
 Ran'ng        2126 C7688BE-F  K Ri                 622 K2     F4V 
 Hk!iorohkekr  2726 C9C4468-D  K Fl Ni              100 K2     M6III 
-Kraahk'gaak!  2926 C4359BC-F    Hi In              101 Kk     F1V M0D 
+Kraahk'gaak!  2926 C4359BC-F    Hi In              101 Kk     F1V M0V
 Kunain        3026 A686578-F  O Ag Ni              403 Kk     G6V 
-Noorr'        3126 A65AA74-F  K Hi In Wa           113 Kk     G0V M7D 
+Noorr'        3126 A65AA74-F  K Hi In Wa           113 Kk     G0V M7V
 Taxka'k       0927 C342555-E    Ni Po              413 K3     G3V 
 Ranroot       1427 B513623-D    Ic Na Ni           704 K3     M0V 
 Iitax         1727 B574799-F  K Ag                 703 K3     F5V 
-Irila         1827 C451332-9  K Lo Ni Po           102 K2     G7V M7D 
-Teexunex      1927 C528300-C  K Lo Ni              500 K2     M3V M5D 
+Irila         1827 C451332-9  K Lo Ni Po           102 K2     G7V M7V
+Teexunex      1927 C528300-C  K Lo Ni              500 K2     M3V M5V
 Nekriigr      2427 E243533-E  K Ag Ni Po           402 K2     F6V 
 Gzurraroot    2827 C468676-C  O Ag Ni Ri           903 Kk     F4V 
-Etugr!rr      2927 C551379-9    Lo Ni Po           206 Kk     F9V M2D 
-'kr'xk        3127 C65737B-B    Lo Ni              115 Kk     F3V M5D 
+Etugr!rr      2927 C551379-9    Lo Ni Po           206 Kk     F9V M2V
+'kr'xk        3127 C65737B-B    Lo Ni              115 Kk     F3V M5V
 !n!rr!'kr     1128 B443655-F  K Ag Ni Po           101 K3     F4V 
 Ak'kaakeeri   1328 D696553-C  K Ag Ni              613 K3     F4V 
-Uukixkaxii    1428 C6B4567-F  O Fl Ni              902 K3     F0V M2D 
+Uukixkaxii    1428 C6B4567-F  O Fl Ni              902 K3     F0V M2V
 Eerura        1728 E466447-9    Ni                 222 K3     G7V 
 Xt!tam'm      1928 B45698A-F    Hi In              203 K2     F0V 
 Ink'k'g       2228 C6B3302-A  K Fl Lo Ni           803 K2     F2V 
-Gr!kikr'      2428 A584524-F  K Ag Ni              301 K2     F7V M4D 
+Gr!kikr'      2428 A584524-F  K Ag Ni              301 K2     F7V M4V
 Xikegn'k      2728 C73A668-C  K Ni Wa              804 K2     G2V 
 Toorr'k       2828 D66998B-F  K Hi In              422 Kk     F3V 
 Grika         2928 B235102-C  O Lo Ni              501 Kk     M6V 
 Gh!rir!!i     0529 E525424-9  K Ni                 513 K3     M4V 
 Korung        0729 C556555-D  K Ag Ni              101 K3     F6V 
-K'konanxogne  0829 B86A66A-F  K Ni Ri Wa           202 K3     F2V M5D 
+K'konanxogne  0829 B86A66A-F  K Ni Ri Wa           202 K3     F2V M5V
 Eekkroo       1029 B234776-F  O                    315 K3     G6III 
 Naaleexk      1129 C512633-E  K Ic Na Ni           901 K3     M8III 
-Eroaaxk       1229 C666520-B  K Ag Ni              513 K3     F8V M3D 
+Eroaaxk       1229 C666520-B  K Ag Ni              513 K3     F8V M3V
 Maraaxkutula  1529 B489205-B  K Lo Ni              801 K3     F1V 
-Ghimii        1629 C427640-F  O Ni                 305 K3     M6V M7D 
+Ghimii        1629 C427640-F  O Ni                 305 K3     M6V M7V
 Righ'riiroox  1929 C5A089A-F  O De                 414 K2     G4V 
 L'ghu         2029 C8D169D-F    Fl Ni              203 K2     M5V 
-Kriree        2229 E986300-8  K Lo Ni              800 K2     F6V M3D 
+Kriree        2229 E986300-8  K Lo Ni              800 K2     F6V M3V
 Uaat'm        2429 E54245A-C  K Ni Po              120 K2     F1V 
 'x'ririir     2829 C260684-F    De Ni Ri           104 Kk     F3V 
 Oorrar        2929 B788556-F  O Ag Ni              404 Kk     F0V 
@@ -361,62 +361,62 @@ K!nokr        1230 X423442-1    Ni Po              613 K3     M3V
 'xkekax       1330 CAA2533-C    Fl Ni              903 K3     F4V 
 Unghker       1630 C527798-E  K                    103 K3     F8V 
 Trikraatu     1830 B7B0211-F  O De Lo Ni           100 KC     M3V 
-Nu'!'r'!n     2030 C8A5644-F  K Fl Ni              311 K2     M1V M0D 
+Nu'!'r'!n     2030 C8A5644-F  K Fl Ni              311 K2     M0V M1V
 Kriirre       2230 CA99553-E  O Ni                 823 K2     F8V 
-Iikraroogr    2330 E645302-A  K Lo Ni              301 K2     F2V M1D 
-Reegr'ngikr   2630 C455587-F  K Ag Ni              904 K2     F2V M3D 
+Iikraroogr    2330 E645302-A  K Lo Ni              301 K2     F2V M1V
+Reegr'ngikr   2630 C455587-F  K Ag Ni              904 K2     F2V M3V
 Eexaak        2730 C785531-E    Ag Ni              603 K2     F5V 
 !rriikir      2830 D677AAB-E  K Hi In              102 Kk     M3V 
 Kooliikree    3230 D426898-B  K                    121 Kk     F9V 
 Mbeeuxk       0131 C498332-E  K Lo Ni              611 KC     F9V 
 Greerroo!g    0331 C666486-D    Ni                 601 K3     F9V 
-Likre         0431 C989544-F    Ni                 404 K3     F0V M3D 
+Likre         0431 C989544-F    Ni                 404 K3     F0V M3V
 Ur'           0531 C696153-D  K Lo Ni              402 K3     K0V 
 Mbex!'        0631 E110488-D  K Ni                 904 K3     M1V 
-Kir!'lugh     0731 D6776A8-E  K Ag Ni              302 K3     F9V M7D 
+Kir!'lugh     0731 D6776A8-E  K Ag Ni              302 K3     F9V M7V
 Oorrung!r     0831 C467525-D  O Ag Ni              300 K3     G9V 
 Exk!riig'r'   1331 C200666-E    Na Ni Va           905 K3     F9IV 
 X'rep         1431 E2006BF-9    Na Ni Va           601 K3     K6V 
-K!t'n         1531 A110301-F  O Lo Ni              713 K3     M7V M2D 
-K!bukrerr'    1631 E9A5A54-B  K Fl Hi In           600 K3     F6V M7D 
+K!t'n         1531 A110301-F  O Lo Ni              713 K3     M2V M7V
+K!bukrerr'    1631 E9A5A54-B  K Fl Hi In           600 K3     F6V M7V
 Kr!k'         1831 A7A279A-F    Fl                 102 KC     M1V 
-Iiroonxuirr   2031 D643520-D  K Ag Ni Po           405 K2     F2V M7D 
+Iiroonxuirr   2031 D643520-D  K Ag Ni Po           405 K2     F2V M7V
 Guketi        2331 C763AAA-F  O Hi In              413 K2     F6V 
-Ghaiiiil      2531 C647864-C                       806 K2     G7V M8D 
-Eetroob'r     3031 E484867-D    Ri                 300 Kk     G4V M8D F6V M4D 
+Ghaiiiil      2531 C647864-C                       806 K2     G7V M8V
+Eetroob'r     3031 E484867-D    Ri                 300 Kk     G4V M8V F6V M4V
 Rr'ghaxreekr  0232 C778620-E  K Ag Ni              700 K3     F5V 
 Griliku       0332 C437656-F  K Ni                 900 K3     M3V 
-Ktokr         0432 E540474-A  K De Ni Po           416 K3     G6V M2D 
-Xtee!ng       0532 C9A5877-C  K Fl                 804 K3     F2V M3D F2V 
+Ktokr         0432 E540474-A  K De Ni Po           416 K3     G6V M2V
+Xtee!ng       0532 C9A5877-C  K Fl                 804 K3     F2V M3V F2V
 K'kem         0732 E100561-A    Ni Va              700 K3     M2V 
 R!''          1132 C8577BD-F  O Ag                 700 K3     K8V 
 Xtiignuxuu    1432 C888100-A  K Lo Ni              304 K3     M2V 
 Kritreeten'n  1532 D998000-7  O Ba Lo Ni           200 K3     F5V 
 Griighiinee   1932 B657567-F  O Ag Ni              703 KC     F9V 
-Krerrur       2032 D74A000-8  K Ba Lo Ni Wa        805 KC     F4V M0D 
+Krerrur       2032 D74A000-8  K Ba Lo Ni Wa        805 KC     F4V M0V
 Riiil!ran!    2232 B553345-E  O Lo Ni Po           620 K2     F1V 
 Gh'ghul       2332 C400778-F  K Na Va              402 K2     K2V 
-'keekregne    2532 C57A55A-C    Ni Wa              714 K2     F4V M5D 
+'keekregne    2532 C57A55A-C    Ni Wa              714 K2     F4V M5V
 Gnoobiikee    2932 A466357-F  K Lo Ni              413 Kk     F1V 
-Iigniri       3232 C45569A-F  K Ag Ni              904 Kk     F1V M1D 
+Iigniri       3232 C45569A-F  K Ag Ni              904 Kk     F1V M1V
 Grakt'ng'r    0133 C000965-F  K As Hi Na           301 K3     F9V 
-Rikraabiube   0233 A448977-F  K Hi In              405 K3     F6V M6D 
-Kaamboolu     0333 C86A788-F  O Ri Wa              805 K3     F7V M6D 
+Rikraabiube   0233 A448977-F  K Hi In              405 K3     F6V M6V
+Kaamboolu     0333 C86A788-F  O Ri Wa              805 K3     F7V M6V
 Gn!'xerr      0533 D79A337-9  K Lo Ni Wa           903 K3     F0V 
 Toongan'roor  0633 E253310-A  K Lo Ni Po           203 K3     F2V 
-X!r!irrir     0733 C500999-E    Hi Na Va           200 K3     F9D M8D 
-Unir'r        0933 BAE4796-E  K Fl                 200 K3     A1V M8D 
+X!r!irrir     0733 C500999-E    Hi Na Va           200 K3     F9D M8V
+Unir'r        0933 BAE4796-E  K Fl                 200 K3     A1V M8V
 Noriixkokraa  1033 B646546-F  K Ag Ni              401 K3     F3V 
 Ulaar'kre     1133 C100635-D  K Na Ni Va           604 K3     M7V 
 Exekr'        1233 B46778D-E  K Ag Ri              111 K3     F8V 
-Tuhk'guu      1933 E1009B6-E  K Hi Na Va           804 KC     K7V M0D 
-Krahkee       2033 B535977-F  O Hi In              524 KC     F5V M0D M2D 
+Tuhk'guu      1933 E1009B6-E  K Hi Na Va           804 KC     K7V M0V
+Krahkee       2033 B535977-F  O Hi In              524 KC     F5V M0V M2V
 R!men!k       2133 E649553-D    Ni                 123 KC     M4V 
 Kukr'kr!k     2233 C222334-A  K Lo Ni Po           603 K2     M4V 
 'kr!riixku    2333 C458798-F    Ag                 400 K2     F2V 
-R'ngeemoogek  2433 E385542-9    Ag Ni              114 KC     K8V M0D 
+R'ngeemoogek  2433 E385542-9    Ag Ni              114 KC     K8V M0V
 Kirikr'k      2933 C263444-D  K Ni                 100 Kk     F9V 
-Mb'xkeeraam   3033 A432100-F  K Lo Ni Po           200 Kk     M8V M1V 
+Mb'xkeeraam   3033 A432100-F  K Lo Ni Po           200 Kk     M1V M8V
 Tur           0134 A586868-F  O Ri                 500 K3     F7V 
 Kroombugh'r   0634 E59A834-B  K Wa                 711 K3     F6V 
 Ukool         0834 A3667CC-F  O Ag Ri              812 K3     F5V 
@@ -425,81 +425,81 @@ Neruo         1434 C685330-B    Lo Ni              902 KC     F7V
 Triikauli     1534 D547543-B  K Ag Ni              723 KC     F5V 
 Uxakramitak   1634 C838755-C                       203 KC     G2III 
 Rirr'nu       1734 C7A5678-B  K Fl Ni              602 KC     M4V 
-!kakiir'ng    1834 B548750-E  O Ag                 602 KC     F3V M3D 
+!kakiir'ng    1834 B548750-E  O Ag                 602 KC     F3V M3V
 Ateer'        2034 B768520-F  K Ag Ni              320 KC     F7V 
 Utagrik       2134 B400764-E  O Na Va              904 KC     M7V 
-Rr'ni         2334 B667343-B  K Lo Ni              303 KC     F1V M0D 
+Rr'ni         2334 B667343-B  K Lo Ni              303 KC     F1V M0V
 Ghoor!temut   2434 E9B4469-E  K Fl Ni              800 KC     M7V 
 Ib!'kr        2934 B226653-E  K Ni                 501 Kk     M1V 
 'r'eerorim    3034 C657731-C  K Ag                 100 Kk     M1V 
 K'x!'graab    0135 A360443-F  K De Ni              913 K3     F1V 
 Rraxkeekiikr  0235 C88988B-C  O Ri                 724 K3     K4V 
 Aalinim       0335 B592420-D  K Ni                 714 K3     F5V 
-Trek!!'kr     0435 C586667-C  K Ag Ni Ri           906 K3     F3V M5D 
+Trek!!'kr     0435 C586667-C  K Ag Ni Ri           906 K3     F3V M5V
 Xw'!t!'ng     0535 E300300-9    Lo Ni Va           810 K3     M3V 
-'k!           0635 B200333-C  K Lo Ni Va           200 K3     M6V M2D 
+'k!           0635 B200333-C  K Lo Ni Va           200 K3     M2V M6V
 Ekuteegh      0935 C3108B9-C  O Na                 104 K3     F5V 
-Ghemb!'tim    1135 B5267AA-F  K                    323 KC     M8V M0D 
+Ghemb!'tim    1135 B5267AA-F  K                    323 KC     M8V M0V
 Kt'kren'r     1435 B575123-D  O Lo Ni              302 KC     F7V 
 Mbiiuuritu    1635 E424100-A  K Lo Ni              400 KC     K7V 
 Xuxuaaki      1735 C7A3246-E  K Fl Lo Ni           822 KC     G5V 
-Gz'm'eegr     1835 E74A459-9  K Ni Wa              834 KC     K5V G8V M8D 
-Pu!ngirr      2035 D684520-C    Ag Ni              704 KC     G9V M7D 
+Gz'm'eegr     1835 E74A459-9  K Ni Wa              834 KC     K5V G8V M8V
+Pu!ngirr      2035 D684520-C    Ag Ni              704 KC     G9V M7V
 Kr'ar         2235 E6388B9-A  K                    800 KC     F0V 
-Lurak'b'ko    2435 D997457-B  K Ni                 606 KC     F2V M4D M6D 
-Iireer'k'     2635 D400475-9  K Ni Va              217 K4     M7V K8D 
+Lurak'b'ko    2435 D997457-B  K Ni                 606 KC     F2V M4D M6V
+Iireer'k'     2635 D400475-9  K Ni Va              217 K4     M7V K8V
 Krirakruxiit  2735 BA86879-F    Ri                 412 K4     F6V 
-'rrek!k       2835 B5526BD-F  O Ni Po              100 K4     F5V M7D 
+'rrek!k       2835 B5526BD-F  O Ni Po              100 K4     F5V M7V
 Gr'rmbaakkoo  0636 E46078C-A  K De Ri              911 K3     G1V 
-'tuuek        1136 C672479-B  K Ni                 620 KC     F9V M3D 
+'tuuek        1136 C672479-B  K Ni                 620 KC     F9V M3V
 Keenire       1236 C56888B-F  K Ri                 221 KC     F1V 
 K!kr'ke       1336 C736456-D  O Ni                 113 KC     M3V 
 Kkooeeng      1436 D785644-A  K Ag Ni Ri           814 KC     F9V 
 'n!r'k        1536 A42158A-F  O Ni Po              902 KC     M3V 
 X'ruk'kri'r   1636 C642A88-F  K Hi In Po           103 KC     F1V 
-Keekuux'r!n   1736 D8B29CB-B    Fl Hi In           805 KC     K7V M5D 
+Keekuux'r!n   1736 D8B29CB-B    Fl Hi In           805 KC     K7V M5V
 !kregetrii    1836 C99A235-E    Lo Ni Wa           900 KC     M3V 
 X'rirr!kr     1936 C949887-E  O                    502 KC     F0V 
-Kuign'hk'k    2336 C678630-E    Ag Ni              421 KC     F4V M3D 
+Kuign'hk'k    2336 C678630-E    Ag Ni              421 KC     F4V M3V
 K!kiige       2436 E534488-D  K Ni                 803 KC     M0V M3V 
-Rruuniira     2536 B7B289A-F  K Fl                 905 K4     F3V M0D 
-Kaaurriino    2636 B5478BE-F  K                    203 K4     G2V M6D 
+Rruuniira     2536 B7B289A-F  K Fl                 905 K4     F3V M0V
+Kaaurriino    2636 B5478BE-F  K                    203 K4     G2V M6V
 Kur!'k'r      2936 C8A858B-E  K Fl Ni              303 K4     K3V 
 Xuxaatiiniik  3036 E310426-9  K Ni                 812 K4     K3II G9V 
-'ghu'rr'      3136 C563954-F    Hi In              301 K4     G0V M8D 
+'ghu'rr'      3136 C563954-F    Hi In              301 K4     G0V M8V
 R'mbiin't     0137 B4739A6-F  K Hi In              401 K3     F4V 
-Kaaakruu      0337 C88A000-D  K Ba Lo Ni Wa        514 K3     F3V F0V M5D 
+Kaaakruu      0337 C88A000-D  K Ba Lo Ni Wa        514 K3     F3V F0V M5V
 In'xkan       0437 A534567-F  K Ni                 210 K3     M6V 
 Engukruxkr!   0537 C592784-F  O                    102 K3     F6V 
-Gner'b        0737 BACA244-F  K Fl Lo Ni Wa        315 K3     M3III M2V M6V 
+Gner'b        0737 BACA244-F  K Fl Lo Ni Wa        315 K3     M3III M2V M6V
 'kx'n'        0837 B948341-F  K Lo Ni              900 K3     F5V 
-Uuri          1237 C96A845-F  K Ri Wa              700 KC     K1V M0D 
-Laano         1337 E9E7885-E    Fl                 503 KC     F4V M7D 
+Uuri          1237 C96A845-F  K Ri Wa              700 KC     K1V M0V
+Laano         1337 E9E7885-E    Fl                 503 KC     F4V M7V
 Kerri         1437 A100644-F  K Na Ni Va           304 KC     M3V 
 Il!t!urr      1737 A99A5A7-F  K Ni Wa              702 KC     F1V 
 Tromaa        1837 A55688A-F  K                    400 KC     K4V 
-Uutu          1937 C525583-F  K Ni                 518 KC     M6V M7D 
-Xt'raru       2337 C000424-C  K As Ni              304 KC     M7V M8D 
+Uutu          1937 C525583-F  K Ni                 518 KC     M6V M7V
+Xt'raru       2337 C000424-C  K As Ni              304 KC     M7V M8V
 Xuxooxk       2537 C74A568-F  O Ni Wa              913 K4     F1V 
-Mb'xe         3137 D7588BB-C                       828 K4     F5V M8D 
+Mb'xe         3137 D7588BB-C                       828 K4     F5V M8V
 Aale!gh       3237 C66A566-F  O Ni Wa              903 K4     F7V 
 R'ke          0438 D524200-9  K Lo Ni              712 K3     K0V 
 Irrak         0838 E203A98-E    Hi Ic Na Va        400 K3     F9V 
-Rigz!         0938 C310668-F  K Na Ni              318 K3     F8V M8D F5V 
-Oori          1138 C494256-C  K Lo Ni              223 KC     F7V M2D 
+Rigz!         0938 C310668-F  K Na Ni              318 K3     F8V M8V F5V
+Oori          1138 C494256-C  K Lo Ni              223 KC     F7V M2V
 Kurrok'xku    1338 B586134-E  O Lo Ni              512 KC     F7V 
-Kreengerii    2038 CAB5433-F  K Fl Ni              622 KC     F4V M2D 
+Kreengerii    2038 CAB5433-F  K Fl Ni              622 KC     F4V M2V
 Xk!turrerik   2438 B785620-F  O Ag Ni Ri           703 K4     F8V 
-Gnuka         2538 C200674-F  O Na Ni Va           522 K4     A1IV M0D 
+Gnuka         2538 C200674-F  O Na Ni Va           522 K4     A1IV M0V
 Retuirr       2638 C73A333-E    Lo Ni Wa           900 K4     M3V 
 Kr!al!        2838 B100687-F  O Na Ni Va           623 K4     K6V M4V 
-Uum!kaa       2938 E576565-D  K Ag Ni              522 K4     F9V M4D 
+Uum!kaa       2938 E576565-D  K Ag Ni              522 K4     F9V M4V
 Tiikkutu      3038 C857202-C  K Lo Ni              803 K4     F7V 
-Teeuk         3138 C201500-F  O Ic Ni Va           801 K4     M8V M6D 
-Gh!agig       3238 A54357A-F  K Ag Ni Po           502 K4     F9V M3D 
+Teeuk         3138 C201500-F  O Ic Ni Va           801 K4     M6V M8V
+Gh!agig       3238 A54357A-F  K Ag Ni Po           502 K4     F9V M3V
 Mbukimurreg   0139 B99A121-D  O Lo Ni Wa           922 K3     F8V 
 Ruuk!ng!'k    0239 B410301-C  K Lo Ni              702 K3     M4V 
-N'xt'ng'      0439 E346697-D  K Ag Ni              851 K3     F4V M0D 
+N'xt'ng'      0439 E346697-D  K Ag Ni              851 K3     F4V M0V
 Kolaat        1039 B785686-D    Ag Ni Ri           624 KC     F1V 
 'krkr'ki      1339 E120663-A  K De Na Ni Po        713 KC     G3V M8V 
 Hkur'xungik   1639 E637385-A    Lo Ni              901 KC     M8V 
@@ -507,22 +507,22 @@ Gh'rrix       1739 C8B3666-E  K Fl Ni              100 KC     M6V
 Kriinkax      2039 A84A644-F    Ni Wa              104 KC     M4V 
 Grukaaket'    2139 D848223-A    Lo Ni              203 KC     F2V 
 T'tiraakr     2639 D549263-A    Lo Ni              403 K4     F2V 
-K'rr!x!gr     2839 D535544-C    Ni                 303 K4     M0V M7D 
+K'rr!x!gr     2839 D535544-C    Ni                 303 K4     M0V M7V
 Kakraaxk      3139 D8389AA-C    Hi In              610 K4     F9V 
 Tuxiilal      3239 A798899-F  O                    610 K4     F4V 
-Iiux'l        0140 A529123-D  K Lo Ni              515 K3     M6V M4D 
-Krout         0240 C96A757-E    Ri Wa              703 K3     K9V M5D 
+Iiux'l        0140 A529123-D  K Lo Ni              515 K3     M4V M6V
+Krout         0240 C96A757-E    Ri Wa              703 K3     K9V M5V
 Ikagr!n       0340 C755694-D  K Ag Ni              104 K3     F5V 
 Gh'ktor       0540 B767223-F  O Lo Ni              812 K3     F3V 
 Keebiingunek  0640 C795114-C  K Lo Ni              600 K3     M5V 
 Egix          0740 C436563-F  K Ni                 502 K3     F1IV 
 Uurre         1040 C523345-C    Lo Ni Po           120 KC     G2V 
-I'ni          1340 E210766-D    Na                 204 KC     M7V M8D 
+I'ni          1340 E210766-D    Na                 204 KC     M7V M8V
 M'ikeete      1540 C200779-F  K Na Va              700 KC     M8III 
-En!krruuk     1640 C96A100-A  K Lo Ni Wa           301 KC     F1V M4D 
-Kuinermb!r    1940 C735454-B  K Ni                 313 KC     F4V M4D 
+En!krruuk     1640 C96A100-A  K Lo Ni Wa           301 KC     F1V M4V
+Kuinermb!r    1940 C735454-B  K Ni                 313 KC     F4V M4V
 Tiikim        2140 C200687-C    Na Ni Va           202 KC     M2V 
 Leer'eei      2240 D635220-A  O Lo Ni              732 KC     M7V 
 !'miil        2340 B340540-F    De Ni Po           300 KC     K2V 
 Hkingubi      3140 D565275-7    Lo Ni              601 K4     F6V 
-Iikiirr'gha   3240 D682A64-B    Hi In              604 K4     F9V M0D 
+Iikiirr'gha   3240 D682A64-B    Hi In              604 K4     F9V M0V

--- a/res/Sectors/M1105/Ghoekhnael.tab
+++ b/res/Sectors/M1105/Ghoekhnael.tab
@@ -5,7 +5,7 @@ Ghoe	A	0105		X445000-0		Ba Lo Ni		011	--	F6 V D						0
 Ghoe	A	0106		X500000-0		Ba Lo Ni Va		012	--	M7 V						0
 Ghoe	A	0204		X9C5000-0		Ba Fl Lo Ni		010	--	M5 V D						0
 Ghoe	A	0205		X575000-0		Ba Lo Ni		003	--	F3 V D						0
-Ghoe	A	0208		X100000-0		Ba Lo Ni Va		008	--	K2 V G0 V D						0
+Ghoe	A	0208		X100000-0		Ba Lo Ni Va		008	--	G0 V K2 V D						0
 Ghoe	A	0210		X694000-0		Ba Lo Ni		010	--	F6 V D						0
 Ghoe	A	0303		X200000-0		Ba Lo Ni Va		003	--	M3 II						0
 Ghoe	A	0406		X584000-0		Ba Lo Ni		002	--	F6 V						0
@@ -74,7 +74,7 @@ Ghoe	C	2401		X250000-0		Ba De Lo Ni Po		024	--	F3 V F4 V D						0
 Ghoe	C	2404		X677000-0		Ba Lo Ni		004	--	G5 V						0
 Ghoe	C	2409	Khaersnourr	C655777-6		Ag		203	Va	G2 V						0
 Ghoe	C	2410	Terroullaz	C587500-9		Ag Ni		814	Va	F8 V						0
-Ghoe	D	2506		X230000-0		Ba De Lo Ni Po		000	--	M8 V M2 V						0
+Ghoe	D	2506		X230000-0		Ba De Lo Ni Po		000	--	M2 V M8 V						0
 Ghoe	D	2510	Thorvazaeghz	C386448-9		Ni		903	Va	M8 V						0
 Ghoe	D	2601		X7A4000-0		Ba Fl Lo Ni		005	--	M5 V D						0
 Ghoe	D	2603		X465000-0		Ba Lo Ni		028	--	F5 V D						0
@@ -121,7 +121,7 @@ Ghoe	E	0519		X110000-0		Ba Lo Ni		013	--	F3 V						0
 Ghoe	E	0616		X564000-0		Ba Lo Ni		002	--	G9 V						0
 Ghoe	E	0617		X425000-0		Ba Lo Ni		013	--	K1 V						0
 Ghoe	E	0620	Sonid	B523125-A		Lo Po DrakW		200	TY	F2 V						0
-Ghoe	E	0716		X637000-0		Ba Lo Ni		016	--	M6 V M5 V						0
+Ghoe	E	0716		X637000-0		Ba Lo Ni		016	--	M5 V M6 V						0
 Ghoe	E	0720	Enoent	B588885-6	V	Pa Ph Ri DrakW		602	TY	F1 V						0
 Ghoe	E	0813		X100000-0		Ba Lo Ni Va		002	--	F2 IV						0
 Ghoe	E	0817		X53A000-0		Ba Lo Ni Wa		003	--	M3 V						0
@@ -134,8 +134,8 @@ Ghoe	F	0920		X420000-0		Ba De Lo Ni Po		002	--	M1 V						0
 Ghoe	F	1013		X576000-0		Ba Lo Ni		013	--	F6 V						0
 Ghoe	F	1015		X583000-0		Ba Lo Ni		006	--	F8 V D						0
 Ghoe	F	1017		X567000-0		Ba Lo Ni		002	--	F9 V D						0
-Ghoe	F	1113		X754000-0		Ba Lo Ni		002	--	K0 V F9 V						0
-Ghoe	F	1114		X336000-0		Ba Lo Ni		010	--	M4 V M1 V						0
+Ghoe	F	1113		X754000-0		Ba Lo Ni		002	--	F9 V K0 V						0
+Ghoe	F	1114		X336000-0		Ba Lo Ni		010	--	M1 V M4 V						0
 Ghoe	F	1115		X848000-0		Ba Lo Ni		003	--	F7 V						0
 Ghoe	F	1117		X858000-0		Ba Lo Ni		001	--	G7 V						0
 Ghoe	F	1118		X585000-0		Ba Lo Ni		002	--	F8 V						0
@@ -155,7 +155,7 @@ Ghoe	F	1619	Azdong	B242120-A	CK	Lo Ni Po		700	Va	F6 V						0
 Ghoe	G	1712	Gunae	B556100-6		Lo Ni		600	Va	G9 V						0
 Ghoe	G	1715	Gzukhaegerr	E656512-6	C	Ag Ni		302	Va	F4 V D						0
 Ghoe	G	1717	Ueksvourrogh	C9A5222-8	K	Fl Lo Ni		903	Va	F5 V						0
-Ghoe	G	1718	Errazueghong	C463140-7	K	Lo Ni		717	Va	K9 V G4 V						0
+Ghoe	G	1718	Errazueghong	C463140-7	K	Lo Ni		717	Va	G4 V K9 V						0
 Ghoe	G	1719	Uekakrus	E688212-3	C	Lo Ni		524	Va	F6 V D						0
 Ghoe	G	1720	Goekhaghik	C561305-9		Lo Ni		204	Va	F3 V						0
 Ghoe	G	1811	Ghoudhougue	C9A9165-9		Fl Lo Ni		225	Va	A1 V						0
@@ -326,7 +326,7 @@ Ghoe	L	3130	Thaekhver	B234456-D		Ni		504	Va	M8 V D						0
 Ghoe	L	3222	Knagkhokhs	E475545-2	C	Ag Ni		220	Va	F8 V						0
 Ghoe	L	3224	Kangzueraerr	C221455-9	K	Ni Po		305	Va	K7 V D						0
 Ghoe	L	3226	Dhogagurang	D200732-6	C	Na Va		211	Va	M5 V						0
-Ghoe	L	3228	Ghoudoukeng	C000627-A		As Na Ni		122	Va	M8 V M3 V D						0
+Ghoe	L	3228	Ghoudoukeng	C000627-A		As Na Ni		122	Va	M3 V M8 V D						0
 Ghoe	M	0132		X456000-0		Ba Lo Ni		003	--	F1 V						0
 Ghoe	M	0135	Fivshie	C96A501-B		Ni Wa		303	Zh	M0 V						0
 Ghoe	M	0231		X100000-0		Ba Lo Ni Va		001	--	M5 V D						0
@@ -404,7 +404,7 @@ Ghoe	O	1737	Ongakhs	A525772-A				202	Va	F0 IV						0
 Ghoe	O	1739	Surdagkhuk	E7467AE-3		Ag		600	Va	F8 V						0
 Ghoe	O	1831	Aoekgharr	C331551-9	CK	Ni Po		105	VB	M5 V						0
 Ghoe	O	1833	Fotaghouk	C555522-2		Ag Ni		701	VB	F0 V						0
-Ghoe	O	1834	Gaekuglath	B7869ED-8		Ga Hi Pr Pz	A	421	VB	G7 V F0 V						0
+Ghoe	O	1834	Gaekuglath	B7869ED-8		Ga Hi Pr Pz	A	421	VB	F0 V G7 V						0
 Ghoe	O	1837	Rraetsotin	C888279-5		Lo Ni		200	Va	G0 V						0
 Ghoe	O	1838	Enaen	C380243-3	C	De Lo Ni		200	Va	F3 V D						0
 Ghoe	O	1933	Alveghzun	A999344-9		Lo		104	VB	G9 V						0
@@ -432,7 +432,7 @@ Ghoe	O	2436	Angaegoeng	B688779-A		Ag Ri		505	VB	F9 V D						0
 Ghoe	O	2439	Vaeurrghgel	C624856-A				113	Va	F2 V						0
 Ghoe	O	2440	Anganksuts	C7C7668-2	CK	Fl Ni		721	Va	M5 V						0
 Ghoe	P	2532	Llouaeso	A68456B-6	K	Ag Mr Ni Pr Px		413	VB	F1 V D						0
-Ghoe	P	2534	Aeragzgvoun	B440477-7		De He Ni Po		505	VB	M5 V M0 V D						0
+Ghoe	P	2534	Aeragzgvoun	B440477-7		De He Ni Po		505	VB	M0 V M5 V D						0
 Ghoe	P	2535	Ueku	B421532-A	K	He Ni Po		500	VB	K7 V						0
 Ghoe	P	2536	Arrgaekhuoe	C345412-9	C	Ni		700	VB	F4 V						0
 Ghoe	P	2540	Ikhsatszig	E373972-6	C	Hi In		413	Va	G0 V						0
@@ -447,7 +447,7 @@ Ghoe	P	2833	Gurrungfegz	B539A9D-A		Hi In		503	Va	F6 V						0
 Ghoe	P	2834	Nguearrgor	C500100-7		Lo Ni Va		403	Va	G5 V D						0
 Ghoe	P	2837	Kaegze	A120558-F	K	De Ni Po		103	Va	K7 V						0
 Ghoe	P	2840	Arrgath	C665586-5		Ag Ni		403	Va	F7 V						0
-Ghoe	P	2932	Ovae	D512312-8		Ic Lo Ni		817	Va	M3 V M2 V M8 V						0
+Ghoe	P	2932	Ovae	D512312-8		Ic Lo Ni		817	Va	M2 V M3 V M8 V						0
 Ghoe	P	2933	Kaikllorz	B439331-E	K	Lo Ni		913	Va	M0 V						0
 Ghoe	P	2939	Khuerrgough	C200545-6	K	Ni Va		502	Va	M2 V						0
 Ghoe	P	3031	Llaeghae	D652448-5		Ni Po		604	Va	F9 V D						0

--- a/res/Sectors/M1105/Gzaekfueg.sec
+++ b/res/Sectors/M1105/Gzaekfueg.sec
@@ -27,7 +27,7 @@ Gvaengfadz    0701 C412620-6    Ic Na Ni           510 Ve     F1V
 Douzaaeks     0801 E968475-6    Ni                 312 V5     F9V
 Urzokhurz     1101 C453456-A  G Ni Po              204 Va     G5V
 Kuzoevo       1201 E426978-8    Hi In              103 Va     F8V
-Faeksugh      1501 E300234-7    Lo Ni Va           823 VG     M8D M3V
+Faeksugh      1501 E300234-7    Lo Ni Va           823 VG     M8V M3V
 Dzekseghzaek  1601 A589310-7    Lo Ni              420 VG     F1V
 Taeurrael     1701 C989876-4                       914 VG     F9V M7V
 Gori          1901 B400269-7    Lo Ni Va           411 VG     M4V M6V
@@ -71,7 +71,7 @@ Voguukh       2205 A69777A-7  G Ag                 203 V5     F0V
 Naengorr      2605 B78A578-8  C Ni Wa              114 Va     G8V
 Odzkhuegodz   2805 C541875-3    Po                 514 Va     K5V
 Ikfu          3205 A758887-B  G                    115 Va     F3V M8V
-Gorsakhsang   0306 D1209CB-9    De Hi In Na Po     503 V5     F1V M5D M8V
+Gorsakhsang   0306 D1209CB-9    De Hi In Na Po     503 V5     F1V M5V M8V
 Gvugvatsong   0506 C585446-5  C Ni                 115 V5     F7V
 Kongelvae     0706 C533552-A    Ni Po              503 V5     M1V
 Gzaekeng      1506 C56897A-7    Hi In              100 V5     G5V
@@ -87,7 +87,7 @@ Gangollghaer  2806 B564001-A    Lo Ni              204 Va     F6V
 Nezueg        2906 D426104-9  C Lo Ni              412 Va     K0V M5V
 Atsngoerr     0407 X242510-0    Ni Po              722 V5     F2V F5V M7V
 Siedzthokh    0507 E849422-3    Ni                 116 V5     K9V M8V
-Irrorr        1107 E788555-4  C Ag Ni              206 V5     F4V M4D M0V
+Irrorr        1107 E788555-4  C Ag Ni              206 V5     F4V M4V M0V
 Aekkoekhs     1407 D434643-6  C Ni                 402 V5     M2V M1V
 Rundzer       1607 B330874-9    De Na Po           914 V5     F4V
 Usgvourzodh   2207 D736749-3  C                    805 V5     M4V M4V
@@ -106,10 +106,10 @@ Llaangken     0609 B44678B-8    Ag                 714 V5     F5V
 Rouksougho    0909 C200563-6    Ni Va              913 V5     G0V
 Osong         1209 C767256-7    Lo Ni              910 V5     G7V
 Nakisueth     1809 D400433-7    Ni Va              205 V5     M0V M3V
-Tadzogar      2009 C200146-5    Lo Ni Va           405 V5     G3V M5D M1V
+Tadzogar      2009 C200146-5    Lo Ni Va           405 V5     G3V M5V M1V
 Engekh        2509 E665202-7  C Lo Ni              402 V5     K9V
 Llusuerrg     2609 D647324-4  G Lo Ni              702 V5     F1V
-Errkfaekso    2709 E210002-2  C Lo Ni              90A V5     M7V M1D M8V
+Errkfaekso    2709 E210002-2  C Lo Ni              90A V5     M7V M1V M8V
 Saeanglon     3009 D454421-4    Ni                 403 VN     M8V
 Ngarroel      3209 C610988-7    Hi Na              314 VN     F7V M5V
 Ghongal       0210 C9C3244-3  C Fl Lo Ni           704 V5     M5V
@@ -148,7 +148,7 @@ Tuoez         2512 C400562-7    Ni Va              603 V5     G8V M7V
 Ollaerzoerz   2612 EAD4678-1    Fl Ni              123 V5     K9V M0V
 Gzitsezoegh   3012 C554234-9    Lo Ni              106 VN     F9V M6V
 Gheguesae     3112 C456200-9    Lo Ni              200 VN     F9V
-Aaoeou        3212 C89A379-8    Lo Ni Wa           907 VN     K9V M7D M5V
+Aaoeou        3212 C89A379-8    Lo Ni Wa           907 VN     K9V M7V M5V
 Guutsa        0913 C753101-4    Lo Ni Po           303 V5     F6V M2V
 Orsgeghoeze   1213 C9C1587-6  G Fl Ni              602 V5     M2V M6V
 Taoekh        1313 CAE9000-5  G Ba Fl Lo Ni        903 V5     M2V
@@ -164,8 +164,8 @@ Arsghourrg    1214 B658976-A    Hi In              602 V5     M0V M5V
 Ghallkaegz    1914 B232111-B  G Lo Ni Po           604 V5     M4V M7V
 Gvioengoegh   2414 A884626-6  G Ag Ni              504 V5     F5V M0V
 Enekhzul      2814 C110458-B  C Ni                 502 Va     M3V
-Llothurr      3014 C544477-8    Ni                 607 Va     F4V M2D F7V
-Ousagudha     1315 C350778-5    De Po              512 V5     F9V F3V
+Llothurr      3014 C544477-8    Ni                 607 Va     F4V M2V F7V
+Ousagudha     1315 C350778-5    De Po              512 V5     F3V F9V
 Eredhok       1815 CAB5144-7  G Fl Lo Ni           322 V5     M3V
 Riegallonzak  1915 B460367-5  G De Lo Ni           914 V5     F7V
 Dakhsarrllo   2015 C857663-1  C Ag Ni              803 V5     F0V M3V
@@ -259,7 +259,7 @@ Cifo          3025 B237464-A  A Ni Po              802 Ga     M6V
 Atha          3225 B69788B-A  S Ic Na Va           800 Ga     K0V
 Koeenaerkoe   1326 C7879CA-7    Hi In              312 V5     F7V
 Faethkhueg    1426 E68A559-3    Ni Wa              117 V5     F9V M4V
-Vuenengouz    1526 E585789-4  C Ag                 207 V5     F7V M1D F6V
+Vuenengouz    1526 E585789-4  C Ag                 207 V5     F7V M1V F6V
 Gogvoeroghz   2126 D757466-6    Ni                 924 V5     F1V
 Gazoun        2326 D340975-6    De Hi In Po        400 V5     F1V
 Kazzoukal     2426 BAC7746-9    Fl                 802 V5     K3V M1V
@@ -280,7 +280,7 @@ Foekhorr      1428 E988584-4  C Ag Ni              302 V5     K6V
 Ghueuedhars   1628 E250355-4    De Lo Ni Po        101 V5     K5V M6V
 Foenrars      1828 C646240-2  G Lo Ni              922 V5     F4V
 Adharen       1928 C210699-6  G Na Ni              304 V5     F2V
-Knueraerrun   2128 D100777-3    Na Va              118 V5     M4V M1D F9V M4V
+Knueraerrun   2128 D100777-3    Na Va              118 V5     M4V M1V F9V M4V
 Ongnonggors   2428 E98A495-5  C Ni Wa              101 V5     F9V
 Orraerz       2528 C946556-A    Ag Ni              804 V5     F6V
 Asoitad       2728 D986323-2    Lo Ni              500 Ga     F4V

--- a/res/Sectors/M1105/Gzaekfueg.txt
+++ b/res/Sectors/M1105/Gzaekfueg.txt
@@ -118,7 +118,7 @@ Hex  Name                 UWP       Remarks              {Ix} (Ex)    [Cx]   N B
 1218 Oulraz               D334205-6 Lo                   {-3} (510-2) [1194] - C  - 400 7  V5 M1 II G8 V
 1311 Llekna               E578344-3 Lo                   {-3} (820-1) [4166] - -  - 501 9  V5 F4 V M1 V 
 1313 Taoekh               CAE9100-8 Lo Tz                {-2} (700-5) [5247] - K  - 903 8  V5 M2 V      
-1315 Ousagudha            C350778-5 De Po                {-1} (966+2) [7964] - -  - 512 7  V5 K9 V K3 V 
+1315 Ousagudha            C350778-5 De Po                {-1} (966+2) [7964] - -  - 512 7  V5 K3 V K9 V 
 1317 Kenal                C2006AD-9 Na Ni Va Tz          {-1} (A55-1) [467A] - -  - 500 6  V5 M6 V M6 V 
 1413 Dhillourr            B110A7A-G Hi In Na Cp          {+5} (B9F+1) [BH9J] - -  - 102 9  V5 F9 V      
 1512 Kurfoegkokna         B371642-A He Ni                {+1} (A53-3) [4647] - K  - 504 10 V5 K1 V M5 V 

--- a/res/Sectors/M1105/Irugangong.sec
+++ b/res/Sectors/M1105/Irugangong.sec
@@ -15,7 +15,7 @@ Irugangong
 .             1201 X787000-0    Ba Lo Ni           014 --     F9V M6V
 .             1601 X879000-0    Ba Lo Ni           000 --     F0V 
 .             2901 X140000-0    Ba De Lo Ni Po     006 --     G6V M3V
-.             0502 X000000-0    As Ba Lo Ni        005 --     M6V M2V
+.             0502 X000000-0    As Ba Lo Ni        005 --     M2V M6V
 .             0702 X787000-0    Ba Lo Ni           004 --     F2V M5V
 .             0802 X888000-0    Ba Lo Ni           006 --     F5V M4V
 .             1302 X370000-0    Ba De Lo Ni        021 --     F2V M5V
@@ -42,19 +42,19 @@ Irugangong
 .             3004 X888000-0    Ba Lo Ni           001 --     M4V 
 .             0805 X576000-0    Ba Lo Ni           004 --     G3V 
 .             1005 X300000-0    Ba Lo Ni Va        015 --     F6V 
-.             1405 X636000-0    Ba Lo Ni           003 --     M5V M2V
-.             1605 X120000-0    Ba De Lo Ni Po     020 --     M6V M1V 
+.             1405 X636000-0    Ba Lo Ni           003 --     M2V M5V
+.             1605 X120000-0    Ba De Lo Ni Po     020 --     M1V M6V
 .             2405 X692000-0    Ba Lo Ni           000 --     F1V 
-.             3005 X320000-0    Ba De Lo Ni Po     011 --     G9V M5V 
+.             3005 X320000-0    Ba De Lo Ni Po     011 --     G9V M5V
 .             0606 X511000-0    Ba Ic Lo Ni        006 --     M0V M3V
 .             0706 X456000-0    Ba Lo Ni           000 --     F9V 
 .             0806 X874000-0    Ba Lo Ni           004 --     F6V 
 .             1006 X520000-0    Ba De Lo Ni Po     003 --     M0V 
 .             1306 X99A000-0    Ba Lo Ni Wa        022 --     F2V 
-.             1506 X6A2000-0    Ba Fl Lo Ni        017 --     M8V M3V
+.             1506 X6A2000-0    Ba Fl Lo Ni        017 --     M3V M8V
 .             1706 X538000-0    Ba Lo Ni           003 --     M2V 
-.             2006 X433000-0    Ba Lo Ni Po        007 --     M1V M3V 
-.             2706 X757000-0    Ba Lo Ni           028 --     M6V M5V
+.             2006 X433000-0    Ba Lo Ni Po        007 --     M1V M3V
+.             2706 X757000-0    Ba Lo Ni           028 --     M5V M6V
 .             0307 X512000-0    Ba Ic Lo Ni        000 --     M1V 
 .             0507 X500000-0    Ba Lo Ni Va        024 --     M8V 
 .             0907 X684000-0    Ba Lo Ni           013 --     G3V 
@@ -67,8 +67,8 @@ Irugangong
 .             3107 X220000-0    Ba De Lo Ni Po     024 --     G2V 
 .             0208 X9AA000-0    Ba Fl Lo Ni Wa     003 --     M0V M4V
 .             0708 X344000-0    Ba Lo Ni           013 --     F3V 
-.             0808 X130000-0    Ba De Lo Ni Po     008 --     M2V K9V 
-.             1008 X302000-0    Ba Ic Lo Ni Va     001 --     M4V M3V
+.             0808 X130000-0    Ba De Lo Ni Po     008 --     K9V M2V
+.             1008 X302000-0    Ba Ic Lo Ni Va     001 --     M3V M4V
 .             1508 X552000-0    Ba Lo Ni Po        012 --     F3V M5V
 .             1608 XA9A000-0    Ba Lo Ni Wa        032 --     G0V 
 .             1708 X402000-0    Ba Ic Lo Ni Va     013 --     G6V 
@@ -85,9 +85,9 @@ Irugangong
 .             2909 X656000-0    Ba Lo Ni           005 --     G5V M7V
 .             3209 X9B3000-0    Ba Fl Lo Ni        000 --     M8V 
 .             0910 X510000-0    Ba Lo Ni           000 --     M6V 
-.             1510 X635000-0    Ba Lo Ni           003 --     M6V M2V
+.             1510 X635000-0    Ba Lo Ni           003 --     M2V M6V
 .             1810 X746000-0    Ba Lo Ni           014 --     F2V 
-.             1910 X583000-0    Ba Lo Ni           010 --     F1V M0V 
+.             1910 X583000-0    Ba Lo Ni           010 --     F1V M0V
 .             3010 X55A000-0    Ba Lo Ni Wa        003 --     K6V 
 .             3210 X696000-0    Ba Lo Ni           011 --     F8V M6V
 .             0411 X6B2000-0    Ba Fl Lo Ni        000 --     M6V 
@@ -110,7 +110,7 @@ Irugangong
 .             1615 X6B4000-0    Ba Fl Lo Ni        014 --     K4V M3V
 .             1815 XAE8000-0    Ba Fl Lo Ni        010 --     M1V M2V
 .             2015 X886000-0    Ba Lo Ni           004 --     F0V 
-.             2115 X9B2000-0    Ba Fl Lo Ni        014 --     F9V M2V 
+.             2115 X9B2000-0    Ba Fl Lo Ni        014 --     F9V M2V
 .             0716 X252000-0    Ba Lo Ni Po        004 --     G0V 
 .             0916 X351000-0    Ba Lo Ni Po        000 --     F0V M5V
 .             1116 X667000-0    Ba Lo Ni           003 --     F9V 
@@ -136,7 +136,7 @@ Irugangong
 .             0320 X797000-0    Ba Lo Ni           000 --     F5V M1V
 .             0720 X364000-0    Ba Lo Ni           005 --     F4V M5V
 .             1320 X569000-0    Ba Lo Ni           006 --     F2V M5V
-.             2520 X100000-0    Ba Lo Ni Va        006 --     M7V K9V G1V 
+.             2520 X100000-0    Ba Lo Ni Va        006 --     G1V K9V M7V
 .             2820 X426000-0    Ba Lo Ni           000 --     G2V 
 .             0121 X726000-0    Ba Lo Ni           000 --     G6V M5V 
 .             0221 X897000-0    Ba Lo Ni           003 --     G7V 
@@ -156,7 +156,7 @@ Irugangong
 .             1822 X336000-0    Ba Lo Ni           001 --     M8V 
 .             2022 X545000-0    Ba Lo Ni           002 --     F2V 
 .             3122 X525000-0    Ba Lo Ni           005 --     G8V M7V
-.             0123 X232000-0    Ba Lo Ni Po        023 --     M3V M0V
+.             0123 X232000-0    Ba Lo Ni Po        023 --     M0V M3V
 .             0423 X679000-0    Ba Lo Ni           000 --     F1V M0V
 .             0823 X74A000-0    Ba Lo Ni Wa        010 --     M4V 
 .             1023 X659000-0    Ba Lo Ni           012 --     F0V M3V
@@ -165,7 +165,7 @@ Irugangong
 .             1423 X351000-0    Ba Lo Ni Po        004 --     F7V 
 .             1823 X76A000-0    Ba Lo Ni Wa        011 --     K3V M8V
 .             2923 X557000-0    Ba Lo Ni           001 --     F0V 
-.             0124 X9E5000-0    Ba Fl Lo Ni        004 --     M7V M5V
+.             0124 X9E5000-0    Ba Fl Lo Ni        004 --     M5V M7V
 .             0324 X540000-0    Ba De Lo Ni Po     016 --     F5V M7V
 .             0524 X362000-0    Ba Lo Ni           011 --     F9V 
 .             1524 X455000-0    Ba Lo Ni           002 --     F8V 
@@ -174,7 +174,7 @@ Irugangong
 .             1225 X659000-0    Ba Lo Ni           000 --     G8V M8V
 .             2425 X55A000-0    Ba Lo Ni Wa        005 --     F0V M4V
 .             2925 X8C3000-0    Ba Fl Lo Ni        000 --     F9V 
-.             3025 X837000-0    Ba Lo Ni           012 --     M6V M0V
+.             3025 X837000-0    Ba Lo Ni           012 --     M0V M3V
 .             0726 X752000-0    Ba Lo Ni Po        011 --     F1V M2V
 .             0826 X424000-0    Ba Lo Ni           002 --     M5V 
 .             1226 X500000-0    Ba Lo Ni Va        002 --     M0V 
@@ -188,10 +188,10 @@ Irugangong
 .             0228 X401000-0    Ba Ic Lo Ni Va     008 --     M2V M7V
 .             0328 X73A000-0    Ba Lo Ni Wa        002 --     M5V 
 .             0728 X235000-0    Ba Lo Ni           002 --     M4V 
-.             1128 X000000-0    As Ba Lo Ni        014 --     F2V M3D M4V
-.             2528 X786000-0    Ba Lo Ni           022 --     F8V M0D M1V
+.             1128 X000000-0    As Ba Lo Ni        014 --     F2V M3V M4V
+.             2528 X786000-0    Ba Lo Ni           022 --     F8V M0V M1V
 .             2828 X300000-0    Ba Lo Ni Va        000 --     M7V 
-.             3028 X100000-0    Ba Lo Ni Va        013 --     F6V M1V 
+.             3028 X100000-0    Ba Lo Ni Va        013 --     F6V M1V
 .             3228 X737000-0    Ba Lo Ni           015 --     K0V 
 .             0129 X303000-0    Ba Ic Lo Ni Va     000 --     F6V 
 .             0629 X8A0000-0    Ba De Lo Ni        014 --     F7V 
@@ -204,7 +204,7 @@ Irugangong
 .             0530 X434000-0    Ba Lo Ni           003 --     G1V 
 .             0730 X252000-0    Ba Lo Ni Po        004 --     F9V 
 .             1830 X510000-0    Ba Lo Ni           013 --     F5V 
-.             2230 X9D2000-0    Ba Fl Lo Ni        000 --     M6V M3V
+.             2230 X9D2000-0    Ba Fl Lo Ni        000 --     M3V M6V
 .             3030 X994000-0    Ba Lo Ni           025 --     F5V M6V
 .             0531 X341000-0    Ba Lo Ni Po        000 --     K2V M0V
 .             0631 X898000-0    Ba Lo Ni           001 --     F9V M7V
@@ -212,13 +212,13 @@ Irugangong
 .             1131 X884000-0    Ba Lo Ni           004 --     F2V M6V
 .             1531 X210000-0    Ba Lo Ni           024 --     K7V 
 .             1831 X436000-0    Ba Lo Ni           015 --     F9V 
-.             2431 X506000-0    Ba Ic Lo Ni Va     007 --     M5V M3V
+.             2431 X506000-0    Ba Ic Lo Ni Va     007 --     M3V M5V
 .             2531 X237000-0    Ba Lo Ni           004 --     M3V 
 .             3031 X510000-0    Ba Lo Ni           024 --     K7V 
 .             0132 X96A000-0    Ba Lo Ni Wa        000 --     F0V 
 .             0832 X100000-0    Ba Lo Ni Va        004 --     M4V 
 .             0932 X648000-0    Ba Lo Ni           000 --     F7V 
-.             1732 X130000-0    Ba De Lo Ni Po     000 --     M3V M0V
+.             1732 X130000-0    Ba De Lo Ni Po     000 --     M0V M3V
 .             2332 X575000-0    Ba Lo Ni           014 --     F4V 
 .             2832 X240000-0    Ba De Lo Ni Po     010 --     F3V 
 .             0433 X576000-0    Ba Lo Ni           003 --     F4V 
@@ -235,7 +235,7 @@ Irugangong
 .             0635 X444000-0    Ba Lo Ni           001 --     K5V M6V
 .             1335 X7C3000-0    Ba Fl Lo Ni        024 --     K0V M3V
 .             1735 X433000-0    Ba Lo Ni Po        000 --     M3V 
-.             1935 X435000-0    Ba Lo Ni           016 --     M0V M2V 
+.             1935 X435000-0    Ba Lo Ni           016 --     M0V M2V
 .             2335 X210000-0    Ba Lo Ni           004 --     K6V 
 .             2935 X556000-0    Ba Lo Ni           002 --     F9V M2V
 .             0436 X200000-0    Ba Lo Ni Va        003 --     F1III 
@@ -244,7 +244,7 @@ Irugangong
 .             1036 X444000-0    Ba Lo Ni           001 --     F4V 
 .             1236 X510000-0    Ba Lo Ni           004 --     K5V M0V
 .             1336 X685000-0    Ba Lo Ni           003 --     F6V M1V
-.             2236 X7B4000-0    Ba Fl Lo Ni        003 --     G7V K5V 
+.             2236 X7B4000-0    Ba Fl Lo Ni        003 --     G7V K5V
 .             2636 X784000-0    Ba Lo Ni           014 --     M3V 
 .             0137 X654000-0    Ba Lo Ni           005 --     K9V M3V
 .             0537 X353000-0    Ba Lo Ni Po        005 --     F8V M1V
@@ -266,4 +266,4 @@ Anghorrsoug   0440 A67A777-B  G Wa                 602 Va     F5V
 Vuangknekh    1340 E340304-7    De Lo Ni Po        615 Va     F3V M4V
 Gvoloer       1440 D547684-5  G Ag Ni              401 Va     F5V 
 Rrangaeng     1540 C64A87A-3    Wa                 212 Va     G9V 
-.             3140 X525000-0    Ba Lo Ni           005 --     M8V M4V
+.             3140 X525000-0    Ba Lo Ni           005 --     M4V M8V

--- a/res/Sectors/M1105/Kharrthon.sec
+++ b/res/Sectors/M1105/Kharrthon.sec
@@ -60,7 +60,7 @@ Uenughzuen    0905 B000500-D  G As Ni              604 VA     M2V
 Ertogoezung   1205 A00087A-A    As Na              623 Va     F9V
 Akhkokhsursa  2005 C433676-7    Na Ni Po           302 Va     M6V 
 Aezu          2105 C869342-7    Lo Ni              801 Va     F6V 
-Rruorzaen     2405 C55A115-8    Lo Ni Wa           315 Va     M4V M2V
+Rruorzaen     2405 C55A115-8    Lo Ni Wa           315 Va     M2V M4V
 Aear          2905 C779104-A    Lo Ni              303 Va     F8V 
 Nueouruek     3005 C96A435-8  G Ni Wa              103 Va     F9V 
 Vaenoetsuel   3205 C201223-8    Ic Lo Ni Va        704 Va     M5V M7V 
@@ -95,10 +95,10 @@ Oegargvodhol  0508 E537347-6    Lo Ni              201 VA     K2V
 Ngeroelkhuer  0808 C69457A-5  C Ag Ni              414 VA     K5V 
 Tosdzigh      1008 D492541-6  C Ni                 303 VA     F1V 
 Rrorszetszar  1308 B769632-6    Ni                 211 Va     F6V M4V
-Ngaezkhodz    1508 D140237-6    De Lo Ni Po        505 Va     G5V M1D F2V 
+Ngaezkhodz    1508 D140237-6    De Lo Ni Po        505 Va     F2V M1V G5V
 Vudzankuers   2008 A100332-D    Lo Ni Va           104 Va     M4V 
 Okuea         2408 C588351-7  G Lo Ni              611 Va     F2V 
-Koungruerz    3108 C67A516-4  C Ni Wa              704 Va     M8V M4V
+Koungruerz    3108 C67A516-4  C Ni Wa              704 Va     M4V M8V
 Gnaefugaa     0409 E588674-4    Ag Ni              414 VA     K6V 
 Khoeka        0509 C31375A-7    Ic Na              801 VA     M4V 
 Guezegdaedh   1109 B457431-9  G Ni                 614 VA     F5V M8V
@@ -154,11 +154,11 @@ Saeoenkoekhs  0913 B453799-7  G Ag Po              503 VA     F3V M1V
 Aeo           1013 X888100-3    Lo Ni              404 VA     F4V 
 Oksagzadz     1213 C9A7430-6  C Fl Ni              515 VA     F9V 
 Rrokaegz      1313 C7A7675-5    Fl Ni              902 VA     M5V 
-Otia          1513 B400510-A  G Ni Va              105 Va     M0V M7D G4V 
+Otia          1513 B400510-A  G Ni Va              105 Va     G4V M7V M0V
 Gagfueging    1813 C795573-2  G Ag Ni              203 Va     F3V M8V
 Khueagzeaek   1913 C638557-7    Ni                 600 Va     M0V 
 Iofue         2013 E78A101-7  C Lo Ni Wa           603 Va     F0V 
-Faekhusi      2513 C00099A-6    As Hi Na           316 Va     F7D M5D M3V
+Faekhusi      2513 C00099A-6    As Hi Na           316 Va     F7V M5V M3V
 Tsaetsaeaek   0514 C674341-6    Lo Ni              410 VA     F0V 
 Alleu         1314 C8A3537-9  C Fl Ni              910 VA     M8II M6V 
 Oeza          1714 D646000-1  C Ba Lo Ni           600 Va     G8V M7V
@@ -184,14 +184,14 @@ Roegaeghz     0816 D545232-2    Lo Ni              621 VA     F6V
 Dzaeigaezoun  1016 CA9A536-7  G Ni Wa              601 VA     M8V 
 Kesoudhu      1516 C551754-8  G Po                 321 Va     F2V 
 Iuegzae       1616 C120455-A  C De Ni Po           511 Va     G8V 
-Osue          1716 C538365-6    Lo Ni              402 Va     M6V M0V
+Osue          1716 C538365-6    Lo Ni              402 Va     M0V M6V
 Soeza         1816 B348876-5  G                    510 Va     F1V 
 Kfaefoutanae  2816 D9B5748-6  G Fl                 204 Va     M2V M8V 
 Uenguekna     3216 C78487A-2  G                    504 Va     F1V 
 Tsesogtaegh   0117 B5619AA-8    Hi In              113 VA     F0V 
 Uae           0617 E384978-7  C Hi In              614 VA     F8V 
 Llasaegnoudo  0717 B8B5002-9  G Fl Lo Ni           912 VA     M7V 
-Uozouzou      2017 B352200-6    Lo Ni Po           918 Va     F5V M4D M1V
+Uozouzou      2017 B352200-6    Lo Ni Po           918 Va     F5V M4V M1V
 Llaetha       2117 B000987-A  G As Hi Na           103 Va     F9V 
 Rrakha        2717 C55559B-4  C Ag Ni              401 Va     G2V 
 Asaegnig      3017 C8C1A7B-8    Fl Hi In           607 Va     F0V M8V
@@ -202,20 +202,20 @@ Vuenga        2318 A380513-C  G De Ni              305 Va     F5V M8V
 Ghallane      2918 E000235-A  C As Lo Ni           820 Va     F1V 
 Roelagzkedh   3218 B659100-6  G Lo Ni              100 Va     F5V 
 Rragvudhue    0119 C89A232-9    Lo Ni Wa           405 VA     F6V 
-Faesuk        0319 A2217AC-9  G Na Po              921 VA     M7V M6V
+Faesuk        0319 A2217AC-9  G Na Po              921 VA     M6V M7V
 Koughzighaek  0519 E666878-0                       815 VA     F9V 
-Zazouvuving   0619 B300220-7  G Lo Ni Va           800 VA     M5V M2V
+Zazouvuving   0619 B300220-7  G Lo Ni Va           800 VA     M2V M5V
 Gaesaevoe     0719 B87A685-C  G Ni Wa              602 VA     F4V 
-Ouvoe         1119 E486874-0                       604 VA     F2V M0D M7V
+Ouvoe         1119 E486874-0                       604 VA     F2V M0V M7V
 Vaeo          1519 C884523-8    Ag Ni              104 Va     F5V M3V
 Kueghakhe     1619 A200A79-J    Hi Na Va           602 Va     F0V M7V
 Guthorr       1919 B96A441-9    Ni Wa              404 Va     F1V 
 Gegoes        2719 B6A2568-9  G Fl Ni              202 VD     G0V M5V
-Nangurrghong  0420 X5007CD-2  C Na Va              400 VA     F0V M6D M4V 
-Zegzaning     0520 B220442-D  G De Ni Po           100 VA     M3V K8V
+Nangurrghong  0420 X5007CD-2  C Na Va              400 VA     F0V M6V M4V
+Zegzaning     0520 B220442-D  G De Ni Po           100 VA     K8V M3V
 Aetaghinoen   0720 C98A322-9  G Lo Ni Wa           200 VA     F0V M8V
 Gzaetaen      0820 C445559-7  G Ag Ni              714 VA     F6V 
-Deghaelaegh   1120 C764200-5  C Lo Ni              715 VA     F5V M0D F2V 
+Deghaelaegh   1120 C764200-5  C Lo Ni              715 VA     F2V M0V F5V
 Naegoulli     1320 D665402-6  G Ni                 500 Va     F7V 
 Euesiou       1420 B729A74-B    Hi In              814 Va     K1V M0V
 Vaedhezae     1520 E274465-4  C Ni                 202 Va     F5V 
@@ -237,7 +237,7 @@ Koeoung       1521 B577000-9  C Ba Lo Ni           422 Va     F1V
 Soetanoul     1621 D8B5742-1    Fl                 603 Va     M5V M8V
 Toksu         2121 C344102-6  G Lo Ni              201 VD     F5V M4V
 Gzadzuekdue   2621 B425651-C    Ni                 103 VD     K9V M5V
-Llaksae       2721 B635366-7  G Lo Ni              917 VD     M5V M2V
+Llaksae       2721 B635366-7  G Lo Ni              917 VD     M2V M5V
 Kaevou        3121 A340300-9  G De Lo Ni Po        423 VD     F7V 
 Gvoetouknue   0622 C531111-7  C Lo Ni Po           406 VA     F0IV M5V 
 Voduerroetho  0722 E140688-6    De Ni Po           723 VA     F3V M4V
@@ -252,7 +252,7 @@ Lougzageou    3022 B330241-9  G De Lo Ni Po        323 VD     F2V M6V
 Tsikataek     0223 C684453-4  G Ni                 903 VA     F9V M3V
 Ninkounfirs   0323 C510664-4  G Na Ni              314 VA     M2V 
 Uerra         0523 B474265-7    Lo Ni              714 VA     F9V 
-Dzaghaoda     1223 B568147-6    Lo Ni              606 Va     F7V M0D M7V
+Dzaghaoda     1223 B568147-6    Lo Ni              606 Va     F7V M0V M7V
 Fuefa         1423 C566698-7    Ag Ni Ri           816 Va     G8V M6V
 Lleliae       1623 B8B7588-9    Fl Ni              303 Va     G1V M5V
 Uneg          1723 C98A7BB-6  H Wa                 901 Va     F7V M0V
@@ -262,7 +262,7 @@ Aksan         2623 D424554-8    Ni                 114 VD     K6V
 Raellsoukasa  3023 E759233-6  C Lo Ni              412 VD     F5V 
 Ouaea         0424 C774454-8    Ni                 425 VA     F3V M4V
 Nadanllukh    1424 B445479-9    Ni                 104 Va     F5V 
-Kuekfue       1924 A447510-A  G Ag Ni              413 VD     F9V M2D M8V
+Kuekfue       1924 A447510-A  G Ag Ni              413 VD     F9V M2V M8V
 Rraedzousaog  2024 C95A67B-5  G Ni Wa              600 VD     F0V 
 Rrarrraeifae  2224 D796414-2    Ni                 116 VD     F5V M8V
 Zerrou        2324 B567555-9    Ag Ni              226 VD     F2V M0V
@@ -273,13 +273,13 @@ Ikhiks        1025 C552A77-5    Hi In Po           802 Va     F6V
 Arrgots       1425 C868876-7  C                    701 Va     F4V 
 Guegvuar      1525 A9B3450-B  G Fl Ni              304 Va     G8V 
 Ekghaervegz   2125 E5347BB-3                       823 VD     K8V 
-Ksallvuennuz  2625 D3047A8-2  G Ic Va              203 VD     M4V M3V 
+Ksallvuennuz  2625 D3047A8-2  G Ic Va              203 VD     M3V M4V
 Tsollanzae    2825 C669349-9    Lo Ni              111 VD     F2V 
 Oeaeg         3025 E527659-4  C Ni                 400 VD     M8V 
 Ghourragllir  0526 B673246-7  C Lo Ni              914 VA     F0V 
 Angirrinluen  0926 E544423-3    Ni                 804 Va     F5V 
 Soong         1026 B799436-6    Ni                 501 Va     F0V M7V
-Noufuefeaek   1326 B6B3444-A    Fl Ni              733 Va     M1V M0V 
+Noufuefeaek   1326 B6B3444-A    Fl Ni              733 Va     M0V M1V
 Akatsuegerrg  1426 C260611-6  G De Ni              804 Va     F5V 
 Afaedosue     1726 C552333-5    Lo Ni Po           200 VD     G2V 
 Rakfoe        1826 A553420-B    Ni Po              214 VD     F5V 
@@ -314,11 +314,11 @@ Kurrtsas      0129 E8B4456-2    Fl Ni              902 VA     M1V
 Sathuel       0329 C270225-7    De Lo Ni           203 VA     F9V 
 Ghithirr      1329 C9A1723-3  G Fl                 502 Va     M8V 
 Aesaerr       1629 C6555AD-6    Ag Ni              501 Va     G4V 
-Oufuegoknuue  2029 X310200-5    Lo Ni              400 Va     M2V M0V 
-Duekhszoudz   2329 C784651-7    Ag Ni Ri           514 Va     F7V M1D F9V 
+Oufuegoknuue  2029 X310200-5    Lo Ni              400 Va     M0V M2V
+Duekhszoudz   2329 C784651-7    Ag Ni Ri           514 Va     F7V M1V F9V
 Oenova        2529 A443688-B  G Ag Ni Po           914 Va     F5V 
 Kfalla        3029 C363A9A-B    Hi In              600 Va     F1V 
-Aksufekha     1730 E000632-3  C As Na Ni           107 Va     K7V M4D M7V
+Aksufekha     1730 E000632-3  C As Na Ni           107 Va     K7V M4V M7V
 Segoe         2530 C22457C-6  G Ni                 702 Va     G2V 
 Asuesgnousik  2930 C424100-8  G Lo Ni              801 Va     F7V 
 Dhaeru        3030 D774000-5  C Ba Lo Ni           906 Va     M0V M7V
@@ -346,16 +346,16 @@ Raoudue       0633 B553788-6    Ag Po              401 Ve     M1V
 Lloesoouuz    1433 C100776-8  C Na Va              611 Va     M3III 
 Doeouagnoe    1533 C583000-6    Ba Lo Ni           700 Va     F3V 
 Ghueouuoghz   1633 C55568A-6  H Ag Ni              110 Va     F3V 
-Kidzurre      2333 B5A4100-6  G Fl Lo Ni           925 Va     M7V M4V
+Kidzurre      2333 B5A4100-6  G Fl Lo Ni           925 Va     M4V M7V
 Aenggvourr    2533 C383677-9  C Ag Ni              801 Va     M2V M5V
 Gnaeozokhs    2933 C363347-9  C Lo Ni              101 Va     F9V M6V
 Ivighegouel   0734 E584545-0  C Ag Ni              224 Ve     G9V 
 Ugouksidou    0834 C300464-6    Ni Va              702 Ve     M5V 
 Zananots      0934 A455510-9  G Ag Ni              603 Ve     F5V 
 Sadhoae       1434 B352545-7    Ni Po              105 Va     F8V M5V
-Thogknoun     2234 C130577-B  C De Ni Po           500 Va     M3V M2V 
+Thogknoun     2234 C130577-B  C De Ni Po           500 Va     M2V M3V
 Vaeue         2534 C200977-C  C Hi Na Va           111 Va     F6V 
-Unars         2834 E7A6453-4  C Fl Ni              705 Va     M8V M1V
+Unars         2834 E7A6453-4  C Fl Ni              705 Va     M1V M8V
 Gaeaenil      3034 C654540-6    Ag Ni              303 Va     F0V M3V
 Udokue        3134 A7A5542-A  G Fl Ni              200 Va     M1V M5V
 Arrzaer       0835 C569387-8    Lo Ni              212 Ve     K1V M3V
@@ -397,7 +397,7 @@ Raekhagz      3238 C333115-8  C Lo Ni Po           702 VX     G0V
 Aenaesnuzarr  0139 C569200-7    Lo Ni              122 Ve     F1V M5V
 Khaeaenoe     0339 C789874-6                       411 Ve     F2V M7V
 Nevouea       0439 C23238C-7    Lo Ni Po           602 Ve     K9III 
-Kersgaenaer   0639 X300656-2  C Na Ni Va           801 Ve     M1V M0V
+Kersgaenaer   0639 X300656-2  C Na Ni Va           801 Ve     M0V M1V
 Kaetsedhe     0939 B526356-C  C Lo Ni              711 Va     F0III 
 Ghoutson      1139 C624979-9    Hi In              627 Va     F5V M5V
 Ksukidz       1439 C300831-7    Na Va              324 Va     F1V 

--- a/res/Sectors/M1105/Ksinanirz.sec
+++ b/res/Sectors/M1105/Ksinanirz.sec
@@ -147,7 +147,7 @@ Sughue        0116 B559552-B    Ni                 803 Va     K4V
 Rrozanrroeng  0316 C225200-7    Lo Ni              401 Va     M1V M2V
 Uesatsagzon   0716 X543644-0  C Ag Ni Po           124 Va     F0V 
 Raekhirr      0916 E97A597-6    Ni Wa              513 Va     F2V 
-Ruganill      1316 C221AC8-A  G Hi In Na Po        305 Va     G2V F9V 
+Ruganill      1316 C221AC8-A  G Hi In Na Po        305 Va     F9V G2V
 Ogoedha       1516 C799456-7  C Ni                 713 Va     G4V 
 Dzorrgun      2416 X855884-0  C                    402 Va     F9V M2V
 Doe           2716 C899666-8    Ni                 600 Va     F3V 


### PR DESCRIPTION
@inexorabletash asked me to, when submitting bulk sector-data fixen, break up said fixen PRs into different classes of sectors, so here goes with squaring up the stellar data in Undeveloped Sectors.
I'm not making any deliberate attempt to canonicalise star sizes as per T5.10 Book 3 p 28.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is _swapped_ into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).