### PR TITLE
Fix Stiatlchepr sector stellar data

### DIFF
--- a/res/Sectors/M1105/Stiatlchepr.sec
+++ b/res/Sectors/M1105/Stiatlchepr.sec
@@ -42,11 +42,11 @@ Ieda          0105 X8A3000-0    Ba Fl Ni        R  313 Zh G4V
 Iachteblzda   0108 A866568-B  Z Ag Ni              922 Zh M3V
 Shtienzhid    0109 X7A7000-0    Ba Fl Ni        R  403 Zh G3II
 ANTSYITL      0110 C5559B9-C    Hi In              124 Zh A2V
-Kripliv       0202 C310202-7  Z Lo Ni              903 Zh M8V M3V
+Kripliv       0202 C310202-7  Z Lo Ni              903 Zh M3V M8V
 Ekrelemeba    0204 A88A756-D  Z Ri Wa Cp           202 Zh M7III
 Faqrtlivrib   0208 C9DA57A-8    Fl Ni Wa           501 Zh M6V
 Atsndr        0209 D564475-2    Ni                 312 Zh K1IV
-Farrfrz       0301 X210000-0    Ba Ni Po        R  125 Na M2V M1V
+Farrfrz       0301 X210000-0    Ba Ni Po        R  125 Na M1V M2V
 Rdri          0302 C877874-5    Ag Ri              112 Zh G3V
 Ashel         0303 D675587-5    Ag Ni              324 Zh M7V
 Danzhklaj     0304 X566000-0    Ba Ni           R  724 Zh F0V M4V
@@ -56,13 +56,13 @@ Ovridapr      0309 B000777-A    As Ni              322 Zh M8III
 Fivlchta      0310 X100000-0    Ba Ni Va        R  101 Zh M4V
 Dlekrb        0401 C55746A-6    Ag Ni              223 Zh M3V
 JETLKRIA      0402 A889A7A-E  Z Hi In Na           114 Zh M0V M8V
-Ianchzhots    0405 A520576-9  Z De Ni Po           112 Zh M6V M2V
-Zhet          0501 X301000-0    Ba Ic Ni Va     R  134 Na K3V K0V
+Ianchzhots    0405 A520576-9  Z De Ni Po           112 Zh M2V M6V
+Zhet          0501 X301000-0    Ba Ic Ni Va     R  134 Na K0V K3V
 Stiti         0503 X649000-0    Ba Ni           R  120 Zh M2V
 Einj          0505 A954312-B  Z Lo Ni           A  600 Zh M3V
-Ifrdadr       0506 X488000-0    Ba Ni           R  123 Zh M5V M8V M2V
+Ifrdadr       0506 X488000-0    Ba Ni           R  123 Zh M2V M8V M5V
 Yabrabr       0507 X420000-0    Ba De Ni Po     R  524 Zh F5V
-Irnjzdiez     0510 C9A7456-8    Fl Lo Ni           203 Zh M5V M2V
+Irnjzdiez     0510 C9A7456-8    Fl Lo Ni           203 Zh M2V M5V
 Eshdled       0602 B99A554-B  Z Ni Wa              920 Zh F8V
 Aniefr        0605 X799000-0    Ba Ni           R  414 Zh F0V
 Samimpa       0606 B424210-9  Z Lo Ni              424 Zh M6V
@@ -73,7 +73,7 @@ Bretel        0702 A69A767-A  Z Wa                 113 Zh M4V
 Tlieshtalvib  0704 B8577C9-6    Ag                 124 Zh G7V
 Biaeer        0706 B688343-B    Lo Ni              103 Zh M4V
 Friaye        0801 X89A000-0    Ba Ni Wa        R  423 Zh G3V
-Pabrtsian     0802 A000210-C  Z As Lo Ni           213 Zh M9V M7V
+Pabrtsian     0802 A000210-C  Z As Lo Ni           213 Zh M7V M9V
 Estbriatla    0803 C656745-6    Ag                 101 Zh F5V
 Planshemi     0804 A540531-A  Z De Ni Po           122 Zh G4III
 Zhentiablan   0806 C996314-5    Lo Ni              522 Zh F2V M1V
@@ -87,19 +87,19 @@ Iensial       0809 X512000-0    Ba Ic Lo Ni     R  724 Zh A4V
 Blechansh     0901 B100664-B    Na Va              313 Zh M1V
 Iaziavokr     0902 X9B4000-0    Ba Fl Ni        R  112 Zh M6V
 Densensh      0904 B96A743-B  Z Wa                 510 Zh M3V
-Akrefr        0905 X6A6000-0    Ba Fl Ni        R  400 Zh M1V M0V M3V
+Akrefr        0905 X6A6000-0    Ba Fl Ni        R  400 Zh M0V M1V M3V
 Radrbl        0906 X777000-0    Ba Ni           R  322 Zh M8V M9V
 Lofriats      0907 X320000-0    Ba De Ni Po     R  911 Zh F7V
 Reridrfegl    0909 X68A000-0    Ba Ni Wa        R  910 Zh M2V M2V
 Zhdiblnie     1002 C78A320-A    Lo Ni Wa           123 Zh M0V
-Didliench     1004 B968741-7  Z Ag                 310 Zh M6V M0V
+Didliench     1004 B968741-7  Z Ag                 310 Zh M0V M6V
 Tliaqriatl    1005 X7B4000-0    Ba Fl Ni        R  524 Zh M7V
 Fibrflepld    1007 A866548-D  Y Ag Ni              103 Zh K8V
 Ablplontnen   1009 X778000-0    Ba Ni           R  713 Zh M0V
 E'eil         1103 X8B7000-0    Ba Fl Lo Ni     R  411 Zh G8V M5V
 Ritie         1104 C000220-8    As Lo Ni Va        403 Zh M9V
 Eshe          1105 B8C0202-B  Z De Lo Ni        A  804 Zh G6V
