### PR TITLE
Fix stellar data in Underdeveloped Sectors, round 5

### DIFF
--- a/res/Sectors/M1105/Angfutsag.sec
+++ b/res/Sectors/M1105/Angfutsag.sec
@@ -9,29 +9,29 @@ Angfutsag
 #--------1---------2---------3---------4---------5---------6---
 #PlanetName   Loc. UPP Code   B   Notes         Z  PBG Al LRX *
 #----------   ---- ---------  - --------------- -  --- -- --- -
-.             0801 X364000-0    Ba Lo Ni           004 --     K0V M2D 
+.             0801 X364000-0    Ba Lo Ni           004 --     K0V M2V
 .             0901 X646000-0    Ba Lo Ni           003 --     F8V 
 .             1401 X310000-0    Ba Lo Ni           004 --     G7V 
 .             2101 X326000-0    Ba Lo Ni           004 --     M0V 
-.             2301 X869000-0    Ba Lo Ni           003 --     F0V M4D 
-.             3201 X696000-0    Ba Lo Ni           004 --     F8V M4D 
+.             2301 X869000-0    Ba Lo Ni           003 --     F0V M4V
+.             3201 X696000-0    Ba Lo Ni           004 --     F8V M4V
 .             0102 X100000-0    Ba Lo Ni Va        003 --     M1V 
 .             0202 X222000-0    Ba Lo Ni Po        001 --     M0V 
-.             0302 X501000-0    Ba Ic Lo Ni Va     030 --     M2V M1D 
+.             0302 X501000-0    Ba Ic Lo Ni Va     030 --     M1V M2V
 .             0502 X96A000-0    Ba Lo Ni Wa        010 --     F6V 
-.             1102 X665000-0    Ba Lo Ni           021 --     F4V M7D 
+.             1102 X665000-0    Ba Lo Ni           021 --     F4V M7V
 .             1202 X84A000-0    Ba Lo Ni Wa        014 --     F7V 
 .             1402 X514000-0    Ba Ic Lo Ni        023 --     M1V 
 .             1602 X100000-0    Ba Lo Ni Va        003 --     F2V 
-.             2302 X451000-0    Ba Lo Ni Po        003 --     G2V M0D 
+.             2302 X451000-0    Ba Lo Ni Po        003 --     G2V M0V
 .             0203 X343000-0    Ba Lo Ni Po        000 --     F3V 
 .             0503 XAC8000-0    Ba Fl Lo Ni        013 --     F9V 
 .             0703 X6A1000-0    Ba Fl Lo Ni        004 --     A6V 
 .             1003 X5A3000-0    Ba Fl Lo Ni        012 --     F6V 
-.             1203 X557000-0    Ba Lo Ni           023 --     F2V M3D 
-.             2403 X100000-0    Ba Lo Ni Va        015 --     M0V M0V 
+.             1203 X557000-0    Ba Lo Ni           023 --     F2V M3V
+.             2403 X100000-0    Ba Lo Ni Va        015 --     M0V M0V
 .             2703 X475000-0    Ba Lo Ni           000 --     K2V 
-.             2803 X646000-0    Ba Lo Ni           004 --     F7V M5D 
+.             2803 X646000-0    Ba Lo Ni           004 --     F7V M5V
 .             0104 X5A1000-0    Ba Fl Lo Ni        010 --     M2V 
 .             0404 X896000-0    Ba Lo Ni           020 --     F0V 
 .             0704 X510000-0    Ba Lo Ni           000 --     G8V 
@@ -39,133 +39,133 @@ Angfutsag
 .             1904 X669000-0    Ba Lo Ni           012 --     F4V 
 .             2804 X444000-0    Ba Lo Ni           002 --     F1V 
 .             0405 X879000-0    Ba Lo Ni           020 --     F2V 
-.             1205 X100000-0    Ba Lo Ni Va        014 --     M3V M6V 
+.             1205 X100000-0    Ba Lo Ni Va        014 --     M3V M6V
 .             1305 XA77000-0    Ba Lo Ni           002 --     F2V 
 .             1505 X302000-0    Ba Ic Lo Ni Va     000 --     M5V 
 .             1705 X543000-0    Ba Lo Ni Po        001 --     F4V 
 .             2005 X8B6000-0    Ba Fl Lo Ni        010 --     M8V 
 .             2405 X100000-0    Ba Lo Ni Va        002 --     G8V 
 .             3005 X300000-0    Ba Lo Ni Va        003 --     M2V 
-.             0106 X6A0000-0    Ba De Lo Ni        015 --     M0V M2II 
+.             0106 X6A0000-0    Ba De Lo Ni        015 --     M2II M0V
 .             0806 X343000-0    Ba Lo Ni Po        003 --     K2V 
 .             1206 X666000-0    Ba Lo Ni           012 --     F6V 
 .             1706 X405000-0    Ba Ic Lo Ni Va     002 --     M7V 
-.             2206 X330000-0    Ba De Lo Ni Po     003 --     K0V M4D 
-.             3206 X7B3000-0    Ba Fl Lo Ni        006 --     M2V K2V 
-.             0907 X200000-0    Ba Lo Ni Va        014 --     F9V M3D 
+.             2206 X330000-0    Ba De Lo Ni Po     003 --     K0V M4V
+.             3206 X7B3000-0    Ba Fl Lo Ni        006 --     M2V K2V
+.             0907 X200000-0    Ba Lo Ni Va        014 --     F9V M3V
 .             1007 X100000-0    Ba Lo Ni Va        001 --     M8V 
-.             1207 X546000-0    Ba Lo Ni           000 --     F0V M8D 
+.             1207 X546000-0    Ba Lo Ni           000 --     F0V M8V
 .             1307 X582000-0    Ba Lo Ni           033 --     F9V 
-.             2007 X845000-0    Ba Lo Ni           024 --     G7V M3D 
+.             2007 X845000-0    Ba Lo Ni           024 --     G7V M3V
 .             2107 X9C0000-0    Ba De Lo Ni        004 --     M5V 
-.             2207 X476000-0    Ba Lo Ni           016 --     F4V M0D 
+.             2207 X476000-0    Ba Lo Ni           016 --     F4V M0V
 .             2307 X76A000-0    Ba Lo Ni Wa        003 --     M4V 
 .             2907 X332000-0    Ba Lo Ni Po        004 --     F8V 
-.             3007 X75A000-0    Ba Lo Ni Wa        000 --     F6V M0D 
-.             3107 X110000-0    Ba Lo Ni           003 --     G3V M0D 
+.             3007 X75A000-0    Ba Lo Ni Wa        000 --     F6V M0V
+.             3107 X110000-0    Ba Lo Ni           003 --     G3V M0V
 .             0208 X986000-0    Ba Lo Ni           003 --     G5V 
-.             0308 X87A000-0    Ba Lo Ni Wa        001 --     F3V M7D 
+.             0308 X87A000-0    Ba Lo Ni Wa        001 --     F3V M7V
 .             0708 X677000-0    Ba Lo Ni           002 --     F3V 
 .             1208 X6A4000-0    Ba Fl Lo Ni        000 --     M8III 
-.             1608 X424000-0    Ba Lo Ni           008 --     M3V M2D 
-.             1808 XAE6000-0    Ba Fl Lo Ni        024 --     F5V M4D 
+.             1608 X424000-0    Ba Lo Ni           008 --     M2V M3V
+.             1808 XAE6000-0    Ba Fl Lo Ni        024 --     F5V M4V
 .             2108 X334000-0    Ba Lo Ni           000 --     K0V 
 .             2908 X563000-0    Ba Lo Ni           020 --     F0V 
 .             0409 X8C6000-0    Ba Fl Lo Ni        000 --     M7III 
-.             0609 X85A000-0    Ba Lo Ni Wa        004 --     F4V M1D 
-.             1009 X674000-0    Ba Lo Ni           010 --     M3V M8D 
-.             1109 X648000-0    Ba Lo Ni           003 --     F7V M2V 
+.             0609 X85A000-0    Ba Lo Ni Wa        004 --     F4V M1V
+.             1009 X674000-0    Ba Lo Ni           010 --     M3V M8V
+.             1109 X648000-0    Ba Lo Ni           003 --     F7V M2V
 .             1209 X440000-0    Ba De Lo Ni Po     023 --     F4V 
 .             1309 X656000-0    Ba Lo Ni           003 --     G4V 
-.             2109 X100000-0    Ba Lo Ni Va        001 --     F9IV M2V 
-.             2209 X75A000-0    Ba Lo Ni Wa        000 --     F4V M8D 
-.             2309 X476000-0    Ba Lo Ni           006 --     F0V M4D M2D 
-.             2509 X797000-0    Ba Lo Ni           004 --     F8V M1D 
+.             2109 X100000-0    Ba Lo Ni Va        001 --     F9IV M2V
+.             2209 X75A000-0    Ba Lo Ni Wa        000 --     F4V M8V
+.             2309 X476000-0    Ba Lo Ni           006 --     F0V M4V M2V
+.             2509 X797000-0    Ba Lo Ni           004 --     F8V M1V
 .             0110 X556000-0    Ba Lo Ni           010 --     G3V 
-.             0710 X333000-0    Ba Lo Ni Po        002 --     M1V M4V 
-.             2510 X273000-0    Ba Lo Ni           013 --     F9V M5D 
-.             0711 X451000-0    Ba Lo Ni Po        000 --     F6V M1D M0D 
+.             0710 X333000-0    Ba Lo Ni Po        002 --     M1V M4V
+.             2510 X273000-0    Ba Lo Ni           013 --     F9V M5V
+.             0711 X451000-0    Ba Lo Ni Po        000 --     F6V M1V M0V
 .             0811 X738000-0    Ba Lo Ni           001 --     F9V 
-.             1911 X435000-0    Ba Lo Ni           003 --     M3V M6V 
+.             1911 X435000-0    Ba Lo Ni           003 --     M3V M6V
 .             2411 X438000-0    Ba Lo Ni           003 --     M5V 
-.             2511 X344000-0    Ba Lo Ni           005 --     K6V M5D 
-.             2811 X344000-0    Ba Lo Ni           031 --     F0V M7D 
+.             2511 X344000-0    Ba Lo Ni           005 --     K6V M5V
+.             2811 X344000-0    Ba Lo Ni           031 --     F0V M7V
 .             0112 X765000-0    Ba Lo Ni           001 --     G9V 