-Iat           1106 B9A4223-8    Fl Lo Ni           902 Zh M3V M0V
+Iat           1106 B9A4223-8    Fl Lo Ni           902 Zh M0V M3V
 Letsnansh     1107 X466873-0    Ri              R  103 Zh M0II
 Ekrzhi        1108 B301543-A  Z Ic Ni Va           701 Zh M9V
 Fralzdresh    1110 C989659-9    Ri                 423 Zh M6V
@@ -138,7 +138,7 @@ Rnsqonts      1801 A221301-E  r Lo Ni Po           621 Zh M9III
 Qlanchtlev    1802 B74A200-A  Z Lo Ni Wa           201 Zh M8IV
 ELFOPISH      1803 C100214-C    Lo Ni Va           303 Zh K3V
 Protifr       1806 B500316-C    Lo Ni Va           901 Zh M2V
-Iqradr        1807 X8B7000-0    Ba Fl Ni        R  213 Zh M8V F3IV
+Iqradr        1807 X8B7000-0    Ba Fl Ni        R  213 Zh F3IV M8V
 Shtae         1808 C402577-B    Ic Ni Va           102 Zh F8V
 Qlapli        1809 C100537-8    Ni Va              333 Zh M3V
 Nienziencha   1810 E330210-6    De Lo Ni Po        324 Zh M6V
@@ -148,9 +148,9 @@ Nefbriati     1904 X300000-0    Ba Ni Va        R  313 Zh K3IV
 Prprblatnots  1906 A7A3644-B  Z Fl                 404 Zh M7V
 Chteflrzh     1907 A595400-C    Ni                 202 Zh F9V
 Pliaqldliansh 1908 B7476B8-6    Ag                 200 Zh M2V
-Tetlez        1910 X8C5000-0    Ba Fl Ni        R  822 Zh M9V F2V
+Tetlez        1910 X8C5000-0    Ba Fl Ni        R  822 Zh F2V M9V
 Idliechvrint  2007 X259000-0    Ba Ni           R  322 Zh K2III
-Dadrinj       2010 C565436-5    Ni                 523 Zh F7V M1IV
+Dadrinj       2010 C565436-5    Ni                 523 Zh M1IV F7V
 Shtialzhdants 2104 C96A685-5    Ri Wa              620 Zh G7V
 Iapiapr       2105 B664787-6    Ag                 103 Zh G3IV
 DIABLSEZHCHE  2107 A100966-C  Z Hi In Na Va        725 Zh M2III
@@ -162,15 +162,15 @@ Irienj        2203 B402100-C    Ic Lo Ni Va     A  110 Zh F2III
 IANTSAZH      2204 C856AE9-9    Hi                 125 Zh M8V
 Ikqresh       2205 A539472-D  Z Ni                 104 Zh M6V
 Emme          2207 X96A000-0    Ba Ni Wa        R  202 Zh G6V
-Nedrchti      2209 B784556-8  Z Ag Ni              224 Zh M9V M6D
+Nedrchti      2209 B784556-8  Z Ag Ni              224 Zh M6V M9V
 SHTEVRI       2302 C6839B9-9    Hi              U  113 Zh M5V
 Vleqiafie     2303 D453788-7    Po                 114 Zh M3V
 Iabokrfiqr    2304 A0005AA-C  Z As Ni              113 Zh K5IV
 Zhdielfon     2305 C65A455-9    Ni Wa              133 Zh M8IV
 Tsallize      2306 X647000-0    Ba Ni           R  900 Zh M3V M3V
-Pientne       2308 X9C7000-0    Ba Fl Ni        R  022 Zh G3V M1D
+Pientne       2308 X9C7000-0    Ba Fl Ni        R  022 Zh G3V M1V
 Qlrie'        2401 A343657-E  Y Po                 422 Zh F4V
-FERZDLEZHDR   2402 A200A54-D  Z Hi In Na Va Cp     221 Zh K2III M3D
+FERZDLEZHDR   2402 A200A54-D  Z Hi In Na Va Cp     221 Zh K2III M3V
 Onzhshti      2404 D556445-6    Ni                 414 Zh M6V
 Qrezdie       2406 B958724-A    Ag                 104 Zh F7V
 Shtobrfledri  2407 C736AAA-9    Hi                 113 Zh M7V
@@ -185,10 +185,10 @@ Dietlfrepr    2501 A400568-C  Z Ni Va              724 Zh K2V
 Tanjkrazh     2502 E500474-8    Ni Va              622 Zh F3III
 Defranz       2505 A464764-8  Z Ag Ri              324 Zh G1IV
 Qrebriql      2506 B667333-8    Lo Ni              404 Zh M7V
-IEZDRA        2507 C7B2A57-9    Fl Hi              114 Zh M9V M7D
+IEZDRA        2507 C7B2A57-9    Fl Hi              114 Zh M7V M9V
 Vlietsfria    2602 AAA6644-A  Z Fl                 221 Zh G4V
 Eqplishi      2603 B8A6887-8    Fl                 224 Zh M6V