-.             0212 X462000-0    Ba Lo Ni           021 --     F3V M6D 
+.             0212 X462000-0    Ba Lo Ni           021 --     F3V M6V
 .             0612 X130000-0    Ba De Lo Ni Po     000 --     F0V 
 .             0812 X543000-0    Ba Lo Ni Po        002 --     F4V 
 .             1012 X362000-0    Ba Lo Ni           000 --     F0V 
-.             1212 X130000-0    Ba De Lo Ni Po     029 --     M7V M3D G9V 
+.             1212 X130000-0    Ba De Lo Ni Po     029 --     M7V M3V G9V
 .             1412 X241000-0    Ba Lo Ni Po        022 --     F2V 
 .             1512 X364000-0    Ba Lo Ni           001 --     F7V 
 .             1912 X633000-0    Ba Lo Ni Po        003 --     F6V 
 .             2912 X232000-0    Ba Lo Ni Po        030 --     F1V 
-.             3112 X569000-0    Ba Lo Ni           004 --     K5V M3D 
+.             3112 X569000-0    Ba Lo Ni           004 --     K5V M3V
 .             3212 X629000-0    Ba Lo Ni           010 --     G5V 
-.             0913 X000000-0    As Ba Lo Ni        026 --     G8V M2D 
-.             1513 X969000-0    Ba Lo Ni           013 --     F5V M5D 
+.             0913 X000000-0    As Ba Lo Ni        026 --     G8V M2V
+.             1513 X969000-0    Ba Lo Ni           013 --     F5V M5V
 .             1913 X410000-0    Ba Lo Ni           004 --     F0V 
-.             2013 X847000-0    Ba Lo Ni           017 --     F5V M1D 
+.             2013 X847000-0    Ba Lo Ni           017 --     F5V M1V
 .             2313 X322000-0    Ba Lo Ni Po        002 --     F5V 
 .             0114 X668000-0    Ba Lo Ni           002 --     M7V 
-.             0314 XAA7000-0    Ba Fl Lo Ni        017 --     M1V M2D 
+.             0314 XAA7000-0    Ba Fl Lo Ni        017 --     M1V M2V
 .             1714 X300000-0    Ba Lo Ni Va        001 --     K9V 
 .             1814 X667000-0    Ba Lo Ni           003 --     F0V 
-.             2314 X8C6000-0    Ba Fl Lo Ni        004 --     M0V M5D 
-.             2414 X433000-0    Ba Lo Ni Po        003 --     M2V M8D 
-.             2714 X764000-0    Ba Lo Ni           014 --     F2V M3D 
-.             3014 X466000-0    Ba Lo Ni           004 --     F1V M8D 
+.             2314 X8C6000-0    Ba Fl Lo Ni        004 --     M0V M5V
+.             2414 X433000-0    Ba Lo Ni Po        003 --     M2V M8V
+.             2714 X764000-0    Ba Lo Ni           014 --     F2V M3V
+.             3014 X466000-0    Ba Lo Ni           004 --     F1V M8V
 .             0115 X764000-0    Ba Lo Ni           002 --     F7V 
 .             0715 X998000-0    Ba Lo Ni           012 --     F0V 
-.             1115 X888000-0    Ba Lo Ni           000 --     K8V M3D 
+.             1115 X888000-0    Ba Lo Ni           000 --     K8V M3V
 .             1215 X464000-0    Ba Lo Ni           014 --     F5V 
-.             1415 X366000-0    Ba Lo Ni           012 --     F1V M8D 
+.             1415 X366000-0    Ba Lo Ni           012 --     F1V M8V
 .             1515 X425000-0    Ba Lo Ni           004 --     F8V 
-.             1715 X555000-0    Ba Lo Ni           000 --     F2V M3D 
+.             1715 X555000-0    Ba Lo Ni           000 --     F2V M3V
 .             2815 X234000-0    Ba Lo Ni           023 --     M4V 
 .             2915 X729000-0    Ba Lo Ni           000 --     G0V 
-.             3015 X100000-0    Ba Lo Ni Va        010 --     M2V M3D 
+.             3015 X100000-0    Ba Lo Ni Va        010 --     M2V M3V
 .             3215 X544000-0    Ba Lo Ni           012 --     F5V 
 .             0216 X8B4000-0    Ba Fl Lo Ni        013 --     K6III 
-.             1616 X610000-0    Ba Lo Ni           001 --     M0V M5D 
+.             1616 X610000-0    Ba Lo Ni           001 --     M0V M5V
 .             1816 X343000-0    Ba Lo Ni Po        000 --     F0V 
-.             2716 X000000-0    As Ba Lo Ni        002 --     M4V M3V 
+.             2716 X000000-0    As Ba Lo Ni        002 --     M3V M4V
 .             2816 X442000-0    Ba Lo Ni Po        015 --     F5V 
 .             0217 X000000-0    As Ba Lo Ni        020 --     F5V 
 .             0517 X788000-0    Ba Lo Ni           015 --     F7V 
 .             0817 X6A2000-0    Ba Fl Lo Ni        000 --     M2V 
 .             0917 X521000-0    Ba Lo Ni Po        003 --     M1V 
 .             1017 X110000-0    Ba Lo Ni           001 --     K0V 
-.             1317 X687000-0    Ba Lo Ni           011 --     F5V M7D 
+.             1317 X687000-0    Ba Lo Ni           011 --     F5V M7V
 .             2017 X200000-0    Ba Lo Ni Va        013 --     M2V 
-.             2317 X355000-0    Ba Lo Ni           021 --     G7V M4D 
+.             2317 X355000-0    Ba Lo Ni           021 --     G7V M4V
 .             2717 X362000-0    Ba Lo Ni           001 --     F3V 
-.             2917 X9C2000-0    Ba Fl Lo Ni        003 --     K2V M6D 
+.             2917 X9C2000-0    Ba Fl Lo Ni        003 --     K2V M6V
 .             0118 X434000-0    Ba Lo Ni           002 --     M3II 
 .             0218 X545000-0    Ba Lo Ni           025 --     F2V 
 .             0418 X556000-0    Ba Lo Ni           003 --     F1V 
 .             0618 X400000-0    Ba Lo Ni Va        000 --     M1V 
 .             0718 X360000-0    Ba De Lo Ni        020 --     F8V 
-.             1318 X426000-0    Ba Lo Ni           004 --     M2V M7V 
-.             1418 X525000-0    Ba Lo Ni           015 --     M4V M0D 
-.             1718 X757000-0    Ba Lo Ni           014 --     F6V M2D 
+.             1318 X426000-0    Ba Lo Ni           004 --     M2V M7V
+.             1418 X525000-0    Ba Lo Ni           015 --     M0V M4V
+.             1718 X757000-0    Ba Lo Ni           014 --     F6V M2V
 .             1918 X140000-0    Ba De Lo Ni Po     024 --     G6V 
-.             2118 X65A000-0    Ba Lo Ni Wa        004 --     F5V M1D 
-.             2718 X754000-0    Ba Lo Ni           020 --     F8V M5D 
+.             2118 X65A000-0    Ba Lo Ni Wa        004 --     F5V M1V
+.             2718 X754000-0    Ba Lo Ni           020 --     F8V M5V
 .             3018 X400000-0    Ba Lo Ni Va        000 --     K4V 
 .             3218 X6A4000-0    Ba Fl Lo Ni        002 --     M4V 
 .             0519 X7A0000-0    Ba De Lo Ni        013 --     F3V 
-.             1519 X210000-0    Ba Lo Ni           004 --     M1V M1D 
-.             1619 X75A000-0    Ba Lo Ni Wa        026 --     F3V M2D 
-.             1919 X531000-0    Ba Lo Ni Po        001 --     M3V M4D 
+.             1519 X210000-0    Ba Lo Ni           004 --     M1V M1V
+.             1619 X75A000-0    Ba Lo Ni Wa        026 --     F3V M2V
+.             1919 X531000-0    Ba Lo Ni Po        001 --     M3V M4V
 .             2019 X533000-0    Ba Lo Ni Po        014 --     F5V 
 .             2119 X646000-0    Ba Lo Ni           024 --     K1V 
 .             2219 X120000-0    Ba De Lo Ni Po     014 --     M2V 
 .             2619 X696000-0    Ba Lo Ni           004 --     G9V 
-.             2919 X232000-0    Ba Lo Ni Po        011 --     M5V M1D 
+.             2919 X232000-0    Ba Lo Ni Po        011 --     M1V M5V
 .             0520 XA69000-0    Ba Lo Ni           000 --     F2V 
-.             0820 X546000-0    Ba Lo Ni           035 --     F6V M0D 
-.             1220 X583000-0    Ba Lo Ni           023 --     F0V M7D 
+.             0820 X546000-0    Ba Lo Ni           035 --     F6V M0V
+.             1220 X583000-0    Ba Lo Ni           023 --     F0V M7V
 .             1520 X5A2000-0    Ba Fl Lo Ni        001 --     M4V 
 .             2220 X200000-0    Ba Lo Ni Va        012 --     M5V 
 .             2720 X523000-0    Ba Lo Ni Po        020 --     F3V 
@@ -173,8 +173,8 @@ Angfutsag
 .             0821 X000000-0    As Ba Lo Ni        020 --     M5V 
 .             1221 X9B7000-0    Ba Fl Lo Ni        022 --     M4V 
 .             1721 X97A000-0    Ba Lo Ni Wa        005 --     F5V 
-.             2821 X535000-0    Ba Lo Ni           001 --     M2V M2III 
-.             3021 X410000-0    Ba Lo Ni           006 --     M8V M7D 
+.             2821 X535000-0    Ba Lo Ni           001 --     M2III M2V
+.             3021 X410000-0    Ba Lo Ni           006 --     M8V M7V
 .             3221 X6A0000-0    Ba De Lo Ni        001 --     M8V 
 .             0122 X110000-0    Ba Lo Ni           014 --     A1V 
 .             0622 X444000-0    Ba Lo Ni           004 --     F5V 
@@ -183,24 +183,24 @@ Angfutsag
 .             3022 X300000-0    Ba Lo Ni Va        003 --     F0V 
 .             0123 X231000-0    Ba Lo Ni Po        002 --     M1V 
 .             0223 X765000-0    Ba Lo Ni           003 --     F9V 
-.             1123 X110000-0    Ba Lo Ni           002 --     M3V M0D 
+.             1123 X110000-0    Ba Lo Ni           002 --     M3V M0V
 .             1223 X864000-0    Ba Lo Ni           024 --     K1V 
 .             1423 X552000-0    Ba Lo Ni Po        004 --     G5V 