-Vrijdonzh     2605 B789543-7  Z Ni                 714 Zh F8V M2D
+Vrijdonzh     2605 B789543-7  Z Ni                 714 Zh F8V M2V
 Driabribri    2608 B350565-C  Z De Ni Po           113 Zh K3IV
 Niadrqle      2701 C200854-9    Na Va              500 Zh M2III
 Jdiedlijadr   2702 B556302-A    Lo Ni              225 Zh M5V
@@ -209,10 +209,10 @@ Dleshevl      2905 X000000-0    As Ba Lo Ni     R  125 Zh K3II
 Zheiant       2906 A667266-A  Z Lo Ni              822 Zh M7V
 TLIAABRBA     3004 A987999-E  Y Hi In Ri Cp        934 Zh F6V
 Zdibrv        3006 A53A684-B  Z Wa                 304 Zh F4V
-Qretsanjtsie  3009 E688320-6    Lo Ni              204 Zh M8V M1D
+Qretsanjtsie  3009 E688320-6    Lo Ni              204 Zh M1V M8V
 Natebl        3010 C656267-4    Lo Ni              424 Zh F7V
 Pieli         3101 X232000-0    Ba Lo Ni Po     R  623 Zh K2III
-Krnchprpr     3103 C785866-6    Ri                 224 Zh F3V M2IV
+Krnchprpr     3103 C785866-6    Ri                 224 Zh M2IV F3V
 Tszdiaanz     3106 B101434-9  Z Ic Ni Va           724 Zh K7V
 Echzhodliebr  3201 X7A7000-0    Ba Fl Lo Ni     R  514 Zh G3V
 Shachdie      3202 B697855-6                       523 Zh M5V
@@ -221,7 +221,7 @@ Yeplefplifr   3205 X300000-0    Ba Lo Ni Va     R  602 Zh F3V
 Enshi         3206 X000000-0    As Ba Lo Ni     R  404 Zh M4V
 Imtiejets     3207 C893552-8    Ni                 303 Zh F9V
 Bradl         3208 B697563-7    Ag Ni              913 Zh F8V
-Bozdetl       3209 B56515A-7    Lo Ni              613 Zh M6
+Bozdetl       3209 B56515A-7    Lo Ni              613 Zh M6V
 Fietlfedr     3210 A427124-C  Z Lo Ni              204 Zh K4V
 
 @SUB-SECTOR E: Chtasi SECTOR: Stiatlchepr
@@ -245,7 +245,7 @@ Asitl         0311 D357553-4    Ag Ni              225 Zh M7IV
 Tlaprzhe      0312 A7A2200-A  Z Fl Lo Ni           102 Zh M9V
 Iezhdaplkr    0313 B66A426-B    Ni Wa              214 Zh G3IV
 Kriashzhd     0315 A000977-A    As Hi In Na     A  201 Zh K2III
-FLIMSTEZHQLI  0318 C440ACD-C    De Hi In Po     A  112 Zh M2V M2D
+FLIMSTEZHQLI  0318 C440ACD-C    De Hi In Po     A  112 Zh M2V M2V
 Shitsteplavl  0319 B663856-6    Ri                 335 Zh F5IV
 Danchqanshez  0411 B100543-B  Z Ni Va              624 Zh K8II
 Dlanzhiapl    0412 C42277A-5    Na Po              111 Zh M3IV
@@ -253,7 +253,7 @@ Ia'qadl       0413 A563302-A  Z Lo Ni              101 Zh G2V
 Vrenzchtebl   0417 X343000-0    Ba Lo Ni Po     R  323 Zh M1V
 PETSRAFL      0418 C626ACC-8    Hi In              320 Zh F3III
 Aplfr         0419 A588741-8    Ag Ri              403 Zh M3II
-Chtiqalinzh   0511 B384374-8    Lo Ni              322 Zh M8V M1D
+Chtiqalinzh   0511 B384374-8    Lo Ni              322 Zh M1V M8V
 Ekriepl       0513 B877878-B  Z Ga                 523 Zh M7V
 Jdezhea       0515 C8A7400-A    Fl Ni              802 Zh G2IV
 Plobrzhetzh   0517 X610000-0    Ba Ni           R  424 Zh M1V M3V
@@ -275,7 +275,7 @@ CHTONSEPRDAR  0811 B4239BD-C    Hi In Po           124 Zh M3
 Qae           0812 B68A873-A  Z Ri Wa              801 Zh M8IV
 CHTASI        0813 A442AC8-D  Z Hi In Po Cp        302 Zh F8V
 Ianseial      0816 B554532-9    Ag Ni              500 Zh M6III
-Vlashabrjiaq  0818 E100657-A    Na Ni Va           900 Zh K3V M1D
+Vlashabrjiaq  0818 E100657-A    Na Ni Va           900 Zh K3V M1V
 Dlinzhsht     0819 A444300-C  Z Lo Ni              913 Zh M5IV
 Chtodrvrensh  0820 B554532-9    Ag Ni              400 Zh G2III
 
@@ -300,12 +300,12 @@ Zhieshtaech   1214 X510457-5    Ni                 415 Zh K3III
 Nela          1215 C88A659-7    Ri Wa              124 Zh M8V
 Aktsa         1216 B466310-C    Lo Ni              123 Zh F7V
 Metilar       1219 A433300-D  Z Lo Ni Po           302 Zh G1V
-Ichnakljetl   1220 C8C6533-9    Fl Ni              114 Zh M5V G7V
+Ichnakljetl   1220 C8C6533-9    Fl Ni              114 Zh G7V M5V
 Tladeplovieb  1312 B300332-D  Z Lo Ni Va           823 Zh F2V
 Vleakrzhel    1314 C152798-A    Po                 522 Zh M5III
 Drantszhdara  1316 A512226-9  Z Ic Lo Ni           834 Zh F6V
 ENSHQRAJ      1317 B89A9EH-9    Hi In Wa           213 Zh G9V