-.             2123 X484000-0    Ba Lo Ni           021 --     G3V M7D 
+.             2123 X484000-0    Ba Lo Ni           021 --     G3V M7V
 .             3023 X659000-0    Ba Lo Ni           002 --     F3V 
 .             3223 X553000-0    Ba Lo Ni Po        011 --     F2V 
 .             0424 X343000-0    Ba Lo Ni Po        003 --     F2V 
-.             0724 X669000-0    Ba Lo Ni           020 --     F4V M8D 
-.             1024 X6B0000-0    Ba De Lo Ni        022 --     K4II M5V 
-.             1124 X347000-0    Ba Lo Ni           016 --     F6V M4D 
+.             0724 X669000-0    Ba Lo Ni           020 --     F4V M8V
+.             1024 X6B0000-0    Ba De Lo Ni        022 --     K4II M5V
+.             1124 X347000-0    Ba Lo Ni           016 --     F6V M4V
 .             1324 X677000-0    Ba Lo Ni           003 --     K2V 
 .             1824 X8A5000-0    Ba Fl Lo Ni        003 --     M4V 
-.             2024 X8C1000-0    Ba Fl Lo Ni        005 --     M7II M5V 
+.             2024 X8C1000-0    Ba Fl Lo Ni        005 --     M7II M5V
 .             2124 X345000-0    Ba Lo Ni           010 --     F2V 
 .             2724 X787000-0    Ba Lo Ni           004 --     F1V 
-.             2824 X120000-0    Ba De Lo Ni Po     004 --     F0V M6D 
+.             2824 X120000-0    Ba De Lo Ni Po     004 --     F0V M6V
 .             2924 X444000-0    Ba Lo Ni           003 --     F0V 
-.             0325 X774000-0    Ba Lo Ni           004 --     F2V M3D 
+.             0325 X774000-0    Ba Lo Ni           004 --     F2V M3V
 .             0425 X232000-0    Ba Lo Ni Po        002 --     M0V 
 .             0725 X300000-0    Ba Lo Ni Va        023 --     M8V 
 .             1225 X86A000-0    Ba Lo Ni Wa        014 --     F6V 
@@ -209,28 +209,28 @@ Angfutsag
 .             2425 X443000-0    Ba Lo Ni Po        014 --     K4V 
 .             2525 X86A000-0    Ba Lo Ni Wa        013 --     F2V 
 .             2625 X446000-0    Ba Lo Ni           000 --     F5V 
-.             0526 X441000-0    Ba Lo Ni Po        000 --     F5V M8D 
+.             0526 X441000-0    Ba Lo Ni Po        000 --     F5V M8V
 .             1326 X9C5000-0    Ba Fl Lo Ni        003 --     G1V 
 .             1726 X673000-0    Ba Lo Ni           002 --     G4V 
 .             2226 X76A000-0    Ba Lo Ni Wa        022 --     G0V 
 .             2626 X547000-0    Ba Lo Ni           002 --     F6V 
 .             2826 X000000-0    As Ba Lo Ni        016 --     M3II M2V M0V 
-.             3026 X100000-0    Ba Lo Ni Va        014 --     G9V M6D 
+.             3026 X100000-0    Ba Lo Ni Va        014 --     G9V M6V
 .             0127 X5A0000-0    Ba De Lo Ni        004 --     K7II 
 .             0227 X375000-0    Ba Lo Ni           012 --     F2V 
 .             0327 X767000-0    Ba Lo Ni           003 --     F1V 
-.             0527 X866000-0    Ba Lo Ni           003 --     F5V M3D 
-.             1227 X437000-0    Ba Lo Ni           000 --     M5V M1D 
-.             1427 X7C3000-0    Ba Fl Lo Ni        004 --     M8V M3D 
-.             1627 X878000-0    Ba Lo Ni           027 --     G0V M7D 
-.             2027 X7B0000-0    Ba De Lo Ni        006 --     A2V M3D 
-.             2227 X232000-0    Ba Lo Ni Po        016 --     K8V M7D 
-.             2927 X695000-0    Ba Lo Ni           005 --     K4V M3D 
+.             0527 X866000-0    Ba Lo Ni           003 --     F5V M3V
+.             1227 X437000-0    Ba Lo Ni           000 --     M1V M5V
+.             1427 X7C3000-0    Ba Fl Lo Ni        004 --     M3V M8V
+.             1627 X878000-0    Ba Lo Ni           027 --     G0V M7V
+.             2027 X7B0000-0    Ba De Lo Ni        006 --     A2V M3V
+.             2227 X232000-0    Ba Lo Ni Po        016 --     K8V M7V
+.             2927 X695000-0    Ba Lo Ni           005 --     K4V M3V
 .             3227 X95A000-0    Ba Lo Ni Wa        002 --     M6V 
 .             0428 X775000-0    Ba Lo Ni           000 --     F8V 
 .             0728 X100000-0    Ba Lo Ni Va        001 --     A7V 
 .             0828 X325000-0    Ba Lo Ni           003 --     M8V 
-.             1428 X557000-0    Ba Lo Ni           004 --     F6V M7D 
+.             1428 X557000-0    Ba Lo Ni           004 --     F6V M7V
 .             1828 X88A000-0    Ba Lo Ni Wa        004 --     F2V 
 .             2528 X87A000-0    Ba Lo Ni Wa        011 --     F1V 
 .             2728 X314000-0    Ba Ic Lo Ni        004 --     G6IV 
@@ -238,93 +238,93 @@ Angfutsag
 .             0229 X525000-0    Ba Lo Ni           010 --     G4V 
 .             0429 X8D2000-0    Ba Fl Lo Ni        015 --     M3V 
 .             0729 X77A000-0    Ba Lo Ni Wa        010 --     F2V 
-.             1029 X100000-0    Ba Lo Ni Va        014 --     M7V K9V 
+.             1029 X100000-0    Ba Lo Ni Va        014 --     K9V M7V
 .             1329 X439000-0    Ba Lo Ni           003 --     M2III 
 .             1429 X556000-0    Ba Lo Ni           020 --     G0V 
 .             1529 X573000-0    Ba Lo Ni           012 --     F9V 
 .             2429 X7B5000-0    Ba Fl Lo Ni        005 --     M1V 
-.             2529 X645000-0    Ba Lo Ni           003 --     F6V M4D 
+.             2529 X645000-0    Ba Lo Ni           003 --     F6V M4V
 .             2729 X000000-0    As Ba Lo Ni        004 --     M6V 
-.             3029 X466000-0    Ba Lo Ni           004 --     F5V M0D 
+.             3029 X466000-0    Ba Lo Ni           004 --     F5V M0V
 .             3229 X447000-0    Ba Lo Ni           000 --     F6V 
 .             0430 X776000-0    Ba Lo Ni           003 --     F9V 
-.             2130 X658000-0    Ba Lo Ni           008 --     F8V M3D F3V M3V 
+.             2130 X658000-0    Ba Lo Ni           008 --     F8V M3V F3V M3V
 .             2730 X666000-0    Ba Lo Ni           021 --     F4V 
 .             2830 X75A000-0    Ba Lo Ni Wa        003 --     F7V M7V 
 .             2930 X576000-0    Ba Lo Ni           003 --     G3V 
 .             3030 X000000-0    As Ba Lo Ni        017 --     F5III M4V 
 .             1031 X361000-0    Ba Lo Ni           012 --     G9V 
-.             1531 X655000-0    Ba Lo Ni           007 --     F2V M2D 
-.             1931 X768000-0    Ba Lo Ni           00A --     F8V M7D F3V 
+.             1531 X655000-0    Ba Lo Ni           007 --     F2V M2V
+.             1931 X768000-0    Ba Lo Ni           00A --     F8V M7V F3V
 .             2331 X241000-0    Ba Lo Ni Po        004 --     G4V 
 .             2431 X454000-0    Ba Lo Ni           014 --     F3V 
 .             2631 X666000-0    Ba Lo Ni           000 --     G5V 
 .             2931 X585000-0    Ba Lo Ni           014 --     F6V 
 .             0332 X656000-0    Ba Lo Ni           012 --     K4V 
 .             0532 X78A000-0    Ba Lo Ni Wa        002 --     F5V 
-.             0732 X536000-0    Ba Lo Ni           002 --     K8V M3D 
-.             1132 X423000-0    Ba Lo Ni Po        013 --     M3V M0V 
+.             0732 X536000-0    Ba Lo Ni           002 --     K8V M3V
+.             1132 X423000-0    Ba Lo Ni Po        013 --     M0V M3V
 .             1632 X7C8000-0    Ba Fl Lo Ni        023 --     M6V 
-.             1832 X7A2000-0    Ba Fl Lo Ni        000 --     M7V M3V 
-.             2132 X000000-0    As Ba Lo Ni        016 --     M5V M6D 
+.             1832 X7A2000-0    Ba Fl Lo Ni        000 --     M3V M7V
+.             2132 X000000-0    As Ba Lo Ni        016 --     M5V M6V
 .             2932 X120000-0    Ba De Lo Ni Po     013 --     M6V 
-.             0533 X412000-0    Ba Ic Lo Ni        002 --     M6V M2V 
+.             0533 X412000-0    Ba Ic Lo Ni        002 --     M2V M6V
 .             1133 X574000-0    Ba Lo Ni           001 --     G7V 
-.             1333 X454000-0    Ba Lo Ni           005 --     F1V M5D 
-.             1533 X222000-0    Ba Lo Ni Po        002 --     M4V M2D 
-.             2233 X340000-0    Ba De Lo Ni Po     020 --     F0V M2D 
+.             1333 X454000-0    Ba Lo Ni           005 --     F1V M5V
+.             1533 X222000-0    Ba Lo Ni Po        002 --     M2V M4V
+.             2233 X340000-0    Ba De Lo Ni Po     020 --     F0V M2V
 .             2333 X658000-0    Ba Lo Ni           024 --     G5V 
 .             2433 X783000-0    Ba Lo Ni           003 --     F4V 
 .             2533 X877000-0    Ba Lo Ni           023 --     F8V 
 .             3133 X575000-0    Ba Lo Ni           004 --     F7V 
-.             0534 X244000-0    Ba Lo Ni           005 --     F5V M4D 
-.             0634 X668000-0    Ba Lo Ni           004 --     F1V M0D 
-.             0934 X410000-0    Ba Lo Ni           020 --     M3V M3D 
-.             1034 X624000-0    Ba Lo Ni           012 --     F5V M1D 
-.             1234 X536000-0    Ba Lo Ni           000 --     F0V M0D 
+.             0534 X244000-0    Ba Lo Ni           005 --     F5V M4V
+.             0634 X668000-0    Ba Lo Ni           004 --     F1V M0V
+.             0934 X410000-0    Ba Lo Ni           020 --     M3V M3V
+.             1034 X624000-0    Ba Lo Ni           012 --     F5V M1V
+.             1234 X536000-0    Ba Lo Ni           000 --     F0V M0V
 .             1734 X691000-0    Ba Lo Ni           013 --     F1V 
 .             2834 X766000-0    Ba Lo Ni           000 --     F6V 