-Ezh Tsiadlzd  1318 B7A2756-8  Z Fl                 203 Zh M9V M7D
+Ezh Tsiadlzd  1318 B7A2756-8  Z Fl                 203 Zh M7V M9V
 Anzhzhrdeql   1412 B468257-B  Z Lo Ni              824 Zh G2IV
 EJIEK         1413 C546988-5    Hi In              803 Zh M4V
 Dekrinsh      1414 X342000-0    Ba Lo Ni Po     R  614 Zh K3V
@@ -315,9 +315,9 @@ Pipleql       1513 X000000-0    As Ba Lo Ni     R  314 Zh K0V
 Tlaflzdit     1514 X425000-0    Ba Lo Ni        R  424 Zh F6V
 Eprtlilt      1515 X677000-0    Ba Lo Ni        R  204 Zh G3V
 Qribrr        1519 E53A114-6    Lo Ni Wa           310 Zh M5IV
-Chtiantseia   1520 A896620-9    Ag                 713 Zh M7V M2D
+Chtiantseia   1520 A896620-9    Ag                 713 Zh M2V M7V
 Tlianshzabl   1614 B400310-8    Lo Ni Va           822 Zh F1V
-Serezhdflyia  1615 A530878-B  Z De Na Po        A  601 Zh M6V F1V
+Serezhdflyia  1615 A530878-B  Z De Na Po        A  601 Zh F1V M6V
 RAVRVEDR      1616 B331976-C  Z Hi Na Po           701 Zh M4IV
 Atieanj       1619 X100000-0    Ba Lo Ni Va     R  222 Zh M2III
 
@@ -335,7 +335,7 @@ Zienseltian   1718 B744110-B    Lo Ni              115 Zh M1V
 Vedreblchien  1719 C661353-9    Lo Ni              713 Zh G2V
 Senens        1720 C656656-8    Ag Ni              224 Zh F7V M1V
 Etpefltse     1811 B9667BA-A    Ag                 321 Zh G4V
-Dreflpatl     1812 E125540-9    Ni                 500 Zh M3V M6D
+Dreflpatl     1812 E125540-9    Ni                 500 Zh M3V M6V
 Shtiefrqa     1814 C454467-6    Ni                 424 Zh F8IV
 IEZDOTLABL    1817 B645998-C  Z Hi In              212 Zh M7V
 Shtamzhdeaz   1819 C745689-A    Ag Ni              110 Zh F7V M6V
@@ -345,7 +345,7 @@ Binzhachten   1918 A100100-C  Z Lo Ni              202 Zh K1III
 Binchzhdadri  1919 A549200-D  Z Lo Ni              223 Zh M3V
 Vlietlzhdie   1920 C756421-6  Z Ni                 302 Zh M2V M2V
 Vlableql      2012 X7A6000-0    Ba Fl  Ni       R  300 Zh G7V
-ZDINSAQESTIA  2014 A899A99-E  Z Hi In              722 Zh F7V M7D
+ZDINSAQESTIA  2014 A899A99-E  Z Hi In              722 Zh F7V M7V
 NEDLEZHDR     2015 A999999-F  Z Hi In Ri Cp        313 Zh G3IV
 Sidrdlenj     2016 B40088B-9    Na Va              234 Zh F3
 Driaflzha     2020 C230125-B    De Lo Ni Po        603 Zh K4V
@@ -355,8 +355,8 @@ Itlniazhbekr  2115 D887400-5    Ni                 301 Zh M7V
 Zhatlchte     2116 D964357-8    Lo Ni              333 Zh G8V
 Qlenjieplbe   2119 C564654-4    Ag Ri              123 Zh M2V
 Kreztliap     2211 A123544-C  Z Ni Po              104 Zh K3V
-Tlrstea       2212 X697000-0    Ba Ni           R  313 Zh M6V M4V
-Piechovrash   2215 C595220-9    Lo Ni              522 Zh M2V M5II
+Tlrstea       2212 X697000-0    Ba Ni           R  313 Zh M4V M6V
+Piechovrash   2215 C595220-9    Lo Ni              522 Zh M5II M2V
 Rilqlapl      2216 C741665-5    Ni Po              723 Zh K7III
 Qraqltlaqrzd  2217 C654110-5    Lo Ni              824 Zh M3V
 Nietliaf      2218 C120247-C    De Lo Ni Po        414 Zh M7IV
@@ -372,7 +372,7 @@ Pezzhdadrkodr 2413 X87A000-0    Ba Ni Wa        R  103 Zh G5IV
 Zeqla         2415 D100401-B    Ni Va              223 Zh M5III
 Obdiprlfl     2416 C8A7659-C    Ag Fl Ni           134 Zh G7V
 Tsiebrensh    2417 B773558-C  Z Ni                 712 Zh M7V
-Teshte        2420 X9C9000-0    Ba Fl Ni        R  314 Zh M9V M6III
+Teshte        2420 X9C9000-0    Ba Fl Ni        R  314 Zh M6III M9V
 
 @SUB-SECTOR H: Chatsiebrefr SECTOR: Stiatlchepr
 #
@@ -385,7 +385,7 @@ Vlel          2519 D769756-7    Ri                 620 Zh M7V
 Chtadlzhebl   2520 C694576-7    Ag Ni              123 Zh M3V
 Dlabrfrin     2613 E96A783-3    Ri Wa              423 Zh G0V
 Tliea         2614 E000201-8    As Lo Ni        A  214 Zh K0V
-Iplmiek       2615 C768234-5    Lo Ni              101 Zh M8V F1V
+Iplmiek       2615 C768234-5    Lo Ni              101 Zh F1V M8V
 Krbrzdapabr   2616 X000000-0    As Ba Ni        R  215 Zh K3V
 Fleztelrnch   2617 B9B1656-9  Z Fl                 524 Zh M3V M3V
 Zhedebril     2618 C966449-8    Ni                 222 Zh G3V
@@ -394,14 +394,14 @@ Fletstsal     2716 B879599-C  Z Ni                 220 Zh F8V M7V
 Eprqiemisod   2717 D434551-6    Ni                 310 Zh M2V
 Chtotlshte    2719 A624542-A  Z Ni                 124 Zh M5V
 Kefints       2720 D200375-9    Lo Ni Va           525 Zh K3V
-Kretsejivlzd  2811 E600663-8    Na Ni Va           322 Zh M0V K1V
+Kretsejivlzd  2811 E600663-8    Na Ni Va           322 Zh K1V M0V
 Beshpri       2812 A440472-D  Z De Ni Po           323 Zh K5V
 Batsbevl      2815 C9D447A-5    Fl Ni              221 Zh M8V
 Vladrkrie     2819 EA79120-5    Lo Ni              622 Zh G9V
 Ietliefatl    2912 B668378-A  Z Lo Ni              114 Zh M9V
 Datlzdet      2914 A68A467-C  Z Ni Wa              603 Zh M0V
-Ezchta        2915 A986789-9  Z Ag Ri           A  220 Zh M7V M0V
-Anzhip        2917 C4848AA-7    Ga                 302 Zh M6V M3V
+Ezchta        2915 A986789-9  Z Ag Ri           A  220 Zh M0V M7V
+Anzhip        2917 C4848AA-7    Ga                 302 Zh M3V M6V
 Lavvlananzh   2918 X8C5000-0    Ba Fl Ni        R  624 Zh F0V M6V
 Chatsiebrefr  2919 A86A386-E  Z Lo Ni Wa Cp        101 Zh G2IV
 Majflial      2920 B78A57A-B    Ni Wa              413 Zh M8V
@@ -417,7 +417,7 @@ CHalklozh     3119 E888472-7    Ni                 520 Zh M8V
 Tsialzhd      3120 B523455-9    Ni Po              110 Zh M3V
 Kriechstie    3211 B8675A9-A    Ag Ni              213 Zh G2V
 Lapieflt      3214 A8684BE-B  Z Ga Ni              212 Zh G1IV
-Revzdier      3215 X696000-0    Ba Ni           R  114 Zh M3V M1V
+Revzdier      3215 X696000-0    Ba Ni           R  114 Zh M1V M3V
 Chtekl        3216 X240760-1    De Po           R  600 Zh K2V
 Driefbranch   3217 AA9A335-D  Z Ag                 324 Zh M6V
 Shteplazh     3219 X9C8000-0    Ba Fl Ni        R  201 Zh M8V
@@ -440,7 +440,7 @@ Siabliafrble  0226 C310321-8    Lo Ni              201 Zh K2V
 Ieet          0228 X540000-0    Ba De Ni Po     R  614 Zh M2V M2V
 Deprdlevldai  0230 A400366-A  Z Lo Ni Va           415 Zh K3V
 Ebrbekr       0321 X723000-0    Ba Ni Po        R  312 Zh F6IV
-Daf           0324 C673400-8    Lo Ni              824 Zh F5V M2D
+Daf           0324 C673400-8    Lo Ni              824 Zh F5V M2V
 Ardlo'        0325 A753762-A  Z Po                 801 Zh M7IV
 Dlavlidafl    0326 C500864-9    Na Va              321 Zh F8V
 Shatliedrekl  0328 C79A400-B    Ni Wa              200 Zh M5V
@@ -448,7 +448,7 @@ Brenzheliaf   0330 A244695-B  Z Ag Ni              724 Zh F3V M1V
 Naranzatl     0423 X6B1000-0    Ba Fl Ni        R  023 Zh M9V
 Flienshtlap   0425 A867453-B  Z Ag Ni              223 Zh M2V
 Adinszl       0427 X000000-0    As Ba Ni        R  113 Zh K2V
-Feldostlish   0429 D543667-2    Ni Po              125 Zh F7V M3D
+Feldostlish   0429 D543667-2    Ni Po              125 Zh F7V M3V
 Efazdosh      0430 B434130-D  Z Lo Ni              122 Zh F3IV
 Fraflzodi     0521 A776334-A  Z Lo Ni              902 Zh M7V
 Tlashakritl   0523 C434698-9    Ni                 313 Zh G2IV
@@ -501,7 +501,7 @@ Niazepfrye    1223 A432721-B  Z Na Po              523 Zh F8V
 Zhdienzh      1224 E400431-5    Ni Va              204 Zh M3V
 Sheliajnenz   1226 D100678-7    Na Ni Va           404 Zh K2V
 Imzl          1227 C565767-5    Ri                 402 Zh G3V
-Tleprshtafrd  1228 C4303A8-B  Z De Lo Ni Po        913 Zh M2V M3D
+Tleprshtafrd  1228 C4303A8-B  Z De Lo Ni Po        913 Zh M2V M3V
 Ismlz         1324 C423389-B    Lo Ni Po           702 Zh F5V
 Eafrikrachl   1325 C652300-6    Lo Ni Po           602 Zh M7V
 Ozh           1327 A1008AA-C  Z Na Va              522 Zh K7V