-.             3134 X443000-0    Ba Lo Ni Po        017 --     F6V M2D 
-Kfoersarsaz   0335 B884001-9    Lo Ni              535 Va     F4V M8D 
+.             3134 X443000-0    Ba Lo Ni Po        017 --     F6V M2V
+Kfoersarsaz   0335 B884001-9    Lo Ni              535 Va     F4V M8V
 .             1435 X220000-0    Ba De Lo Ni Po     000 --     K2V 
-.             1935 X544000-0    Ba Lo Ni           015 --     K4V F6V M0D 
+.             1935 X544000-0    Ba Lo Ni           015 --     K4V F6V M0V
 .             2435 X997000-0    Ba Lo Ni           020 --     F2V 
-.             2535 X678000-0    Ba Lo Ni           023 --     F9V M3D 
+.             2535 X678000-0    Ba Lo Ni           023 --     F9V M3V
 .             2835 X120000-0    Ba De Lo Ni Po     002 --     F5II 
 Daeathae      0436 C665326-6    Lo Ni              712 Va     F4V 
 Kukunazarz    0836 C356979-9    Hi In              720 Va     F4V 
 .             1536 X200000-0    Ba Lo Ni Va        011 --     F6III 
 .             1736 X73A000-0    Ba Lo Ni Wa        003 --     G1IV K0V 
 .             2136 X79A000-0    Ba Lo Ni Wa        003 --     G0V 
-.             2436 X400000-0    Ba Lo Ni Va        003 --     G6V K5D 
-.             2636 X898000-0    Ba Lo Ni           000 --     F5V M4D 
+.             2436 X400000-0    Ba Lo Ni Va        003 --     G6V K5V
+.             2636 X898000-0    Ba Lo Ni           000 --     F5V M4V
 Saegdonorror  0437 D648101-4    Lo Ni              902 Va     F2V 
-Goluek        0637 E36767C-5  C Ag Ni              701 Va     F7V M4D 
-Gzodharrg     1037 C5037AA-4  C Ic Na Va           334 Va     G0V M6D 
+Goluek        0637 E36767C-5  C Ag Ni              701 Va     F7V M4V
+Gzodharrg     1037 C5037AA-4  C Ic Na Va           334 Va     G0V M6V
 .             1837 X621000-0    Ba Lo Ni Po        022 --     M6V 
-.             2637 X563000-0    Ba Lo Ni           003 --     M5V M0D M6D 
-.             2937 X320000-0    Ba De Lo Ni Po     001 --     K2V M3D 
+.             2637 X563000-0    Ba Lo Ni           003 --     M0V M5V M6V
+.             2937 X320000-0    Ba De Lo Ni Po     001 --     K2V M3V
 .             3037 X310000-0    Ba Lo Ni           003 --     M7V 
 Fueze         1138 C246430-4  H Ni                 500 Va     M0V 
 Gvaaeueksaa   1238 D689675-0  C Ni                 904 Va     M8V 
-Goeouaelaets  1338 DA6A745-3  C Ri Wa              205 Va     F0V M4D 
-Kuoedzi       1438 B7B669B-9    Fl Ni              104 Va     K3V M7D 
+Goeouaelaets  1338 DA6A745-3  C Ri Wa              205 Va     F0V M4V
+Kuoedzi       1438 B7B669B-9    Fl Ni              104 Va     K3V M7V
 .             2638 X684000-0    Ba Lo Ni           001 --     G2V 
-.             2838 X240000-0    Ba De Lo Ni Po     004 --     F1V M2D 
+.             2838 X240000-0    Ba De Lo Ni Po     004 --     F1V M2V
 .             2938 X130000-0    Ba De Lo Ni Po     002 --     G8V 
 .             3238 X610000-0    Ba Lo Ni           012 --     F4V 
-Rudzaghz      0139 D261610-2    Ni                 314 Va     G3V M3D 
-Ollog         0239 A527579-E  G Ni                 201 Va     K2V M0D 
+Rudzaghz      0139 D261610-2    Ni                 314 Va     G3V M3V
+Ollog         0239 A527579-E  G Ni                 201 Va     K2V M0V
 Douforrougz   0439 C98A610-6  G Ni Wa              904 Va     F8V 
-Aooe          0639 D545220-5  C Lo Ni              513 Va     F0V M6D 
+Aooe          0639 D545220-5  C Lo Ni              513 Va     F0V M6V
 Gvakarre      1639 B220533-C    De Ni Po           502 Va     F4V 
 Rrueuoe       2239 C482576-8    Ni                 903 Va     F7V 
 Azueghgvodho  2339 B312775-C  C Ic Na              802 Va     M2V 
 .             2639 X76A000-0    Ba Lo Ni Wa        004 --     F2V 
 .             2839 X312000-0    Ba Ic Lo Ni        004 --     K5V 
-Gavoeko       0240 B675369-6    Lo Ni              515 Va     F7V M8D 
-Khagaghzdzor  0540 C100745-8    Na Va              510 Va     A1V M3D 
+Gavoeko       0240 B675369-6    Lo Ni              515 Va     F7V M8V
+Khagaghzdzor  0540 C100745-8    Na Va              510 Va     A1V M3V
 Dzozenour     0840 C130979-C  C De Hi In Na Po     124 Va     G6V 
 Ghoeksaa      1440 C68A875-4  G Wa                 202 Va     F6V 
-Kezsueth      1840 D635944-5    Hi In              51C Va     F8V M3D M1D 
+Kezsueth      1840 D635944-5    Hi In              51C Va     F8V M3V M1V
 Kfeloun       2040 C356300-8  C Lo Ni              200 Va     F0V 

--- a/res/Sectors/M1105/Dfotseth.sec
+++ b/res/Sectors/M1105/Dfotseth.sec
@@ -10,68 +10,68 @@ Dfotseth
 #PlanetName   Loc. UPP Code   B   Notes         Z  PBG Al LRX *
 #----------   ---- ---------  - --------------- -  --- -- --- -
 .             0201 X534000-0    Ba Lo Ni           000 --     A5V 
-.             0301 X676000-0    Ba Lo Ni           004 --     F3V M6D 
-.             3101 X363000-0    Ba Lo Ni           017 --     F7V M2D 
+.             0301 X676000-0    Ba Lo Ni           004 --     F3V M6V
+.             3101 X363000-0    Ba Lo Ni           017 --     F7V M2V
 .             0702 X482000-0    Ba Lo Ni           003 --     M3V 
 .             3002 X120000-0    Ba De Lo Ni Po     000 --     M6V 
 .             0303 X140000-0    Ba De Lo Ni Po     000 --     F2V 
 .             2703 X699000-0    Ba Lo Ni           002 --     M7V 
 .             0404 X532000-0    Ba Lo Ni Po        027 --     K1II G2V 
-.             0704 X576000-0    Ba Lo Ni           014 --     F5V M6D 
-.             2104 X95A000-0    Ba Lo Ni Wa        010 --     F3V M4D 
+.             0704 X576000-0    Ba Lo Ni           014 --     F5V M6V
+.             2104 X95A000-0    Ba Lo Ni Wa        010 --     F3V M4V
 .             0605 X99A000-0    Ba Lo Ni Wa        003 --     F9V 
 .             3005 X335000-0    Ba Lo Ni           000 --     M4V 
-.             3105 X000000-0    As Ba Lo Ni        004 --     M7V M8D M3D 
-.             0106 X334000-0    Ba Lo Ni           005 --     K2V M2D 
+.             3105 X000000-0    As Ba Lo Ni        004 --     M3V M8V M7V
+.             0106 X334000-0    Ba Lo Ni           005 --     K2V M2V
 .             0406 X577000-0    Ba Lo Ni           000 --     F2V 
-.             0706 X200000-0    Ba Lo Ni Va        003 --     F0V M6D 
+.             0706 X200000-0    Ba Lo Ni Va        003 --     F0V M6V
 .             0806 X89A000-0    Ba Lo Ni Wa        020 --     F7V 
 .             3006 X244000-0    Ba Lo Ni           011 --     G1V 
 .             0207 X423000-0    Ba Lo Ni Po        002 --     M4V 
-.             0407 X000000-0    As Ba Lo Ni        002 --     M4V M8D 
+.             0407 X000000-0    As Ba Lo Ni        002 --     M4V M8V
 .             0507 X967000-0    Ba Lo Ni           023 --     F7V 
-.             2907 X647000-0    Ba Lo Ni           007 --     K6V M0D 
+.             2907 X647000-0    Ba Lo Ni           007 --     K6V M0V
 .             0708 X624000-0    Ba Lo Ni           004 --     F4V 
-.             1609 X545000-0    Ba Lo Ni           017 --     F5V M1D 
-.             2109 X432000-0    Ba Lo Ni Po        002 --     G5V M2D 
-.             3109 X997000-0    Ba Lo Ni           003 --     F5V M1D 
+.             1609 X545000-0    Ba Lo Ni           017 --     F5V M1V
+.             2109 X432000-0    Ba Lo Ni Po        002 --     G5V M2V
+.             3109 X997000-0    Ba Lo Ni           003 --     F5V M1V
 .             0610 X889000-0    Ba Lo Ni           002 --     F8V 
-.             1910 X677000-0    Ba Lo Ni           003 --     F6V M8D 
+.             1910 X677000-0    Ba Lo Ni           003 --     F6V M8V
 .             2710 X477000-0    Ba Lo Ni           003 --     F4V 
 .             2910 X200000-0    Ba Lo Ni Va        014 --     M6V 
 .             3110 X688000-0    Ba Lo Ni           022 --     K4V 
-.             3210 X777000-0    Ba Lo Ni           004 --     F2V M8D 
+.             3210 X777000-0    Ba Lo Ni           004 --     F2V M8V
 .             0411 X85A000-0    Ba Lo Ni Wa        003 --     K0V 
 .             1611 X895000-0    Ba Lo Ni           025 --     F4V 
 .             2111 X584000-0    Ba Lo Ni           010 --     F4V 
 .             0312 X120000-0    Ba De Lo Ni Po     001 --     M8V 