@@ -516,8 +516,8 @@ Anslianzhie   1526 C7767CE-8    Ag                 520 Zh G6V
 Ezianzh       1529 A8447B9-7  Z Ag                 424 Zh M9V
 Endant        1621 B3779C9-C  Z Hi In              502 Zh G1IV
 Dlebadl       1624 AA67958-C  Z Lo Ni              215 Zh G3V
-Vinzhicht     1628 B402755-B  Z Ic Na Va           322 Zh M7V M1D
-Dlilqesh      1630 A000673-D  r As Na Ni           501 Zh M4V M1V
+Vinzhicht     1628 B402755-B  Z Ic Na Va           322 Zh M1V M7V
+Dlilqesh      1630 A000673-D  r As Na Ni           501 Zh M1V M4V
 
 @SUB-SECTOR K: Dleefl SECTOR: Stiatlchepr
 #
@@ -551,8 +551,8 @@ Chtiatsfians  2225 C547827-9    Ag                 210 Zh F7V
 Shade'krach   2227 C443120-5    Lo Ni Po           324 Zh M2V
 KLEZHIRZDAVL  2230 A347999-A  Z Hi In              702 Zh F3IV
 TLIENTSE'     2321 C666966-A    Hi In              402 Zh G3V
-Sish          2322 B200355-A  Z Lo Ni Po           514 Zh M2V K4V
-Zdrieyipra    2324 B142520-4    Ni Po              324 Zh F1II M6D
+Sish          2322 B200355-A  Z Lo Ni Po           514 Zh K4V M2V
+Zdrieyipra    2324 B142520-4    Ni Po              324 Zh F1II M6V
 Da'chariedle  2325 X200000-0    Ba Ni           R  622 Zh K3V
 Kliev         2326 B356320-8    Lo Ni              512 Zh M4V
 Antsazhiefl   2327 C7CA100-9    Fl Lo Ni Wa        423 Zh A6V
@@ -569,7 +569,7 @@ Otstlanzhast  2426 A86976A-D  Z Ri                 820 Zh G7V
 #PlanetName   Loc. UPP Code   B   Notes         Z  PBG Al LRX *
 #----------   ---- ---------  - --------------- -  --- -- --- -
 Dlefrplrdlia  2521 A521452-C  Z Ni Po              512 Zh M2V
-Atlzhenszin   2525 C6A7535-8    Ag Fl Ni           314 Zh M8V M4V
+Atlzhenszin   2525 C6A7535-8    Ag Fl Ni           314 Zh M4V M8V
 Shenzchtenzh  2526 E157247-5    Lo Ni              902 Zh K4V
 Fiklbadlstie  2622 D20069B-7    Na Ni Va           804 Zh F3V
 Qlazhdopizze  2623 A644622-C  Z Ag Ni              304 Zh M9V
@@ -581,11 +581,11 @@ Chepezhi      2628 C310300-9    Lo Ni              224 Zh K1III
 Stichdlanzh   2629 B200588-C  Z Ni Va              513 Zh F2V
 Pliez         2722 C688213-9    Lo Ni              110 Zh M2V M2V
 Aer           2725 CA8A675-B    Ni Ri Wa           920 Zh M6V
-Enchtanjtl    2729 B675331-6    Lo Ni              125 Zh M7V M3V
+Enchtanjtl    2729 B675331-6    Lo Ni              125 Zh M3V M7V
 Tedl          2730 A364200-B  Z Lo Ni              121 Zh G4V
 Kevdrietsdl   2822 D13179A-7    Na Po              603 Zh F6V
 Chanjshasta   2823 B7A8886-9  Z Fl                 115 Zh G2IV
-Keprzenzh     2824 C341563-9    Ni Po              301 Zh F3V M2D
+Keprzenzh     2824 C341563-9    Ni Po              301 Zh F3V M2V
 Achpieagrs    2825 E847352-5    Lo Ni           R  200 Zh M3V
 FIEVR         2826 AAA7AA7-D  Z Fl Hi Ni           402 Zh M6V
 Brianrienzc   2922 B14379C-C  Z Po                 401 Zh F6V M2V
@@ -605,11 +605,11 @@ Blanzievl     3124 C826367-B    Lo Ni              401 Zh F4IV
 Qledtlepro    3128 A846778-8  Z Ag                 520 Zh M9V
 Ienttez       3130 A733337-C  Z Lo Ni Po           214 Zh F6V K3V
 Plazhepzde    3223 A445320-B  Z Lo Ni              424 Zh M2IV
-Yiadle        3224 D958120-3    Lo Ni              412 Zh M7V M2D
+Yiadle        3224 D958120-3    Lo Ni              412 Zh M2V M7V
 Jdenteste     3226 E744400-6    Ni              A  214 Zh F7V
 Ablshtibr     3227 D346620-4    Ag Ni              623 Zh K5V
 Dienz         3228 C540230-7    De Lo Ni Po        224 Zh M6V
-Zdenshkezie   3229 C440379-5    De Lo Ni Po        102 Zh M3V M2D
+Zdenshkezie   3229 C440379-5    De Lo Ni Po        102 Zh M2V M3V
 Eqle          3230 A7A5200-9  Z Fl Lo Ni           622 Zh G2V
 
 @SUB-SECTOR M: Zhdovie SECTOR: Stiatlchepr
@@ -625,8 +625,8 @@ Iatlafref     0138 B110213-A  Z Lo Ni              622 Zh K7IV
 Zheflmiats    0231 C720779-4    De Na Po           913 Zh M2III
 Ekrzhia'paz   0232 A200830-C  Z Na Va              822 Zh M8V
 SHIEZIBLCHR   0233 B6679C9-7    Hi In              313 Zh G1V
-Zhialidlad    0234 B133898-B    Na Po              902 Zh F2V M2D
-Soliejplan    0235 E544338-8    Lo Ni              500 Zh M4D
+Zhialidlad    0234 B133898-B    Na Po              902 Zh F2V M2V
+Soliejplan    0235 E544338-8    Lo Ni              500 Zh M4V
 Edlneq        0236 B69367A-6                       124 Zh M3V
 Aob           0238 X400000-0    Ba Ni Va        R  310 Zh K6III
 Adlzhdosh     0333 A747974-D  Z Lo Ni              701 Zh M7V
@@ -641,7 +641,7 @@ Volzhdiesh    0432 B975556-7    Ni                 310 Zh G5V
 Siebrtlapl    0434 X945000-0    Ba Ni           R  102 Zh F7V
 Zhiechtsant   0435 X210000-0    Ba Lo Ni        R  303 Zh M1III
 Ezh Chiezii   0438 C000435-8    As Ni              904 Zh K7V
-Yiazdotsel    0440 C524541-5    Ni                 424 Zh F2V M2D
+Yiazdotsel    0440 C524541-5    Ni                 424 Zh F2V M2V
 Jdapr         0533 B567776-8    Ag Ri              800 Zh G7V
 Ikrre         0538 A757558-B  Z Ag Ni              722 Zh F1IV
 Anchiabriar   0631 C268214-A  Z Lo Ni              414 Zh G3V
@@ -654,7 +654,7 @@ Drakriedie    0733 D330325-8    De Lo Ni Po        524 Zh M6V
 Tatliel       0734 B676776-8  Z Ag                 602 Zh G6IV
 Ziaro         0738 C245656-A    Ag Ni              222 Zh F7III
 Zhdedlqlavr   0739 B653463-A    Ni Po              514 Zh F3V
-Ialzda        0740 X200000-0    Ba Ni Va        R  601 Zh K2V M3D
+Ialzda        0740 X200000-0    Ba Ni Va        R  601 Zh K2V M3V
 Fretlbrevlra  0833 C879323-6    Lo Ni              724 Zh M5V
 Abr           0835 C741220-7    Lo Ni Po           425 Zh M2V
 Ste'desh      0840 A000343-B  Z As Lo Ni           922 Zh F5V
@@ -674,7 +674,7 @@ LEBAEFR       1037 A2009EH-D  Z Hi In Na Va Cp     201 Zh K3IV
 Efchiqmie     1038 B610555-8    De Ni              602 Zh M0III
 Aazbi         1133 B231100-B  Z Lo Ni Po           814 Zh M8V
 Kelokievlch   1134 E200230-8    Lo Ni Va           401 Zh M2IV
-Moiple        1137 X000000-0    As Ba Lo Ni     R  502 Zh M6V M2D
+Moiple        1137 X000000-0    As Ba Lo Ni     R  502 Zh M2V M6V
 Idlki         1138 X8B7000-0    Ba Fl Lo Ni     R  734 Zh M6V
 Aprfof        1139 A646200-C  Z Lo Ni              234 Zh F7V
 Dashyi        1140 X954000-0    Ba Ni           R  902 Zh M2II
@@ -685,18 +685,18 @@ Plavebldrat   1236 C435300-A    Lo Ni              623 Zh G3IV
 ZhafrieZo     1238 A867A59-C  Z Hi In              403 Zh K2V K2V
 Vesh          1240 B123779-9  Z Na Po              302 Zh K7V M9V
 Iartliv       1332 C210142-A    Lo Ni              422 Zh M6V
-Adlvazdiet    1335 C889300-9    Lo Ni              501 Zh M6II K9II
+Adlvazdiet    1335 C889300-9    Lo Ni              501 Zh K9II M6II
 Qaazepl       1336 X788744-1    Ag Ri           R  810 Zh F3V
 Chezchtans    1337 A654300-A  Z Lo Ni              605 Zh M0V
 Stenchzhjo    1339 D779679-6    Ni                 723 Zh G5V
 Yornetsia     1431 B472541-9  Z Ni                 103 Zh G2IV
 Ianchinzh     1434 X544000-0    Ba Lo Ni        R  212 Zh M4V M4V
 Klrqrek       1435 X7AA000-0    Ba Fl Lo Ni     R  405 Zh G2V
-Iprtlien      1436 X675000-0    Ba Lo Ni        R  000 Zh M3V F2V
+Iprtlien      1436 X675000-0    Ba Lo Ni        R  000 Zh F2V M3V
 Tsiaprinjd    1438 B452426-9    Ni Po              801 Zh G1III
 Tanshvikl     1439 B975500-B  Z Ag Ni              100 Zh K2V
 Preiabr       1440 X544000-0    Ba Lo Ni        R  222 Zh M7IV
-FRAKRNA       1532 A858999-A  Z Hi                 122 Zh F2V M2D
+FRAKRNA       1532 A858999-A  Z Hi                 122 Zh F2V M2V
 Plefrchiepl   1537 C535454-9    Ni                 213 Zh M9V
 Dleam         1538 X300000-0    Ba Ni Va           904 Zh K2IV
 Ieblianzh     1632 A595600-B  Z Ag Ni              313 Zh M3II