-.             0512 X7B5000-0    Ba Fl Lo Ni        007 --     M8V M6D 
+.             0512 X7B5000-0    Ba Fl Lo Ni        007 --     M6V M8V
 .             0712 X461000-0    Ba Lo Ni           002 --     G2V 
 .             0912 X779000-0    Ba Lo Ni           003 --     F2V 
-.             1412 X697000-0    Ba Lo Ni           002 --     F8V M6D 
-.             1912 X267000-0    Ba Lo Ni           003 --     F2V M4D 
+.             1412 X697000-0    Ba Lo Ni           002 --     F8V M6V
+.             1912 X267000-0    Ba Lo Ni           003 --     F2V M4V
 .             2212 X658000-0    Ba Lo Ni           001 --     F7V 
 .             3012 X9C5000-0    Ba Fl Lo Ni        004 --     M6V 
-.             0313 X686000-0    Ba Lo Ni           004 --     F9V M6D 
+.             0313 X686000-0    Ba Lo Ni           004 --     F9V M6V
 .             0413 X367000-0    Ba Lo Ni           000 --     M5V 
 .             1313 X646000-0    Ba Lo Ni           002 --     F5V 
 .             1513 X9B8000-0    Ba Fl Lo Ni        020 --     M1III 
-.             1613 X538000-0    Ba Lo Ni           029 --     A5III M1V M5D 
-.             2213 X769000-0    Ba Lo Ni           012 --     K6V M3D 
+.             1613 X538000-0    Ba Lo Ni           029 --     A5III M1V M5V
+.             2213 X769000-0    Ba Lo Ni           012 --     K6V M3V
 .             2413 X543000-0    Ba Lo Ni Po        001 --     M6V 
 .             2813 X575000-0    Ba Lo Ni           002 --     F4V 
 .             0214 X77A000-0    Ba Lo Ni Wa        005 --     G8V 
-.             0414 X73A000-0    Ba Lo Ni Wa        022 --     M4V M0D 
-.             0514 X200000-0    Ba Lo Ni Va        004 --     G8IV G4D 
+.             0414 X73A000-0    Ba Lo Ni Wa        022 --     M0V M4V
+.             0514 X200000-0    Ba Lo Ni Va        004 --     G8IV G4V
 .             1114 X510000-0    Ba Lo Ni           004 --     K2V M1V 
-.             1514 X554000-0    Ba Lo Ni           002 --     M6V M1D 
-.             1914 X226000-0    Ba Lo Ni           000 --     M1V M2D 
+.             1514 X554000-0    Ba Lo Ni           002 --     M1V M6V
+.             1914 X226000-0    Ba Lo Ni           000 --     M1V M2V
 .             2014 X464000-0    Ba Lo Ni           003 --     M8V 
 .             2314 X528000-0    Ba Lo Ni           020 --     M3V 
 .             2914 XA8A000-0    Ba Lo Ni Wa        022 --     F3V 
 .             1115 X585000-0    Ba Lo Ni           003 --     G4V 
-.             1215 X776000-0    Ba Lo Ni           016 --     M1V M0D 
-.             2115 X478000-0    Ba Lo Ni           030 --     F8V M7D 
+.             1215 X776000-0    Ba Lo Ni           016 --     M0V M1V
+.             2115 X478000-0    Ba Lo Ni           030 --     F8V M7V
 .             2715 X743000-0    Ba Lo Ni Po        004 --     G7V 
 .             0116 X484000-0    Ba Lo Ni           000 --     K8V 
 .             0616 X633000-0    Ba Lo Ni Po        000 --     M2V 
@@ -79,16 +79,16 @@ Dfotseth
 .             0916 XAE6000-0    Ba Fl Lo Ni        000 --     M2V 
 .             1016 XAA8000-0    Ba Fl Lo Ni        003 --     K8V 
 .             1416 X300000-0    Ba Lo Ni Va        002 --     G2V 
-.             1616 X100000-0    Ba Lo Ni Va        000 --     M3V M5D 
-.             2016 X658000-0    Ba Lo Ni           014 --     F4V M8D 
+.             1616 X100000-0    Ba Lo Ni Va        000 --     M3V M5V
+.             2016 X658000-0    Ba Lo Ni           014 --     F4V M8V
 .             2716 X444000-0    Ba Lo Ni           012 --     F7V 
-.             0117 X656000-0    Ba Lo Ni           022 --     G1V M1D 
+.             0117 X656000-0    Ba Lo Ni           022 --     G1V M1V
 .             0417 X410000-0    Ba Lo Ni           000 --     M1V 
-.             0517 X200000-0    Ba Lo Ni Va        002 --     M0V M0D 
-.             0717 X868000-0    Ba Lo Ni           014 --     F2V M3D 
-.             1317 X654000-0    Ba Lo Ni           011 --     F6V M8D 
-.             2217 X779000-0    Ba Lo Ni           000 --     F2V M7D 
-.             2717 X270000-0    Ba De Lo Ni        005 --     F9V M2D 
+.             0517 X200000-0    Ba Lo Ni Va        002 --     M0V M0V
+.             0717 X868000-0    Ba Lo Ni           014 --     F2V M3V
+.             1317 X654000-0    Ba Lo Ni           011 --     F6V M8V
+.             2217 X779000-0    Ba Lo Ni           000 --     F2V M7V
+.             2717 X270000-0    Ba De Lo Ni        005 --     F9V M2V
 .             2817 X482000-0    Ba Lo Ni           012 --     G1V 
 .             0218 X266000-0    Ba Lo Ni           022 --     K0V 
 .             1118 X224000-0    Ba Lo Ni           000 --     M2V 
@@ -99,50 +99,50 @@ Dfotseth
 .             0519 X421000-0    Ba Lo Ni Po        000 --     M3V 
 .             0719 X526000-0    Ba Lo Ni           003 --     M6V 
 .             0819 X477000-0    Ba Lo Ni           001 --     K9V 
-.             1219 X76A000-0    Ba Lo Ni Wa        003 --     G7V M1D 
-.             1319 X242000-0    Ba Lo Ni Po        024 --     F6V M2D M1D 
+.             1219 X76A000-0    Ba Lo Ni Wa        003 --     G7V M1V
+.             1319 X242000-0    Ba Lo Ni Po        024 --     F6V M2V M1V
 .             2019 X89A000-0    Ba Lo Ni Wa        013 --     F1V 
-.             2119 X150000-0    Ba De Lo Ni Po     010 --     F3V M5D 
+.             2119 X150000-0    Ba De Lo Ni Po     010 --     F3V M5V
 .             2419 X887000-0    Ba Lo Ni           000 --     F7V 
 .             2819 X591000-0    Ba Lo Ni           011 --     F5V 
 .             3019 X784000-0    Ba Lo Ni           011 --     M1V 
-.             0320 X274000-0    Ba Lo Ni           004 --     F5V M5D 
-.             1120 X000000-0    As Ba Lo Ni        013 --     A8V M4D 
+.             0320 X274000-0    Ba Lo Ni           004 --     F5V M5V
+.             1120 X000000-0    As Ba Lo Ni        013 --     A8V M4V
 .             1220 X333000-0    Ba Lo Ni Po        002 --     M1V 
 .             2120 X673000-0    Ba Lo Ni           000 --     F4V 
 .             2420 X110000-0    Ba Lo Ni           004 --     M1V 
-.             3020 X110000-0    Ba Lo Ni           000 --     M7V M8D 
+.             3020 X110000-0    Ba Lo Ni           000 --     M7V M8V
 .             0121 X442000-0    Ba Lo Ni Po        004 --     F0V 
-.             0221 X847000-0    Ba Lo Ni           002 --     F5V M5D 
+.             0221 X847000-0    Ba Lo Ni           002 --     F5V M5V
 .             0321 X8A3000-0    Ba Fl Lo Ni        000 --     M3V 
-.             2321 X673000-0    Ba Lo Ni           004 --     F8V M7D 
+.             2321 X673000-0    Ba Lo Ni           004 --     F8V M7V
 .             3121 X300000-0    Ba Lo Ni Va        003 --     M4V 
-.             0922 X696000-0    Ba Lo Ni           010 --     F2V M4D 
+.             0922 X696000-0    Ba Lo Ni           010 --     F2V M4V
 .             1922 X88A000-0    Ba Lo Ni Wa        002 --     K5V 
 .             2122 X679000-0    Ba Lo Ni           024 --     F3V 
-.             2222 XAB6000-0    Ba Fl Lo Ni        001 --     M6V M7D 
+.             2222 XAB6000-0    Ba Fl Lo Ni        001 --     M6V M7V
 .             3122 X797000-0    Ba Lo Ni           004 --     F6V 
 .             3222 X535000-0    Ba Lo Ni           002 --     M3V 
-.             0523 X300000-0    Ba Lo Ni Va        004 --     K3V F6V M2D 
-.             1923 X575000-0    Ba Lo Ni           020 --     F4V M2D 
-.             0424 X210000-0    Ba Lo Ni           002 --     M4V M7D 
-.             0724 X79A000-0    Ba Lo Ni Wa        015 --     F6V M6D 
+.             0523 X300000-0    Ba Lo Ni Va        004 --     F6V K3V M2V
+.             1923 X575000-0    Ba Lo Ni           020 --     F4V M2V
+.             0424 X210000-0    Ba Lo Ni           002 --     M4V M7V
+.             0724 X79A000-0    Ba Lo Ni Wa        015 --     F6V M6V
 .             0924 X242000-0    Ba Lo Ni Po        002 --     F8V 
-.             1224 X536000-0    Ba Lo Ni           002 --     K4V M3D 
-.             1624 X897000-0    Ba Lo Ni           020 --     F0V M4D 
+.             1224 X536000-0    Ba Lo Ni           002 --     K4V M3V
+.             1624 X897000-0    Ba Lo Ni           020 --     F0V M4V
 .             2224 X343000-0    Ba Lo Ni Po        004 --     F7V F5V 
 .             3224 X565000-0    Ba Lo Ni           020 --     F4V 
 .             0425 X8B3000-0    Ba Fl Lo Ni        005 --     M8V 
-.             0625 X202000-0    Ba Ic Lo Ni Va     026 --     M7V M1D 
+.             0625 X202000-0    Ba Ic Lo Ni Va     026 --     M1V M7V
 .             0725 X658000-0    Ba Lo Ni           002 --     F3V 
 .             1125 X665000-0    Ba Lo Ni           002 --     F6V 
-.             1425 X774000-0    Ba Lo Ni           015 --     F3V M8D 
+.             1425 X774000-0    Ba Lo Ni           015 --     F3V M8V
 .             1525 X000000-0    As Ba Lo Ni        006 --     M1V M2V 