@@ -720,9 +720,9 @@ Ianjbem       1836 X7518AC-1    Po              R  613 Zh M6V
 Rofrtliezhi   1837 C642542-5    Ni Po              202 Zh M2V M2V
 Zdiatchedrie  1838 C454534-8    Ag Ni              801 Zh M4V
 Senzhprepro   1933 A75A355-B  Z Lo Ni Wa           311 Zh K0V M3V
-Ieblqlanch    1934 X752682-3    Ni Po           R  403 Zh M5V M8V M2V
+Ieblqlanch    1934 X752682-3    Ni Po           R  403 Zh M2V M8V M5V
 Iekoz         1935 X7B5000-0    Ba Fl Lo Ni     R  222 Zh F5V
-Ibrqr         1936 XAC6000-0    Ba Fl Lo Ni     R  013 Zh M5V M2V
+Ibrqr         1936 XAC6000-0    Ba Fl Lo Ni     R  013 Zh M2V M5V
 Yevlchtej     1938 D559410-4    Ni                 102 Zh F8V
 Shivtlevrb    1939 D687300-8    Lo Ni              120 Zh G0V
 Atlinzzie     2031 B200400-E  Z Ni Va              302 Zh F6V
@@ -758,7 +758,7 @@ Redrshi       2440 B722788-5  Z Na Po              211 Zh M2V
 Vliekr        2531 E430662-7    De Na Ni Po        402 Zh K3V
 Kliensh       2532 X656678-2    Ag Ni           R  523 Zh M4V
 Iefiastaflenc 2538 B846100-C  Z Lo Hi              510 Zh F3V
-EVTLIBLDRIVL  2540 B300997-B    Hi Ni Va           602 Zh M3V M1V
+EVTLIBLDRIVL  2540 B300997-B    Hi Ni Va           602 Zh M1V M3V
 Shitl         2632 A9A8747-B  Z Fl                 210 Zh G4V
 Qribainzhdr   2634 A387668-D  Z Ag Ni Ri Cp        922 Zh G2V
 Tladrach      2639 D100576-7    Ni Va              415 Zh M2V M2V
@@ -768,11 +768,11 @@ Pledl         2733 B546677-7  Z Ag Ni              524 Zh M6V
 Preldlajaprza 2738 X566000-0    Ba Ni           R  320 Zh G5V
 Onzi          2835 C221774-9    Na Po              501 Zh M2III
 Zdanshchiail  2837 B685323-A  Z Lo Ni              914 Zh G3V
-Plibrpiplit   2838 C443389-A    Lo Ni Po           500 Zh F7V M3D
+Plibrpiplit   2838 C443389-A    Lo Ni Po           500 Zh F7V M3V
 Drepaklstimva 2839 B342100-C  Z Lo Ni Po           622 Zh M1V
 Joniplielva   2931 X430000-0    Ba De Ni Po     R  424 Zh F3IV
 Bliazhdrebr   2932 D756597-3    Ag Ni              223 Zh M4V
-Oliaitlakrch  2935 C400113-B    Lo Ni Va           322 Zh K4V A2D
+Oliaitlakrch  2935 C400113-B    Lo Ni Va           322 Zh A2V K4V
 Zdavile       2936 E9A2334-7    Fl Lo Ni           923 Zh G1IV
 Ijia          2937 D430311-6    De Lo Ni Po        602 Zh F2III
 Abovki        2939 B572720-5  Z                    623 Zh M5V
@@ -788,8 +788,8 @@ Zhipr         3138 C300657-A  Z Na Ni Va           101 Zh K3III
 Driechetledat 3139 C45A530-8    Ni Wa              124 Zh M7V
 Anjsotstie    3231 X302210-8    De Lo Ni Po     R  902 Zh K2V
 Ieshiejinch   3232 X410000-0    Ba De Ni        R  404 Zh F1IV
-Bralshalej    3234 E100100-9    Lo Ni              913 Zh K4V M3D
+Bralshalej    3234 E100100-9    Lo Ni              913 Zh K4V M3V
 ENCHIADRITL   3235 D856973-4    Hi In              424 Zh F6V
-Ipr           3238 D100666-9    Na Ni Va           512 Zh M3V M2V
+Ipr           3238 D100666-9    Na Ni Va           512 Zh M2V M3V
 Zdetleklatl   3239 E100442-8    Ni Va              724 Zh F4IV
 Izmal         3240 A000652-9  Z As Na              112 Zh K2V

--- a/res/Sectors/M1105/yiklerzdanzh.sec
+++ b/res/Sectors/M1105/yiklerzdanzh.sec
@@ -101,7 +101,7 @@ Chaos Fallen  0631 A0009A6-C  T As Hi In Na        732 TL F0V D
 Candlelight   0632 C110497-B    Ni Lo              520 TL M9V                 
 Sitiefladr    0638 A2679BB-B  M Hi                 613 Na M2V D              
 Jansaze'      0640 X642000-0    Ba Po              002 Na M6V                 
-Stielivrtl    0701 A5647A7-9  Z Ag                 524 Zh M1V K3V             
+Stielivrtl    0701 A5647A7-9  Z Ag                 524 Zh K3V M1V             
 Poshtozhi'led 0702 E100467-7    Va Ni Lo O:0701 U  511 Zh M1V                 
 Tostaavr      0707 C6697A7-6                       715 Zh M5III G1V           
 Chtench       0708 A85AA45-B  Z Wa Hi Cp           305 Zh K3V M6V             


### PR DESCRIPTION
Clean up stellar data in M1105 Stiatlchepr, and one straggler in Yiklerzdanzh.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is swapped into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).