-.             1925 X689000-0    Ba Lo Ni           006 --     F3V M1D F5V M7D 
+.             1925 X689000-0    Ba Lo Ni           006 --     F3V M1V F5V M7V
 .             2025 X567000-0    Ba Lo Ni           007 --     G1V G0V 
-.             2125 X556000-0    Ba Lo Ni           005 --     F5V M1D 
-.             2325 X9B6000-0    Ba Fl Lo Ni        005 --     M5V M4D 
-.             2425 X562000-0    Ba Lo Ni           003 --     F5V F2V M2D 
+.             2125 X556000-0    Ba Lo Ni           005 --     F5V M1V
+.             2325 X9B6000-0    Ba Fl Lo Ni        005 --     M4V M5V
+.             2425 X562000-0    Ba Lo Ni           003 --     F5V F2V M2V
 .             2825 X649000-0    Ba Lo Ni           020 --     F4V 
 .             2925 X322000-0    Ba Lo Ni Po        004 --     F6V 
 .             3025 X97A000-0    Ba Lo Ni Wa        002 --     F3V 
@@ -153,21 +153,21 @@ Dfotseth
 .             3226 X96A000-0    Ba Lo Ni Wa        000 --     F8V 
 .             0827 X584000-0    Ba Lo Ni           001 --     G7V 
 .             1027 X786000-0    Ba Lo Ni           000 --     F8V 
-.             1727 X335000-0    Ba Lo Ni           004 --     F0V M1D 
+.             1727 X335000-0    Ba Lo Ni           004 --     F0V M1V
 .             2027 X9D6000-0    Ba Fl Lo Ni        003 --     M7V 
 .             2127 X323000-0    Ba Lo Ni Po        002 --     M4V 
-.             2427 X536000-0    Ba Lo Ni           000 --     K2V M5D 
+.             2427 X536000-0    Ba Lo Ni           000 --     K2V M5V
 .             0128 X7A4000-0    Ba Fl Lo Ni        002 --     M8V 
 .             0828 X356000-0    Ba Lo Ni           004 --     F5V 
-.             1028 X544000-0    Ba Lo Ni           010 --     G0V M0D 
+.             1028 X544000-0    Ba Lo Ni           010 --     G0V M0V
 .             1528 X000000-0    As Ba Lo Ni        001 --     G5V 
-.             1628 X451000-0    Ba Lo Ni Po        010 --     F9V M2D 
-.             1828 X794000-0    Ba Lo Ni           006 --     F8V M4D 
+.             1628 X451000-0    Ba Lo Ni Po        010 --     F9V M2V
+.             1828 X794000-0    Ba Lo Ni           006 --     F8V M4V
 .             2428 X666000-0    Ba Lo Ni           012 --     F6V 
 .             2628 X300000-0    Ba Lo Ni Va        002 --     M6V 
-.             0429 X667000-0    Ba Lo Ni           024 --     G0V M6D 
+.             0429 X667000-0    Ba Lo Ni           024 --     G0V M6V
 .             1029 X969000-0    Ba Lo Ni           010 --     M0V 
-.             1329 X210000-0    Ba Lo Ni           003 --     M6V M4D 
+.             1329 X210000-0    Ba Lo Ni           003 --     M4V M6V
 .             1829 X989000-0    Ba Lo Ni           013 --     F5V 
 .             2829 X528000-0    Ba Lo Ni           014 --     M3V 
 .             0330 X000000-0    As Ba Lo Ni        000 --     M0V 
@@ -178,54 +178,54 @@ Dfotseth
 .             3130 X462000-0    Ba Lo Ni           003 --     F4V 
 .             0431 X677000-0    Ba Lo Ni           000 --     F5V 
 .             0731 X7B2000-0    Ba Fl Lo Ni        015 --     F7III 
-.             1131 X548000-0    Ba Lo Ni           005 --     M2V M6D 
+.             1131 X548000-0    Ba Lo Ni           005 --     M2V M6V
 .             1731 X330000-0    Ba De Lo Ni Po     000 --     M7V 
 .             3231 X565000-0    Ba Lo Ni           002 --     F8V 
-.             1332 X363000-0    Ba Lo Ni           012 --     G3V M8D 
-.             1932 X453000-0    Ba Lo Ni Po        014 --     F4V M8D 
-.             2132 X698000-0    Ba Lo Ni           002 --     G2V M1D 
+.             1332 X363000-0    Ba Lo Ni           012 --     G3V M8V
+.             1932 X453000-0    Ba Lo Ni Po        014 --     F4V M8V
+.             2132 X698000-0    Ba Lo Ni           002 --     G2V M1V
 .             0333 XA9A000-0    Ba Lo Ni Wa        001 --     K4V 
-.             0533 X67A000-0    Ba Lo Ni Wa        015 --     F0V M7D 
-.             0933 X383000-0    Ba Lo Ni           020 --     F3V M3D 
-.             1733 X436000-0    Ba Lo Ni           005 --     M1V M5D 
+.             0533 X67A000-0    Ba Lo Ni Wa        015 --     F0V M7V
+.             0933 X383000-0    Ba Lo Ni           020 --     F3V M3V
+.             1733 X436000-0    Ba Lo Ni           005 --     M1V M5V
 .             1933 X899000-0    Ba Lo Ni           021 --     F1V 
 .             2533 X9C6000-0    Ba Fl Lo Ni        004 --     F3IV M1V 
 .             2833 X463000-0    Ba Lo Ni           003 --     F8V 
-.             3133 X410000-0    Ba Lo Ni           004 --     K9V M5D 
-.             0934 X659000-0    Ba Lo Ni           006 --     G5V M2D 
+.             3133 X410000-0    Ba Lo Ni           004 --     K9V M5V
+.             0934 X659000-0    Ba Lo Ni           006 --     G5V M2V
 .             1234 X9C3000-0    Ba Fl Lo Ni        013 --     G5V 
-.             2434 X200000-0    Ba Lo Ni Va        002 --     F7V M5D 
+.             2434 X200000-0    Ba Lo Ni Va        002 --     F7V M5V
 .             2734 X000000-0    As Ba Lo Ni        002 --     M6V 
 .             3234 X77A000-0    Ba Lo Ni Wa        010 --     F0V 
 .             0735 X456000-0    Ba Lo Ni           004 --     M1V 
 .             0935 X160000-0    Ba De Lo Ni        002 --     G7V 
 .             1235 X99A000-0    Ba Lo Ni Wa        003 --     F9V 
-.             1635 X535000-0    Ba Lo Ni           015 --     F3V M3D 
+.             1635 X535000-0    Ba Lo Ni           015 --     F3V M3V
 .             1835 X360000-0    Ba De Lo Ni        004 --     F9V 
 .             2335 X276000-0    Ba Lo Ni           004 --     F1V 
-.             2535 X200000-0    Ba Lo Ni Va        016 --     M3V M0D 
-.             2635 X200000-0    Ba Lo Ni Va        022 --     G4V M7D 
-.             0236 X99A000-0    Ba Lo Ni Wa        025 --     F8V M5D 
-.             0536 X9A8000-0    Ba Fl Lo Ni        007 --     K2V M1D 
-.             0736 X644000-0    Ba Lo Ni           006 --     F2V M7D F8V M2D 
-.             0936 X336000-0    Ba Lo Ni           014 --     F6V M6D M2D 
+.             2535 X200000-0    Ba Lo Ni Va        016 --     M0V M3V
+.             2635 X200000-0    Ba Lo Ni Va        022 --     G4V M7V
+.             0236 X99A000-0    Ba Lo Ni Wa        025 --     F8V M5V
+.             0536 X9A8000-0    Ba Fl Lo Ni        007 --     K2V M1V
+.             0736 X644000-0    Ba Lo Ni           006 --     F2V M7V F8V M2V
+.             0936 X336000-0    Ba Lo Ni           014 --     F6V M6V M2V
 .             1436 X425000-0    Ba Lo Ni           000 --     M0V 
 .             1536 X8C8000-0    Ba Fl Lo Ni        002 --     M5III 
 .             2236 X64A000-0    Ba Lo Ni Wa        004 --     F0V 
-.             0137 X777000-0    Ba Lo Ni           001 --     F8V M0D 
-.             0237 X667000-0    Ba Lo Ni           001 --     F8V M3D 
+.             0137 X777000-0    Ba Lo Ni           001 --     F8V M0V
+.             0237 X667000-0    Ba Lo Ni           001 --     F8V M3V
 .             1237 X454000-0    Ba Lo Ni           000 --     M1V 
-.             1437 X320000-0    Ba De Lo Ni Po     001 --     F4V M5D 
+.             1437 X320000-0    Ba De Lo Ni Po     001 --     F4V M5V
 .             2037 X979000-0    Ba Lo Ni           010 --     F0V 
-.             0538 X9A6000-0    Ba Fl Lo Ni        014 --     G0V M2D 
+.             0538 X9A6000-0    Ba Fl Lo Ni        014 --     G0V M2V
 .             1138 X210000-0    Ba Lo Ni           000 --     G0III 
-.             1238 XA95000-0    Ba Lo Ni           004 --     F5V M4D 
+.             1238 XA95000-0    Ba Lo Ni           004 --     F5V M4V
 .             1738 X97A000-0    Ba Lo Ni Wa        002 --     F8V 
 .             1938 X556000-0    Ba Lo Ni           013 --     F8V 
 .             2338 X100000-0    Ba Lo Ni Va        007 --     M5V M7V 
-.             2638 X676000-0    Ba Lo Ni           000 --     M4V M7D 
+.             2638 X676000-0    Ba Lo Ni           000 --     M4V M7V
 .             1039 X887000-0    Ba Lo Ni           000 --     F2V 
-.             1439 X426000-0    Ba Lo Ni           002 --     K5V M0D K7V M2D 
+.             1439 X426000-0    Ba Lo Ni           002 --     K5V M0V K7V M2V
 .             1539 X100000-0    Ba Lo Ni Va        000 --     F2V 
 .             1739 X99A000-0    Ba Lo Ni Wa        002 --     F4V 
 .             1839 X729000-0    Ba Lo Ni           001 --     M6V 
@@ -235,4 +235,4 @@ Oughouzoth    3239 B654244-A    Lo Ni              804 Va     F0V
 .             0740 X000000-0    As Ba Lo Ni        002 --     F8V 
 .             0840 X563000-0    Ba Lo Ni           010 --     F9V 
 .             0940 X364000-0    Ba Lo Ni           002 --     K5V 
-.             1740 X9A4000-0    Ba Fl Lo Ni        005 --     K1V M8D 
+.             1740 X9A4000-0    Ba Fl Lo Ni        005 --     K1V M8V

--- a/res/Sectors/M1105/Finggvakhou.sec
+++ b/res/Sectors/M1105/Finggvakhou.sec
@@ -132,7 +132,7 @@ Finggvakhou
 .             0217 X110000-0    Ba Lo Ni           003 --     K2V M0V
 .             1617 X310000-0    Ba Lo Ni           003 --     M4V M8V
 .             1917 X344000-0    Ba Lo Ni           002 --     F3V 
-.             2017 X333000-0    Ba Lo Ni Po        002 --     M5V M0V
+.             2017 X333000-0    Ba Lo Ni Po        002 --     M0V M5V
 .             2317 X575000-0    Ba Lo Ni           000 --     F4V 
 .             2617 X322000-0    Ba Lo Ni Po        004 --     M7V 
 .             0318 X402000-0    Ba Ic Lo Ni Va     015 --     M1V M7V

--- a/res/Sectors/M1105/Gelath.sec
+++ b/res/Sectors/M1105/Gelath.sec
@@ -31,12 +31,12 @@ Ghugzorr      0202 C30068D-E  K Na Ni Va           220 KO     M3V
 K'grghu       0402 C545364-E    Lo Ni              902 KO     M5V 
 Vokskhon      0602 A689535-A  C Ni                 725 Va     F5V M3V
 Kua           0802 C8746A6-F    Ag Ni              322 KO     F3V M0V
-Gheksaesag    1002 B200330-B  G Lo Ni Va           909 Va     M1V M5V K5V
+Gheksaesag    1002 B200330-B  G Lo Ni Va           909 Va     K5V M5V M1V
 Dzagzsurrgh   1102 X686566-0  C Ag Ni              812 Va     F0V 
 N'rr'r        1402 D594200-7  K Lo Ni              612 KO     F9V 
 Verrghoukh    1902 C572568-7    Ni                 818 Va     G2V M7V
 Llezugz       2302 C000424-8    As Ni              102 Va     M5V 
-Kaegnakengoz  2402 D9A4369-3  C Fl Lo Ni           714 Va     M5V M6V M3V
+Kaegnakengoz  2402 D9A4369-3  C Fl Lo Ni           714 Va     M3V M6V M5V
 Orksaerrgaer  2602 C556524-4    Ag Ni              904 Va     F1V M1V
 Ezaksgvakhs   2702 C88A520-6    Ni Wa              503 Va     F7V M7V
 Knukskurrig   3202 B888463-5  G Ni                 103 Va     F0V 
@@ -91,7 +91,7 @@ Kreengit'kr   1006 B200234-E    Lo Ni Va           412 KO     M3V M6V
 Inaar         1206 X878542-1    Ag Ni              305 KO     F6V M3V M4V
 Neghoorrik    1806 E3307CE-F  K De Na Po           101 KO     M5V 
 Gnafe         2006 D323872-5    Na Po              212 Va     F9V M1V
-Thugae        2206 E637697-1    Ni                 504 Va     M1V M0V M4V
+Thugae        2206 E637697-1    Ni                 504 Va     M0V M1V M4V
 Dungkhak      2306 E22336A-5  C Lo Ni Po           902 Va     F6V M8V
 Rarulguerr    2506 B75A877-B  G Wa                 403 Va     F4V M8V
 Vaegrokae     2706 B885865-4  G Ri                 703 Va     M2V 
@@ -108,7 +108,7 @@ Gudhaerrghon  2207 C87848D-5    Ni                 200 Va     F9V
 Rudhkorsdael  2507 B301858-B    Ic Na Va           303 Va     K5V 
 Gaersfezforr  2707 D432100-8  C Lo Ni Po           704 Va     M4II 
 Rrugzazighz   3007 C86A322-6  G Lo Ni Wa           314 Va     F2V M7V
-Ksughzorall   3107 D564403-5  H Ni                 301 Va     F8V M3V F0V
+Ksughzorall   3107 D564403-5  H Ni                 301 Va     F0V M3V F8V
 Lakrux        0508 C547555-E    Ag Ni              403 KO     F7V M7V
 L!grikr't     0808 E100005-8    Lo Ni Va           314 KO     M3V M7V
 Kku!!raan     1008 C772785-E  K                    903 KO     F1V 
@@ -117,7 +117,7 @@ Booghiir      1708 C335677-D  O Ni                 101 KO     K3V M5V
 Gvoedzue      2008 A160115-D  G De Lo Ni           203 Va     F7V 
 Kegaedhegh    2108 C8B5516-3    Fl Ni              713 Va     F5IV 
 Rorrdholkok   2308 C446575-5    Ag Ni              102 Va     F1V 
-Rrouruen      2808 B100446-A  G Ni Va              416 Va     M7V M6V M6V
+Rrouruen      2808 B100446-A  G Ni Va              416 Va     M6V M7V M6V
 Ghiug         2908 B89A7A9-B  G Wa                 501 Va     F5V 
 Gniku         0309 C440766-F    De Po              500 KO     F5V 
 K'gaar        0509 C743233-D  K Lo Ni Po           802 KO     F0V 
@@ -144,7 +144,7 @@ Gnareek       1011 C4845AC-F  K Ag Ni              100 KO     F8V
 Kixax         1311 C110777-E  K Na                 113 KO     M2V 
 Kaengughdhue  1711 CAC6556-4  C Fl Ni              804 Va     K7V M3V
 Dagzan        2211 A465210-C  G Lo Ni              311 Va     F5V 
-Nazril        2511 C200265-9  C Lo Ni Va           816 Va     M4V M5V M2V 
+Nazril        2511 C200265-9  C Lo Ni Va           816 Va     M2V M5V M4V
 Tokaax        0212 C847753-C  K Ag                 100 KO     G8V 
 Kughaat!      0412 E6A37CC-A    Fl                 210 KO     F8V 
 X'eegakr'     1212 B110200-F  O Lo Ni              104 KO     F0V M3V
@@ -168,7 +168,7 @@ R'rmaaeeg     0814 B2408B9-F  O De Po              213 KO     F9V
 Gh!m!!        1014 C52A547-F  O Ni Wa              604 KO     M3V M8V
 Kir!!iix      1414 C00088A-F  K As Na              300 KO     G0V 
 Doaghz        1614 E57586B-3                       512 Va     G9V 
-R!rat         0315 D400114-C  K Lo Ni Va           315 KO     M3V F6V M1V
+R!rat         0315 D400114-C  K Lo Ni Va           315 KO     F6V M3V M1V
 Lupok         0715 D346662-B  K Ag Ni              704 KO     F0V 
 Rukr'         0815 C444632-F  K Ag Ni              612 KO     F8V M3V
 N'k'rr!!rii   1015 A552764-F  K Po                 526 KO     F9V M5V
@@ -177,7 +177,7 @@ Gvokokhksal   0116 B232522-8    Ni Po              202 Va     M2V
 Lluknoers     0216 C324455-7  C Ni                 601 Va     M6V 
 Mighur'r      0316 C130322-E  K De Lo Ni Po        701 KO     K9V 
 Garrut        0616 C839555-B    Ni                 902 KO     G4V 
-Rokik'kul     0916 B310754-F  K Na                 826 KO     K7V M8V M4II M6V
+Rokik'kul     0916 B310754-F  K Na                 826 KO     M4II M8V K7V M6V
 Zougedor      0717 E553667-2  C Ag Ni Po           610 Va     K2V 
 Kfountuell    1117 E65A876-3    Wa                 900 Va     M4V M8V
 T!reerit      1417 C263586-F  O Ag Ni              504 KO     F2V M4V
@@ -199,7 +199,7 @@ Dovae         0320 C8C3968-7  C Fl Hi In           102 Va     M1V M2V
 Llokno        0420 C776777-6    Ag                 107 Va     F6V M0V
 Zongdhaeghz   0520 B353578-9    Ag Ni Po           202 Va     M7V 
 Raedhkfaeng   0620 B4499BD-A    Hi In              416 Va     F2V M5V M3V
-Nitengixag    1720 D3557BA-B  K Ag                 605 KO     F8V F2V 
+Nitengixag    1720 D3557BA-B  K Ag                 605 KO     F2V F8V
 .             2320 X224000-0    Ba Lo Ni           002 --     F7V 
 N!ak          2721 B777457-E  K Ni                 702 Kk     F3V 
 Tl!geer       2821 E547666-B    Ag Ni              100 Kk     F1V 
@@ -231,8 +231,8 @@ Xin'keei      3226 C648424-F  K Ni                 531 Kk     F2V M6V
 K!ub!krxk!xk  2327 E534120-A  K Lo Ni              100 Kk     M4V 
 'kr'k         2627 C210885-F  K Na                 510 Kk     F2V M0V
 Nukeera       2727 C413457-B  O Ic Ni              801 Kk     M8V 
-Raakoo        2827 B6A5679-F  O Fl Ni              302 Kk     F7IV M4V 
-Nooki         3127 D8A9466-C  O Fl Ni              404 Kk     K0V M4V 
+Raakoo        2827 B6A5679-F  O Fl Ni              302 Kk     F7IV M4V
+Nooki         3127 D8A9466-C  O Fl Ni              404 Kk     K0V M4V
 Ghikrooxkip   3227 B242669-D  K Ni Po              402 Kk     G6V 
 .             1128 X639000-0    Ba Lo Ni           002 --     F7V 
 K'raal        2228 C658749-F  K Ag                 312 Kk     K6V 

--- a/res/Sectors/M1105/Gh1hken.sec
+++ b/res/Sectors/M1105/Gh1hken.sec
@@ -26,11 +26,11 @@ Neeek'bli     2301 B564341-F  O Lo Ni              804 Kk     F5V M8V
 Kiir'         2701 A575756-F  O Ag                 102 Kk     M0V 
 Enaam         2801 C864454-E  O Ni                 203 Kk     K2V 
 Eilum'r       2901 CAA9577-F  O Fl Ni              600 Kk     M6V 
-Tukrulaakr    3101 C541235-C  K Lo Ni Po           416 Kk     F7V M5V 
+Tukrulaakr    3101 C541235-C  K Lo Ni Po           416 Kk     F7V M5V
 Trumiikik     1002 C644565-F  O Ag Ni              703 KC     F8V 
 Eerraameet    1302 B345752-E  O Ag                 115 Kk     F1V M1V
 Angekruurum   2302 C521311-D  O Lo Ni Po           502 Kk     M2V 
-Ghaanoorirer  2402 C879534-F  K Ni                 524 Kk     F6V M0V F3V
+Ghaanoorirer  2402 C879534-F  K Ni                 524 Kk     F3V M0V F6V
 Gr'!mhk'ng    2802 E8B3976-E    Fl Hi In           203 Kk     F1V M1V
 K'xul'rr      2902 D411522-B  K Ic Ni              604 Kk     M0V M1V
 !'xkuroxk     1003 C9B0338-9  K De Lo Ni           313 KC     G8V M1V
@@ -120,7 +120,7 @@ Ghaningung    2309 A846622-F  O Ag Ni              414 Kk     F8V
 T'kr          3109 C734897-C  O                    810 Kk     F2V 
 T'im          3209 B140898-F  O De Po              912 Kk     F7V 
 Nukag!'ruur   1010 C555310-D  K Lo Ni              803 KC     F1V 
-K'noo         1310 C324340-C  K Lo Ni              906 KC     M3V M1V
+K'noo         1310 C324340-C  K Lo Ni              906 KC     M1V M3V
 Mimuukaare    1410 C000420-F  K As Ni              800 KC     M3III 
 Gniimbak!m    1510 C437778-C  O                    703 KC     M6V 
 Kt'eexkeer    1810 A200137-F  O Lo Ni Va           502 K1     M8V 
@@ -161,8 +161,8 @@ K!keera       1313 D454340-9  K Lo Ni              610 KC     F0V M4V
 Urr!ngir      1513 E431521-9  K Ni Po              905 KC     F2V M8V
 Nariireex     1713 C130145-E  K De Lo Ni Po        610 KC     M1V 
 Kel!regr      1913 A662433-F  K Ni                 823 KC     F6V M0V
-K'run         2213 C527343-E  O Lo Ni              204 K2     K9V K1V 
-'r!ngirr      2513 C310566-F  K Ni                 604 Kk     M6V M5V
+K'run         2213 C527343-E  O Lo Ni              204 K2     K1V K9V
+'r!ngirr      2513 C310566-F  K Ni                 604 Kk     M5V M6V
 Eelmb!kkex    2713 C756559-D  K Ag Ni              702 Kk     F5V 
 Kriirig       2813 C787300-B    Lo Ni              604 Kk     F3V 
 Taaa          2913 A745678-F  O Ag Ni              213 Kk     K3V 
@@ -216,7 +216,7 @@ Kr!rriiitang  2017 C410322-A  K Lo Ni              124 K2     F4V M7V
 Nutiikr!gu    2117 D561467-E  K Ni                 212 K2     F7V M2V
 Ekr'ng'       2417 E7358BB-C  K                    103 K2     F6V M2V
 Akerorun      2517 D310485-B  O Ni                 815 K2     M1V M4V
-Ura!g         2617 C439433-E    Ni                 302 K2     M3V K7V 
+Ura!g         2617 C439433-E    Ni                 302 K2     K7V M3V
 Eerug         2817 C351354-D  O Lo Ni Po           801 Kk     F8V 
 Rrong'        3017 C6A57B9-F  K Fl                 204 Kk     K1V M6V
 K'ng't        3217 B579110-D  O Lo Ni              310 Kk     F2V 
@@ -245,7 +245,7 @@ Eeg!r         1820 A654524-F  O Ag Ni              102 KC     M8V
 K!nganguuk    2120 C365966-E    Hi In              504 K2     K6V 
 Tilugneneeng  2220 B444685-D  O Ag Ni              316 K2     F6V M3V
 Rr'rtii       2320 B410001-F  K Lo Ni              201 K2     M4V M8V
-Gnalukraaxk   2420 C434437-C  K Ni                 603 K2     M2V M1V
+Gnalukraaxk   2420 C434437-C  K Ni                 603 K2     M1V M2V
 K'kilok       2520 E555577-E    Ag Ni              721 K2     F0V 
 Nir'tlu       2620 C6A1676-B  K Fl Ni              702 K2     F8V 
 Krurr'rnu     2720 C877278-E  K Lo Ni              400 K2     M8V 
@@ -383,7 +383,7 @@ Kr!k'         1831 A7A279A-F    Fl                 102 KC     M1V
 Iiroonxuirr   2031 D643520-D  K Ag Ni Po           405 K2     F2V M7V
 Guketi        2331 C763AAA-F  O Hi In              413 K2     F6V 
 Ghaiiiil      2531 C647864-C                       806 K2     G7V M8V
-Eetroob'r     3031 E484867-D    Ri                 300 Kk     G4V M8V F6V M4V
+Eetroob'r     3031 E484867-D    Ri                 300 Kk     F6V M8V G4V M4V
 Rr'ghaxreekr  0232 C778620-E  K Ag Ni              700 K3     F5V 
 Griliku       0332 C437656-F  K Ni                 900 K3     M3V 
 Ktokr         0432 E540474-A  K De Ni Po           416 K3     G6V M2V
@@ -404,7 +404,7 @@ Rikraabiube   0233 A448977-F  K Hi In              405 K3     F6V M6V
 Kaamboolu     0333 C86A788-F  O Ri Wa              805 K3     F7V M6V
 Gn!'xerr      0533 D79A337-9  K Lo Ni Wa           903 K3     F0V 
 Toongan'roor  0633 E253310-A  K Lo Ni Po           203 K3     F2V 
-X!r!irrir     0733 C500999-E    Hi Na Va           200 K3     F9D M8V
+X!r!irrir     0733 C500999-E    Hi Na Va           200 K3     F9V M8V
 Unir'r        0933 BAE4796-E  K Fl                 200 K3     A1V M8V
 Noriixkokraa  1033 B646546-F  K Ag Ni              401 K3     F3V 
 Ulaar'kre     1133 C100635-D  K Na Ni Va           604 K3     M7V 
@@ -439,15 +439,15 @@ Trek!!'kr     0435 C586667-C  K Ag Ni Ri           906 K3     F3V M5V
 Xw'!t!'ng     0535 E300300-9    Lo Ni Va           810 K3     M3V 
 'k!           0635 B200333-C  K Lo Ni Va           200 K3     M2V M6V
 Ekuteegh      0935 C3108B9-C  O Na                 104 K3     F5V 
-Ghemb!'tim    1135 B5267AA-F  K                    323 KC     M8V M0V
+Ghemb!'tim    1135 B5267AA-F  K                    323 KC     M0V M8V
 Kt'kren'r     1435 B575123-D  O Lo Ni              302 KC     F7V 
 Mbiiuuritu    1635 E424100-A  K Lo Ni              400 KC     K7V 
 Xuxuaaki      1735 C7A3246-E  K Fl Lo Ni           822 KC     G5V 
-Gz'm'eegr     1835 E74A459-9  K Ni Wa              834 KC     K5V G8V M8V
+Gz'm'eegr     1835 E74A459-9  K Ni Wa              834 KC     G8V K5V M8V
 Pu!ngirr      2035 D684520-C    Ag Ni              704 KC     G9V M7V
 Kr'ar         2235 E6388B9-A  K                    800 KC     F0V 
-Lurak'b'ko    2435 D997457-B  K Ni                 606 KC     F2V M4D M6V
-Iireer'k'     2635 D400475-9  K Ni Va              217 K4     M7V K8V
+Lurak'b'ko    2435 D997457-B  K Ni                 606 KC     F2V M4V M6V
+Iireer'k'     2635 D400475-9  K Ni Va              217 K4     K8V M7V
 Krirakruxiit  2735 BA86879-F    Ri                 412 K4     F6V 
 'rrek!k       2835 B5526BD-F  O Ni Po              100 K4     F5V M7V
 Gr'rmbaakkoo  0636 E46078C-A  K De Ri              911 K3     G1V 
@@ -468,7 +468,7 @@ Kur!'k'r      2936 C8A858B-E  K Fl Ni              303 K4     K3V
 Xuxaatiiniik  3036 E310426-9  K Ni                 812 K4     K3II G9V 
 'ghu'rr'      3136 C563954-F    Hi In              301 K4     G0V M8V
 R'mbiin't     0137 B4739A6-F  K Hi In              401 K3     F4V 
-Kaaakruu      0337 C88A000-D  K Ba Lo Ni Wa        514 K3     F3V F0V M5V
+Kaaakruu      0337 C88A000-D  K Ba Lo Ni Wa        514 K3     F0V F3V M5V
 In'xkan       0437 A534567-F  K Ni                 210 K3     M6V 
 Engukruxkr!   0537 C592784-F  O                    102 K3     F6V 
 Gner'b        0737 BACA244-F  K Fl Lo Ni Wa        315 K3     M3III M2V M6V
@@ -485,7 +485,7 @@ Mb'xe         3137 D7588BB-C                       828 K4     F5V M8V
 Aale!gh       3237 C66A566-F  O Ni Wa              903 K4     F7V 
 R'ke          0438 D524200-9  K Lo Ni              712 K3     K0V 
 Irrak         0838 E203A98-E    Hi Ic Na Va        400 K3     F9V 
-Rigz!         0938 C310668-F  K Na Ni              318 K3     F8V M8V F5V
+Rigz!         0938 C310668-F  K Na Ni              318 K3     F5V M8V F8V
 Oori          1138 C494256-C  K Lo Ni              223 KC     F7V M2V
 Kurrok'xku    1338 B586134-E  O Lo Ni              512 KC     F7V 
 Kreengerii    2038 CAB5433-F  K Fl Ni              622 KC     F4V M2V
@@ -501,7 +501,7 @@ Mbukimurreg   0139 B99A121-D  O Lo Ni Wa           922 K3     F8V
 Ruuk!ng!'k    0239 B410301-C  K Lo Ni              702 K3     M4V 
 N'xt'ng'      0439 E346697-D  K Ag Ni              851 K3     F4V M0V
 Kolaat        1039 B785686-D    Ag Ni Ri           624 KC     F1V 
-'krkr'ki      1339 E120663-A  K De Na Ni Po        713 KC     G3V M8V 
+'krkr'ki      1339 E120663-A  K De Na Ni Po        713 KC     G3V M8V
 Hkur'xungik   1639 E637385-A    Lo Ni              901 KC     M8V 
 Gh'rrix       1739 C8B3666-E  K Fl Ni              100 KC     M6V 
 Kriinkax      2039 A84A644-F    Ni Wa              104 KC     M4V 


### PR DESCRIPTION
@inexorabletash asked me to, when submitting bulk sector-data fixen, break up said fixen PRs into different classes of sectors, so here goes with squaring up the stellar data in Undeveloped Sectors.
I'm not making any deliberate attempt to canonicalise star sizes as per T5.10 Book 3 p 28.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is _swapped_ into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).