### PR TITLE
Fix Numbis sector stellar data

### DIFF
--- a/res/Sectors/M1105/Numbis.txt
+++ b/res/Sectors/M1105/Numbis.txt
@@ -2,7 +2,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 ---- -------------------- --------- ----------------------- ------ ------- ------ - -- - --- -- ---- -------------------
 0103 Gashetha             C662200-6 Lo                      { -2 } (C11+1) [2196] - -  - 414 11 NaXX K5 V K7 V
 0104 Idiefers             B576ABA-E Hi In                   { 4 }  (E9B+0) [9E7D] - N  - 323 16 NaXX K3 V
-0105 Douwi                A83A627-A Wa Ni                   { 1 }  (953-2) [7788] - -  - 610 9  NaXX M6 V G1 V
+0105 Douwi                A83A627-A Wa Ni                   { 1 }  (953-2) [7788] - -  - 610 9  NaXX G1 V M6 V
 0106 Wodean               A000776-A As Va Na Pi             { 2 }  (D6C+2) [999A] - -  - 904 15 NaXX G8 V
 0109 Odot                 E541548-3 He Ni Po                { -3 } (741-2) [3281] - -  - 803 9  Mp   K0 V
 0110 Fetodeng             X763786-0 Ri                      { -1 } (769+0) [4661] - -  - 701 13 Mp   M8 V
@@ -31,15 +31,15 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 0508 Tedoex               D4738AD-3 Ph Pi                   { -2 } (476+0) [B664] - -  - 103 14 Up   K3 V
 0510 Sowe                 E887763-6 Ga Ag Ri Mr             { 0 }  (868+0) [7768] - -  - 410 9  NaXX A3 V
 0601 Aceeciss             X771863-0 He Ph Pi Mr             { -2 } (873+2) [8641] - -  R 801 9  NaXX K0 V
-0602 Bagathio             C596640-7 Ni Ag                   { -1 } (354-2) [954B] - -  - 401 10 NaXX M7 V F9 V
-0603 Caworo               B424338-C Lo                      { 1 }  (C21-1) [445A] - -  - 823 12 Up   G5 V F9 V
+0602 Bagathio             C596640-7 Ni Ag                   { -1 } (354-2) [954B] - -  - 401 10 NaXX F9 V M7 V
+0603 Caworo               B424338-C Lo                      { 1 }  (C21-1) [445A] - -  - 823 12 Up   F9 V G5 V
 0607 Exlen                E574210-5 Lo                      { -3 } (911-3) [6138] - -  - 224 17 Up   G8 V M0 V
 0609 Endaati              E230755-5 De Na Po                { -2 } (666+1) [9516] - -  - 810 7  Up   A4 V
 0701 Staves               C545346-6 Lo                      { -2 } (521+2) [6154] - -  - 201 10 NaXX M9 V
 0704 Letaxeinesan         C553335-6 Lo Po                   { -2 } (A21+1) [8182] - -  - 700 10 Up   K8 V
 0706 Thaacane             B755753-7 Ga Ag                   { 1 }  (866+4) [687B] - -  - 324 13 Up   F1 V K1 V
 0708 Benattun             B320613-B De He Ni Na Po          { 2 }  (H57-1) [782A] - NS - 534 18 Up   G7 V
-0710 Fonagiack            B79A67B-8 Wa Ni                   { -1 } (B50+2) [7554] - -  - 203 8  Up   M3 V M0 V
+0710 Fonagiack            B79A67B-8 Wa Ni                   { -1 } (B50+2) [7554] - -  - 203 8  Up   M0 V M3 V
 0801 Sheteraho            E66AA89-7 Wa Hi                   { -1 } (899+3) [5958] - -  - 304 12 NaXX M0 V
 0803 Aipatu               C437763-7 Mr                      { -1 } (C65+3) [7637] - -  - 500 9  NaXX M8 V
 0806 Abat                 A865655-D Ga Ni Ag Ri             { 3 }  (B54+0) [B93E] - -  - 100 6  Up   G6 V
@@ -62,8 +62,8 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 1210 Hoare                A421659-D He Ni Na Po             { 1 }  (853-2) [6769] - N  - 600 11 Up   F7 V
 1303 Eni                  C43059A-8 De Ni Po                { -2 } (740-3) [4366] - -  - 803 8  NaXX K0 V
 1308 Itho                 C774533-9 Ni Ag                   { 0 }  (B42-2) [6534] - -  - 603 8  NaXX G5 V
-1309 Tesii                E834664-5 Ni Mr                   { -3 } (350+3) [B366] - -  - 900 13 NaXX M7 V M3 V
-1404 Famathando           D563547-4 Ni Pr                   { -3 } (540-4) [8213] - -  - 910 12 NaXX M7 V M1 V
+1309 Tesii                E834664-5 Ni Mr                   { -3 } (350+3) [B366] - -  - 900 13 NaXX M3 V M7 V
+1404 Famathando           D563547-4 Ni Pr                   { -3 } (540-4) [8213] - -  - 910 12 NaXX M1 V M7 V
 1405 Ouner                A100689-B Va Ni Na                { 1 }  (756-2) [775B] - -  - 401 7  NaXX M3 V
 1407 Iilasha              C896546-8 Ni Ag                   { -1 } (744-3) [6448] - -  - 600 5  NaXX G4 V
 1409 Garshel              A43668A-B Ni                      { 1 }  (952+4) [6757] - N  - 924 11 NaXX F5 V
@@ -85,7 +85,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 1807 Ora                  B878A96-9 Hi In                   { 3 }  (A9C+0) [8D67] - -  - 801 9  NaXX M8 V
 1808 Estiarplend          C582657-5 Ni Ri                   { -1 } (254+3) [A553] - -  - 603 16 NaXX G8 V
 1901 Roren                B6A0510-8 He Ni                   { -1 } (742+1) [5498] - -  - 402 9  NaXX K3 V M5 V
-1903 Kosse                C75577A-7 Ga Ag                   { 0 }  (A6C+3) [4795] - -  - 800 12 NaXX M6 V M3 V
+1903 Kosse                C75577A-7 Ga Ag                   { 0 }  (A6C+3) [4795] - -  - 800 12 NaXX M3 V M6 V
 1905 Thachos              CAE8656-7 Ni                      { -2 } (654-3) [741B] - -  - 700 9  NaXX M5 V
 1906 Faschetibene         A537400-A Ni                      { 1 }  (534+0) [4599] - -  - 911 10 NaXX M6 V
 1908 Todora               D371567-8 He Ni Mr                { -3 } (341+2) [822A] - -  - 901 8  NaXX M8 V
@@ -117,7 +117,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 2502 Shogarve             C7C3662-4 Fl Ni O:2803            { -2 } (950+1) [5438] - -  - 714 17 Lx   K2 V
 2503 Loitrala             A677A75-C Hi In                   { 5 }  (99B-2) [AF8A] - NS - 320 8  Lx   K2 V K7 V
 2505 Houeroar             E3006BB-6 Va Ni Na                { -3 } (750-2) [4357] - -  - 701 7  Lx   K9 V
-2506 Cedi                 B335436-A Ni                      { 1 }  (934-4) [451C] - -  - 302 12 NaXX K6 V M1 V K3 V
+2506 Cedi                 B335436-A Ni                      { 1 }  (934-4) [451C] - -  - 302 12 NaXX K3 V M1 V K6 V
 2509 Xkaal'               C47643A-9 Ni Pa                   { -1 } (B31-2) [5314] - O  - 423 11 KkTw M5 V
 2601 Tharar               B435746-9                         { 1 }  (B6A+3) [786B] - -  - 500 12 Lx   F0 II K8 V D
 2604 Teteti               A7468AA-B Ph Pa Pi                { 2 }  (978+0) [AAA7] - -  - 203 14 Lx   M3 V
@@ -129,14 +129,14 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 2707 Gh'ghukaax           B89353A-B Ni                      { 1 }  (D45+1) [6679] - -  - 504 11 KkTw G0 V
 2710 Tiikraakuut          D67953A-8 Ni                      { -3 } (940+1) [4239] - -  - 310 11 KkTw F8 V
 2801 Ela                  B577666-7 Ni Ag O:2803            { 0 }  (752-2) [96A8] - -  - 523 11 Lx   M1 V
-2802 Loitrala             D89756A-6 Ni Ag O:2803            { -2 } (840+0) [6329] - -  - 925 14 Lx   M2 V M0 V
+2802 Loitrala             D89756A-6 Ni Ag O:2803            { -2 } (840+0) [6329] - -  - 925 14 Lx   M0 V M2 V
 2803 Litmo                B300A66-E Va Hi Na In Mr          { 4 }  (C9B+5) [CE7G] - N  - 814 11 Lx   G4 V M9 V
 2804 Ledowalya            B624566-7 Ni O:2803               { -1 } (240+3) [2467] - N  - 900 9  Lx   G6 V
 2805 Rida                 C243630-5 Ni Po                   { -2 } (951-2) [7453] - -  - 314 17 Lx   K7 V
 2806 Kuaghee              B000337-B As Va Lo                { 1 }  (A21-1) [646G] - N  - 904 9  NaXX K5 V
 2807 Arirreeno            C40243A-B Ic Va Ni                { 0 }  (B35-2) [4487] - O  - 813 13 KkTw A0 V
 2808 Liikeela             D66953A-8 Ni Pr                   { -3 } (740-1) [627B] - O  - 601 7  KkTw K9 V M6 V
-2901 Elcir                A9B5356-D Fl Lo                   { 1 }  (D21-4) [646D] - -  - 904 9  Lx   M5 V M9 V M4 V
+2901 Elcir                A9B5356-D Fl Lo                   { 1 }  (D21-4) [646D] - -  - 904 9  Lx   M4 V M9 V M5 V
 2902 Poayisoong           C30058A-8 Va Ni                   { -2 } (942-3) [3388] - -  - 804 11 Lx   F1 V
 2905 Bagiriyo             C120725-B De Na Pi Po             { 1 }  (86A+0) [8868] - -  - 503 9  Lx   F9 V
 2910 Tikru                E411000-0 Ic Ba                   { -3 } (800+2) [0000] - -  - 001 10 KkTw K6 V
@@ -166,7 +166,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 0220 Holeri               B120310-E De Lo Po                { 1 }  (E21-3) [143B] - -  - 212 10 NaXX G6 V
 0312 Thina                B436AA6-E Hi                      { 3 }  (799-1) [9D7G] - N  - 600 11 Mp   M2 V
 0319 Ereso                A541342-C He Lo Po                { 1 }  (621+0) [247B] - -  - 910 9  NaXX M0 V
-0320 Lalya                B364979-C Hi Pr                   { 3 }  (A88-1) [6C5D] - -  - 203 12 NaXX K8 V F9 V
+0320 Lalya                B364979-C Hi Pr                   { 3 }  (A88-1) [6C5D] - -  - 203 12 NaXX F9 V K8 V
 0411 Shahtbeht            A489632-C Ni Ri                   { 2 }  (855-1) [986A] - -  - 620 8  Mp   M4 V M7 V
 0413 Chesi                E644520-3 Ni Ag                   { -2 } (944+3) [5313] - -  - 900 4  NaXX M8 V
 0414 Oesa                 C5569BA-9 Hi                      { 1 }  (C8C-3) [7A77] - -  - 623 11 Mp   K1 V
@@ -183,21 +183,21 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 0717 Kekenan              E567487-7 Ni Pa                   { -3 } (830-2) [1167] - -  - 204 14 NaXX G0 V
 0719 Loutet               E485677-2 Ni Ag Ri                { -1 } (655-2) [1542] - -  - 304 9  NaXX M8 V
 0812 Cani                 A97A301-C Wa Lo                   { 1 }  (C21+4) [548C] - N  - 214 13 Up   K2 V M3 V
-0813 Miwa                 A664778-A Ag Ri                   { 4 }  (B6B+5) [7B48] - N  - 300 10 Up   M4 V M0 V
+0813 Miwa                 A664778-A Ag Ri                   { 4 }  (B6B+5) [7B48] - N  - 300 10 Up   M0 V M4 V
 0814 Ahta                 B557658-6 Ni Ag                   { 0 }  (756+0) [9654] - -  - 823 10 Up   A2 V
 0817 Folorbars            A620522-C De He Ni Po             { 1 }  (E47-2) [865E] - N  - 724 14 NaXX F4 V
 0819 Lehtgun              B998243-7 Lo                      { -1 } (511-2) [4175] - -  - 100 7  NaXX K9 V
 0913 Essa                 D734689-5 Ni                      { -3 } (652+0) [8355] - -  - 900 5  NaXX G5 V
 0914 Shader               C555766-4 Ag O:0907               { 0 }  (B69-1) [9713] - -  - 200 5  NaXX A7 V M4 V
 0915 Enlesodi             B639344-C Lo                      { 1 }  (821-1) [248E] - -  - 602 9  Up   K1 III M4 V D
-0917 Perkind              B202885-9 Ic Va Ph Na Pi          { 1 }  (578+1) [A92B] - -  - 502 8  NaXX M6 V M3 V
+0917 Perkind              B202885-9 Ic Va Ph Na Pi          { 1 }  (578+1) [A92B] - -  - 502 8  NaXX M3 V M6 V
 0919 Eda                  D451873-3 Ph Po                   { -2 } (B73-2) [B648] - -  - 501 10 NaXX G6 V M9 V M0 V
 0920 Oxennanaeng          E734432-6 Ni                      { -3 } (730+3) [3156] - -  - 103 9  NaXX M2 V
 1011 Ildi                 B120840-C De Ph Na Pi Po          { 2 }  (876+1) [7A9B] - -  - 403 13 Up   A1 V G5 V G5 V
 1012 Pliake               C525337-7 Lo                      { -2 } (521+1) [1176] - -  - 514 12 Up   G7 V K5 V
-1017 Luto                 B31387A-8 Ic Ph Na Pi             { 0 }  (77A+4) [683D] - -  - 400 13 Yc   M1 V K4 V
+1017 Luto                 B31387A-8 Ic Ph Na Pi             { 0 }  (77A+4) [683D] - -  - 400 13 Yc   K4 V M1 V
 1018 Ragre                D210697-3 Ni Na                   { -3 } (850-3) [7366] - -  - 304 13 Yc   G6 V
-1019 Vomins               E361000-0 Ba                      { -3 } (B00+2) [0000] - -  - 020 9  Yc   M9 V M5 V
+1019 Vomins               E361000-0 Ba                      { -3 } (B00+2) [0000] - -  - 020 9  Yc   M5 V M9 V
 1111 Assohe               C62A636-9 Ni                      { -1 } (851+3) [9558] - -  - 800 12 Up   F6 V M2 V
 1112 Sifi                 C886552-7 Ga Ni Ag Pr             { -1 } (640+3) [A467] - -  - 700 9  Up   M0 V
 1114 Euse                 E300210-7 Va Lo                   { -3 } (B11-3) [3169] - -  - 602 6  Up   M8 V
@@ -208,7 +208,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 1216 Tarthe               A000763-E As Va Na Pi O:1220      { 2 }  (869+2) [898D] - N  - 600 6  Yc   M1 V
 1217 Thorobens            C240364-6 De Lo Po O:1220         { -2 } (721-1) [5158] - -  - 924 13 Yc   M4 V
 1220 Edienta              A404532-D Ic Va Ni                { 1 }  (546-4) [766D] - N  - 802 9  Yc   K6 V
-1312 Tainat               C643667-7 Ni Po O:0907            { -2 } (C52+2) [4437] - -  - 903 12 NaXX K2 V A6 V
+1312 Tainat               C643667-7 Ni Po O:0907            { -2 } (C52+2) [4437] - -  - 903 12 NaXX A6 V K2 V
 1313 Kire                 B9D2989-D Hi                      { 3 }  (A8C-4) [BC3B] - -  - 412 11 NaXX K2 V
 1314 Muit                 C6107AD-8 Na Pi                   { -1 } (D62-5) [564B] - -  - 514 14 NaXX G6 V
 1316 Efovit               C384104-9 Lo                      { -1 } (H01+3) [111A] - -  - 123 11 Yc   M1 V
@@ -225,7 +225,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 1514 Wanishen             E0009CC-7 As Va Hi Na In          { 0 }  (684+0) [9969] - -  - 504 9  NaXX G7 V
 1516 Esaotoce             C532667-7 Ni Na Po O:1220         { -2 } (753-2) [5419] - -  - 503 8  Yc   G0 V K2 V
 1517 Eteer                A53537B-E Lo                      { 1 }  (621+0) [745C] - -  - 802 11 Yc   K2 V
-1611 Gardaw               B645556-B Ni Ag                   { 2 }  (643+2) [7778] - -  - 601 5  NaXX M9 V M6 V M0 V
+1611 Gardaw               B645556-B Ni Ag                   { 2 }  (643+2) [7778] - -  - 601 5  NaXX M0 V M6 V M9 V
 1613 Tene                 E568245-6 Lo                      { -3 } (611+1) [6184] - -  - 710 9  NaXX F4 V
 1615 Cawand               C230563-9 De Ni Po O:1220         { -1 } (445+0) [642C] - -  - 500 10 Yc   K6 V
 1616 Anwegely             C578533-7 Ni Ag                   { -1 } (B40+0) [3466] - -  - 320 14 Yc   A8 V F5 V
@@ -241,16 +241,16 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 1817 Cesowu               E85A859-9 Wa Ph                   { -1 } (B75+1) [573B] - -  - 901 7  NaXX M7 V
 1911 Athen                B200000-8 Va Di Di(minor)         { -1 } (C0B+1) [0000] - -  - 022 13 NaXX F6 IV
 1912 Beldod               C594200-5 Lo                      { -2 } (911+3) [1142] - -  - 814 15 NaXX G2 V
-1915 Gzam'xk              A495437-C Ni Pa (minor)           { 1 }  (A33-4) [857D] - K  - 812 13 KkTw M6 V M5 V
+1915 Gzam'xk              A495437-C Ni Pa (minor)           { 1 }  (A33-4) [857D] - K  - 812 13 KkTw M5 V M6 V
 1916 'rikookut'           B44269A-B He Ni Po                { 1 }  (854+2) [476B] - K  - 800 13 KkTw M1 V M5 V
-1918 Kagr                 A75789A-C Ga Ph Pa                { 2 }  (F78-1) [9A7D] - K  - 504 10 KkTw M8 V M4 V
+1918 Kagr                 A75789A-C Ga Ph Pa                { 2 }  (F78-1) [9A7D] - K  - 504 10 KkTw M4 V M8 V
 1920 Rookee               D98879A-6 Ag Ri                   { 0 }  (B67+3) [5726] - -  - 302 7  KkTw M3 V M7 V
-2011 Deja                 C644101-8 Lo                      { -2 } (701+1) [3128] - -  - 100 7  NaXX M7 V M4 V
+2011 Deja                 C644101-8 Lo                      { -2 } (701+1) [3128] - -  - 100 7  NaXX M4 V M7 V
 2016 Kurr                 A5A153A-E Fl He Ni                { 1 }  (742+1) [663G] - K  - 700 10 KkTw F7 V
 2017 Eex!gna              E64411A-7 Lo                      { -3 } (B01+3) [1168] - -  - 820 8  KkTw G0 V
 2018 Krur'kragn!          E200000-0 Va Ba                   { -3 } (A00+1) [0000] - -  - 022 12 KkTw A8 V
-2019 Krakrib              A99911A-D Lo                      { 1 }  (901+3) [124G] - -  - 912 9  KkTw K7 V M5 V A0 V A4 V
-2111 Etacha               A441300-F He Lo Po                { 1 }  (B21+3) [144H] - N  - 201 14 NaXX M4 V M3 V
+2019 Krakrib              A99911A-D Lo                      { 1 }  (901+3) [124G] - -  - 912 9  KkTw A0 V M5 V K7 V A4 V
+2111 Etacha               A441300-F He Lo Po                { 1 }  (B21+3) [144H] - N  - 201 14 NaXX M3 V M4 V
 2112 Otouck               C100AB9-D Va Hi Na In             { 3 }  (A96-2) [8D5C] - -  - 104 10 NaXX M9 V
 2114 !xkii                C97953A-A Ni                      { 0 }  (D43-3) [4589] - -  - 323 14 KkTw K3 V
 2116 Guut                 B54853A-A Ni Ag                   { 2 }  (848+3) [775D] - -  - 303 12 KkTw K6 V M3 V
@@ -259,13 +259,13 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 2213 Ireer'niit           A77343A-C Ni                      { 1 }  (A32+0) [756E] - K  - 102 12 KkTw K5 V
 2214 'kukr                C662A9A-C Hi                      { 2 }  (999-4) [6C5C] - -  - 522 12 KkTw M5 V M9 V
 2216 Errik'k              C65469A-8 Ni Ag                   { -1 } (953+3) [4527] - O  - 810 6  KkTw M2 V M7 V
-2217 Rr'gheegni           C77643A-9 Ni Pa                   { -1 } (C35+3) [5346] - O  - 414 13 KkTw M7 V M5 V
+2217 Rr'gheegni           C77643A-9 Ni Pa                   { -1 } (C35+3) [5346] - O  - 414 13 KkTw M5 V M7 V
 2219 R'ng                 E220000-0 De Ba Po                { -3 } (700-3) [0000] - -  - 000 5  KkTw M0 V M5 V
-2311 Xt'n                 EA7A000-0 Oc Ba                   { -3 } (900+0) [0000] - -  - 023 13 KkTw M8 V K9 V
+2311 Xt'n                 EA7A000-0 Oc Ba                   { -3 } (900+0) [0000] - -  - 023 13 KkTw K9 V M8 V
 2312 Nak                  E100000-0 Va Ba                   { -3 } (C00+0) [0000] - -  - 000 8  KkTw K1 III M5 V
-2313 Ureerrer'rrux        B44589A-B Ph Pa Pi                { 2 }  (97E+0) [9A2C] - K  - 504 14 KkTw K5 V A8 V K2 V M1 V
+2313 Ureerrer'rrux        B44589A-B Ph Pa Pi                { 2 }  (97E+0) [9A2C] - K  - 504 14 KkTw A8 V K5 V K2 V M1 V
 2314 Gh'xk                C786A9A-C Ga Hi                   { 2 }  (796+0) [6C7E] - O  - 400 5  KkTw M5 V
-2316 Arengahkik           C46389A-9 Ph Ri                   { 1 }  (A78-1) [595A] - -  - 100 10 KkTw M4 V M1 V
+2316 Arengahkik           C46389A-9 Ph Ri                   { 1 }  (A78-1) [595A] - -  - 100 10 KkTw M1 V M4 V
 2317 K'm'k                D55169A-6 Ni Po                   { -3 } (950-3) [5356] - O  - 201 11 KkTw M8 V M8 V
 2319 Kulaarr              EA8A43A-9 Oc Ni                   { -2 } (B32-1) [423A] - -  - 123 15 KkTw M1 V
 2320 Ghuur                B85879A-A Ag                      { 3 }  (A6B-3) [4A5D] - -  - 201 6  KkTw M6 V
@@ -287,7 +287,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 2812 Xeghahk!ghee         C563A9A-C Hi                      { 2 }  (999-2) [6C2E] - O  - 824 13 KkTw G7 V M2 V
 2814 Gir!!kuu             C56553A-9 Ni Ag Pr (minor)        { 0 }  (F41+0) [2555] - -  - 604 11 KkTw K6 V M3 V
 2815 Kreregh              X55543B-0 Ni Pa (minor)           { -3 } (432-2) [3131] - -  R 723 13 KkTw F2 V
-2912 Zjemu-ay             D67453A-7 Ni Ag (Mazjaru)         { -2 } (941+2) [1389] - -  - 202 11 KkTw K0 V F5 V
+2912 Zjemu-ay             D67453A-7 Ni Ag (Mazjaru)         { -2 } (941+2) [1389] - -  - 202 11 KkTw F5 V K0 V
 2913 Xoognireenak'r       C41143A-B Ic Ni                   { 0 }  (D32-1) [546F] - -  - 103 8  KkTw G7 V
 2916 Kex                  B65989A-A Ph                      { 2 }  (A7B+3) [3A6E] - O  - 500 9  KkTw M2 V
 2917 Mbar                 C766A9A-C Ga Hi                   { 2 }  (C96-2) [AC59] - -  - 800 6  KkTw M2 V
@@ -302,7 +302,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 3112 R!!lukuhkaarr        B68579A-A Ga Ag Ri                { 4 }  (F68-2) [CB1D] - K  - 224 17 KkTw A2 V
 3113 In'r'n               E6A0000-0 He Ba                   { -3 } (600-1) [0000] - -  - 012 11 KkTw F3 V
 3114 Ak                   E100000-0 Va Ba                   { -3 } (B00+0) [0000] - -  - 020 8  KkTw K8 V M2 V
-3116 Kr!keekaa            E64633A-7 Lo                      { -3 } (321+4) [1148] - -  - 700 5  KkTw M7 V M8 V M2 V
+3116 Kr!keekaa            E64633A-7 Lo                      { -3 } (321+4) [1148] - -  - 700 5  KkTw M2 V M8 V M7 V
 3118 Eek                  B654A9A-D Hi                      { 3 }  (89D+0) [BD4F] - K  - 310 8  KkTw K2 V
 3119 Kriirar              C74653A-7 Ni Ag (minor)           { -1 } (741-4) [2426] - -  - 420 7  KkTw A0 V
 3213 Rr!l                 C7B711A-A Fl Lo                   { 0 }  (A01-3) [1168] - O  - 312 12 KkTw G4 IV K6 V F0 V
@@ -314,15 +314,15 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 0121 Fivoix               C62A477-9 Ni                      { -1 } (E33+4) [535B] - -  - 220 10 NaXX M0 V M5 V
 0123 Bareden              C678100-9 Lo                      { -1 } (B01-1) [315B] - -  - 923 10 NaXX G7 V K6 V
 0126 Enshom               B727673-8 Ni                      { -1 } (654+0) [95A8] - -  - 600 5  NaXX K0 V
-0127 Trouteou             C337551-9 Ni                      { -1 } (841-3) [445B] - -  - 300 11 NaXX M4 V A3 V
+0127 Trouteou             C337551-9 Ni                      { -1 } (841-3) [445B] - -  - 300 11 NaXX A3 V M4 V
 0128 Jorshee              C410301-8 Lo                      { -2 } (E21+3) [317A] - -  - 822 7  NaXX G6 V M0 V
 0223 Oayi                 A9A6304-D Fl Lo                   { 1 }  (921+0) [244B] - -  - 301 12 NaXX M7 V
-0226 Orcer                C455441-5 Ni Pa                   { -2 } (930-2) [1287] - -  - 602 12 NaXX K0 V F1 V
+0226 Orcer                C455441-5 Ni Pa                   { -2 } (930-2) [1287] - -  - 602 12 NaXX F1 V K0 V
 0230 Hayasbegh            A2258BB-E Ph Pi                   { 2 }  (975-3) [8A8B] - -  - 322 16 NaXX F0 V
 0322 Thader               E341426-8 He Ni Po                { -3 } (A30+1) [2168] - -  - 503 13 NaXX G9 V
 0324 Entallosa            B210210-8 Lo                      { -1 } (A11+1) [2147] - N  - 523 14 NaXX A3 V
 0421 Getlerdilind         B775213-6 Lo                      { -1 } (411+2) [3169] - -  - 302 9  NaXX M7 V
-0423 Bengcough            D6A3657-7 Fl Ni                   { -3 } (653+2) [8399] - -  - 200 11 NaXX M5 V M4 V
+0423 Bengcough            D6A3657-7 Fl Ni                   { -3 } (653+2) [8399] - -  - 200 11 NaXX M4 V M5 V
 0425 Osho                 A1308CD-D De Ph Na Po             { 2 }  (976+0) [3A8B] - N  - 300 9  NaXX M1 V M8 V
 0427 Utre                 B310836-A Ph Na Pi                { 2 }  (C76-1) [6A1C] - N  - 504 16 NaXX K6 V M2 V
 0430 Gronitcan            A4309CD-D De Hi Na Po             { 3 }  (E8C+1) [9C2D] - N  - 603 7  Cr   M0 V
@@ -335,8 +335,8 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 0626 Encho                B8B37CB-6 Fl                      { 1 }  (66B+2) [5894] - NS - 103 12 NaXX M3 V M9 V
 0627 Bobevanen            C874434-7 Ni Pa                   { -2 } (432-2) [5264] - -  - 524 12 NaXX G8 V
 0629 Etou                 C100698-7 Va Ni Na                { -2 } (A50+4) [6489] - -  - 514 10 Cr   A1 V G2 V
-0630 Thondgonkas          C98A473-A Wa Ni                   { 0 }  (D32-4) [445E] - -  - 323 11 Cr   M7 V M0 V
-0722 Whondafouly          A78A786-E Wa Ri                   { 3 }  (966-4) [4A8K] - -  - 600 10 NaXX M3 V K2 V
+0630 Thondgonkas          C98A473-A Wa Ni                   { 0 }  (D32-4) [445E] - -  - 323 11 Cr   M0 V M7 V
+0722 Whondafouly          A78A786-E Wa Ri                   { 3 }  (966-4) [4A8K] - -  - 600 10 NaXX K2 V M3 V
 0724 Vessa                D356511-7 Ni Ag                   { -2 } (440+0) [5346] - -  - 223 14 Cr   F2 V
 0725 Frotharwo            A662686-C Ni Ri                   { 2 }  (854+0) [282A] - -  - 301 12 Cr   M4 V
 0727 Ono                  EAB5558-4 Fl Ni                   { -3 } (C40-1) [2247] - -  - 521 12 Cr   M7 V
@@ -360,7 +360,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 1122 Taer                 C255649-9 Ni Ag                   { 0 }  (A51+0) [9618] - -  - 401 11 Yc   M0 V
 1123 Frilete              C534125-9 Lo                      { -1 } (401-5) [2137] - -  - 900 10 Yc   K1 III M9 V
 1124 Hidtan               A627341-9 Lo                      { 1 }  (C21+1) [546C] - NS - 403 16 NaXX K3 V
-1127 Erewari              C875596-9 Ni Ag                   { 0 }  (944+1) [653D] - -  - 603 12 Cr   M3 V M1 V
+1127 Erewari              C875596-9 Ni Ag                   { 0 }  (944+1) [653D] - -  - 603 12 Cr   M1 V M3 V
 1129 Esou                 C553400-7 Ni Po                   { -2 } (230-3) [8277] - -  - 700 5  Cr   K7 V M7 V
 1225 Anet                 C688559-A Ni Ag Pr                { 1 }  (543-1) [6685] - -  - 600 5  NaXX M0 V
 1226 Chitixwed            B2409DF-6 De Hi In Po             { 2 }  (68D+1) [AB33] - -  - 900 7  NaXX M3 V
@@ -369,7 +369,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 1323 Folya                D563ADF-6 Hi                      { -1 } (797+2) [A954] - -  - 224 15 Yc   K9 V
 1324 Oyles                A591977-B He Hi In                { 4 }  (68B+0) [AD7E] - -  - 422 9  Yc   G4 V M8 V
 1326 Tirir                E770678-2 De He Ni                { -3 } (652+5) [3322] - -  - 200 5  NaXX M8 V
-1327 Souftone             C626844-8 Ph Pi                   { -1 } (A77+3) [977C] - -  - 101 6  Cr   M0 V A1 V
+1327 Souftone             C626844-8 Ph Pi                   { -1 } (A77+3) [977C] - -  - 101 6  Cr   A1 V M0 V
 1330 Efaong               A3368BF-D Ph                      { 2 }  (F7B+2) [8A7J] - -  - 224 17 Cr   F1 V
 1421 Adshechely           E440203-8 De He Lo Po             { -3 } (911+2) [317A] - -  - 700 11 Yc   K9 V M0 V
 1424 Lende                E773546-4 Ni                      { -3 } (840+3) [5214] - -  - 600 6  Yc   M3 V
@@ -384,10 +384,10 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 1530 Amo                  D100322-9 Va Lo                   { -2 } (D21-1) [317C] - -  - 802 15 Cr   A1 V G1 V
 1621 Rodlelymon           D434520-9 Ni                      { -2 } (640+0) [1315] - -  - 700 9  Yc   M6 V
 1623 Atlis                X210578-4 Ni                      { -3 } (642+0) [2293] - -  - 122 11 Yc   F5 V
-1624 Paem                 B400248-9 Va Lo                   { 1 }  (B11+2) [135A] - NS - 501 12 NaXX M0 V F4 V
+1624 Paem                 B400248-9 Va Lo                   { 1 }  (B11+2) [135A] - NS - 501 12 NaXX F4 V M0 V
 1626 Lopolle              B636550-8 Ni                      { -1 } (741-1) [7479] - -  - 900 6  Cr   M4 V
 1630 Adtiss               E250205-7 De Lo Po                { -3 } (811-1) [114C] - -  - 401 14 NaXX K4 V
-1722 Coniout              D7746AC-2 Ni Ag                   { -2 } (C51-1) [4431] - -  - 802 10 Yc   M7 V M3 V
+1722 Coniout              D7746AC-2 Ni Ag                   { -2 } (C51-1) [4431] - -  - 802 10 Yc   M3 V M7 V
 1723 Gedoor               C6B0477-8 He Ni                   { -2 } (734+4) [1257] - -  - 101 10 Yc   K3 V M7 V
 1725 Alye                 A452522-9 Ni Po                   { 0 }  (341+5) [858D] - N  - 500 8  NaXX F9 V
 1726 Grea                 D433777-6 Na Po                   { -2 } (361+1) [7595] - -  - 823 12 Cr   M9 V
@@ -395,16 +395,16 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 1730 Arsem                A696100-C Lo                      { 1 }  (B01+0) [1269] - N  - 522 11 Cr   K4 V
 1821 Traresill            C532202-B Lo Po                   { 0 }  (311-1) [1277] - -  - 200 13 NaXX M1 V
 1822 Callit               B402674-9 Ic Va Ni Na             { 0 }  (A54-1) [265A] - -  - 224 11 NaXX A1 V
-1824 Yasfo                A696685-7 Ni Ag                   { 0 }  (654-1) [6654] - -  - 900 7  NaXX M9 V M2 V
-1922 Dithet               D400442-8 Va Ni                   { -3 } (731+3) [2157] - -  - 201 8  NaXX M8 V M6 V
+1824 Yasfo                A696685-7 Ni Ag                   { 0 }  (654-1) [6654] - -  - 900 7  NaXX M2 V M9 V
+1922 Dithet               D400442-8 Va Ni                   { -3 } (731+3) [2157] - -  - 201 8  NaXX M6 V M8 V
 1923 Dixeba               E5A0731-7 He                      { -2 } (465+3) [9544] - -  - 903 7  NaXX G0 V
 1925 Ise                  D465354-5 Lo                      { -3 } (521-2) [2187] - -  - 301 6  Cr   K5 V
 1926 Nomi                 A95A665-D Wa Ni O:2130            { 1 }  (957+2) [571F] - -  - 800 10 Cr   K8 V
 1928 Ifeon                E200355-8 Va Lo                   { -3 } (F21-1) [1159] - -  - 323 15 Cr   K5 V M9 V
 1930 Noneboes             C380478-6 De Ni                   { -2 } (433+3) [4265] - -  - 513 10 Cr   G3 V
-2021 Oriir!               A44569A-D Ni Ag                   { 2 }  (B57-1) [488B] - K  - 213 17 KkTw M9 V M1 V
+2021 Oriir!               A44569A-D Ni Ag                   { 2 }  (B57-1) [488B] - K  - 213 17 KkTw M1 V M9 V
 2023 Thefoni              C54877A-7 Ag Pi                   { 0 }  (762+0) [3747] - -  - 811 8  NaXX G4 V M6 V
-2027 Loin                 C968732-3 Ag Ri                   { 1 }  (865+3) [7857] - -  - 515 10 Cr   M8 V M1 V
+2027 Loin                 C968732-3 Ag Ri                   { 1 }  (865+3) [7857] - -  - 515 10 Cr   M1 V M8 V
 2029 Horu                 E570765-6 De He Pi O:2130         { -2 } (B66+5) [9546] - -  - 223 14 Cr   K5 V
 2030 Thesou               E567433-6 Ni Pa                   { -3 } (632-5) [7146] - -  - 300 4  Cr   M9 V M9 V
 2124 Liik'kreexku         C64153A-9 He Ni Po                { -1 } (E40+0) [844B] - O  - 604 13 KkTw M1 V
@@ -415,7 +415,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 2222 Xr!!kitukiit         A48089A-D De Ph Ri                { 3 }  (97A-1) [9B3G] - -  - 700 11 KkTw M4 V
 2223 Kru                  C88A69A-A Wa Ni Ri                { 1 }  (656+3) [6778] - -  - 102 11 KkTw G8 V M7 V
 2225 Kaag                 D45699A-9 Hi                      { 0 }  (D88-4) [B995] - O  - 502 7  KkTw M5 V M5 V
-2226 Muumbi               E838000-0 Ba                      { -3 } (C00+3) [0000] - -  - 020 14 KkTw M8 V M2 V
+2226 Muumbi               E838000-0 Ba                      { -3 } (C00+3) [0000] - -  - 020 14 KkTw M2 V M8 V
 2228 Heetha               B7776B7-8 Ni Ag                   { 0 }  (955-5) [766B] - N  - 822 8  NaXX G7 V
 2230 Genses               A575632-B Ni Ag                   { 2 }  (E56+1) [6869] - -  - 523 14 NaXX G7 V K0 V
 2321 X'k                  B73743A-B Ni                      { 1 }  (835+3) [4518] - K  - 100 5  KkTw G7 V
@@ -434,10 +434,10 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 2528 Tr'k                 A88799A-D Ga Hi Pr                { 3 }  (78C+0) [AC4C] - O  - 902 10 KkTw M2 V
 2529 In!t                 B32153A-C He Ni Po                { 1 }  (B42+0) [666A] - O  - 710 7  KkTw G7 V
 2530 Ni                   B78A21A-D Wa Lo                   { 1 }  (511-3) [334J] - K  - 901 5  KkTw M3 V
-2621 Kigh                 DA6A11A-9 Oc Lo                   { -2 } (801+1) [1138] - O  - 403 13 KkTw K8 V K5 V
+2621 Kigh                 DA6A11A-9 Oc Lo                   { -2 } (801+1) [1138] - O  - 403 13 KkTw K5 V K8 V
 2622 T'mb!!r              E57421A-7 Lo                      { -3 } (511-1) [316A] - -  - 601 10 KkTw M2 V
 2623 Kek                  X76811A-3 Lo Rs                   { -3 } (901-3) [2134] - -  R 401 11 KkTw M2 V
-2624 Kaar                 E100000-0 Va Ba                   { -3 } (900-4) [0000] - -  - 015 10 KkTw G7 V A6 V
+2624 Kaar                 E100000-0 Va Ba                   { -3 } (900-4) [0000] - -  - 015 10 KkTw A6 V G7 V
 2625 Ariikragraa          A97A53A-F Wa Ni                   { 1 }  (C47+2) [464J] - K  - 115 12 KkTw F5 V
 2626 Kriikr               CA9769A-8 Ni Ag                   { -1 } (853-2) [A569] - O  - 722 10 KkTw K6 V
 2628 Kr!                  A26299A-F Hi Pr                   { 3 }  (B88+1) [CC3A] - K  - 100 8  KkTw G1 V
@@ -450,17 +450,17 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 2730 Eem                  E639000-0 Ba                      { -3 } (400+2) [0000] - -  - 024 15 KkTw F5 III
 2821 Gzom                 A410434-B Ni (minor)              { 1 }  (G35-1) [155E] - -  - 915 12 KkTw M0 V M3 V
 2823 Hka                  E79A000-0 Wa Ba                   { -3 } (400+1) [0000] - -  - 002 7  KkTw K7 V M6 V
-2826 Bak                  C65289A-8 Ph Po                   { -1 } (875-1) [873C] - K  - 400 8  KkTw M8 V M3 V
+2826 Bak                  C65289A-8 Ph Po                   { -1 } (875-1) [873C] - K  - 400 8  KkTw M3 V M8 V
 2827 Ghaahk!b             B67653A-B Ni Ag                   { 2 }  (848+1) [574B] - -  - 202 9  KkTw M3 V
 2828 Luupim               X445853-3 Ph Pa Pi (Luupim)       { -2 } (475+1) [7673] - -  R 601 6  KkTw K9 V
 2830 Xikanookr            B79479A-A Ag Pi                   { 3 }  (C6B-2) [6A89] - O  - 100 12 KkTw M4 V
-2922 Eelareer't           C11021A-B Lo                      { 0 }  (B11+2) [324A] - -  - 913 11 KkTw M5 V M1 V
+2922 Eelareer't           C11021A-B Lo                      { 0 }  (B11+2) [324A] - -  - 913 11 KkTw M1 V M5 V
 2923 Rreerr               E8D9000-0 Ba                      { -3 } (600+4) [0000] - -  - 000 8  KkTw M3 V M9 V
 2927 Kaaron!rixiraa       B41011A-A Lo                      { 1 }  (801-4) [1265] - -  - 600 8  KkTw M2 V M7 V
 2928 Kune                 B32333A-C Lo Po                   { 1 }  (B21+3) [1459] - K  - 215 13 KkTw M8 V
 2929 Xkuux                B6B643A-B Fl Ni                   { 1 }  (F36-2) [752F] - O  - 724 14 KkTw G3 V
 3021 Krixuu               B43633A-C Lo                      { 1 }  (721+1) [146C] - K  - 802 9  KkTw M4 V
-3023 Ghir                 E25269A-7 Ni Po                   { -3 } (351+2) [6384] - -  - 914 13 KkTw M7 V M0 V
+3023 Ghir                 E25269A-7 Ni Po                   { -3 } (351+2) [6384] - -  - 914 13 KkTw M0 V M7 V
 3025 R'r!'t               C52411A-9 Lo                      { -1 } (601+0) [2168] - O  - 100 12 KkTw G1 V
 3026 Kragunur             D44669A-7 Ni Ag                   { -2 } (653-1) [4435] - -  - 800 11 KkTw M0 V
 3028 Mbagr'm              B88769A-A Ga Ni Ag Ri             { 3 }  (F59+3) [99AC] - -  - 823 14 KkTw K9 V M4 V
@@ -470,10 +470,10 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 3123 K!x                  B87833A-B Lo                      { 1 }  (B21+2) [8419] - K  - 604 16 KkTw F8 V
 3124 Grikar               C77233A-9 He Lo                   { -1 } (721+1) [122E] - O  - 602 10 KkTw A5 V
 3125 Latuun               B44279A-A He Pi Po                { 2 }  (968+2) [B97C] - -  - 304 15 KkTw K9 V M5 V
-3126 Rreegreek!           A46199A-F Hi Pr                   { 3 }  (88C+2) [9C2H] - -  - 200 13 KkTw M7 V M4 V M6 V
+3126 Rreegreek!           A46199A-F Hi Pr                   { 3 }  (88C+2) [9C2H] - -  - 200 13 KkTw M4 V M7 V M6 V
 3128 Ir't'rruu            CAA533B-6 Fl Lo (minor)           { -2 } (621-3) [2113] - -  - 401 10 KkTw M7 V M8 V
 3130 Tuktaar              C655A9A-C Ga Hi                   { 2 }  (89D-4) [BC1F] - K  - 121 12 KkTw G2 V
-3224 Taaxakaagh           C44279A-9 He Pi Po                { 0 }  (D67-5) [4739] - -  - 920 14 KkTw M9 V M6 V
+3224 Taaxakaagh           C44279A-9 He Pi Po                { 0 }  (D67-5) [4739] - -  - 920 14 KkTw M6 V M9 V
 3226 Kiirr'ng             A26489A-C Ph Pa Ri                { 3 }  (277+1) [6B7B] - O  - 400 9  KkTw M6 V
 3227 Krak                 C66789A-8 Ga Ph Pa Ri             { 0 }  (975+3) [387C] - O  - 104 15 KkTw F1 V
 3228 Yoir                 B402799-C Ic Va Na Pi             { 2 }  (B67+3) [2968] - -  - 814 13 SELK M5 V
@@ -492,12 +492,12 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 0339 Tramoutigat          E524677-7 Ni                      { -3 } (352+0) [6358] - -  - 102 8  Cr   M2 V
 0436 Getin                C1009AB-8 Va Hi Na In             { 1 }  (E8C+0) [EA98] - -  - 623 11 Cr   K5 V
 0438 Inpe                 C8A6566-5 Fl Ni O:0735            { -2 } (A42-3) [7347] - -  - 500 10 Cr   M4 V
-0531 Fibonoide            X32759B-1 Ni                      { -3 } (242+2) [2221] - -  - 802 11 Cr   M9 V M2 V
+0531 Fibonoide            X32759B-1 Ni                      { -3 } (242+2) [2221] - -  - 802 11 Cr   M2 V M9 V
 0535 Shandasexo           C563635-5 Ni Ri                   { -1 } (B55+0) [4544] - -  - 300 5  Cr   G2 V K2 V
 0537 Onou                 E596000-0 Ba                      { -3 } (400-3) [0000] - -  - 023 12 NaXX A8 V
 0539 Triror               B210346-D Lo                      { 1 }  (821+4) [444J] - -  - 504 10 NaXX K3 V
 0540 Farget               C654255-8 Lo                      { -2 } (511+4) [1125] - -  - 100 3  NaXX M8 V
-0632 Irstonfusi           E4509CC-4 De Hi Po                { -1 } (786+0) [C848] - -  - 300 9  Cr   M3 V M0 V
+0632 Irstonfusi           E4509CC-4 De Hi Po                { -1 } (786+0) [C848] - -  - 300 9  Cr   M0 V M3 V
 0635 Odoregha             D6A4887-6 Fl Ph                   { -2 } (C74-1) [8647] - -  - 301 7  Cr   M4 V
 0638 Nana                 D998579-5 Ni Ag                   { -2 } (840-1) [7376] - -  - 502 7  NaXX M7 V
 0639 Ldona                D768745-6 Ag Ri                   { 0 }  (86A+0) [8772] - -  - 301 10 HvFd M0 V
@@ -506,7 +506,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 0733 Ouldfed              B776321-B Lo                      { 1 }  (C21+1) [643C] - -  - 923 17 Cr   F8 V K6 V
 0734 Yorse                EAA7789-7 Fl                      { -2 } (461-3) [C545] - -  - 300 4  Cr   G4 V M7 V
 0735 Brieri               B221A88-D Hi Na In Po             { 4 }  (D99+0) [9E7B] - -  - 102 10 Cr   K1 V
-0738 Rodihs               A574855-B Ph Pa Pi                { 2 }  (578-4) [6A97] - K  - 900 6  HvFd M9 V G9 V
+0738 Rodihs               A574855-B Ph Pa Pi                { 2 }  (578-4) [6A97] - K  - 900 6  HvFd G9 V M9 V
 0740 Naner                E898502-4 Ni Ag                   { -2 } (A41+1) [5375] - -  - 601 11 HvFd M6 V
 0833 Yeip                 C300224-B Va Lo                   { 0 }  (811-2) [2266] - S  - 400 9  Cr   M1 V M2 V
 0836 Brewan               CAA8530-6 Fl Ni                   { -2 } (640+5) [7369] - -  - 523 16 NaXX G1 V K4 V
@@ -522,7 +522,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 1031 Squire               C979363-6 Lo O:0931               { -2 } (621-2) [2143] - -  - 810 14 Cr   K6 V
 1036 Lufoof               C8C5853-5 Fl Ph                   { -1 } (A79+0) [7775] - -  A 412 12 HvFd G9 V
 1038 Oxspere              X648627-2 Ni Ag (minor)           { -2 } (B50-5) [7412] - -  R 502 8  HvFd F9 V
-1039 Paf                  E567746-5 Ag Ri                   { 0 }  (864-1) [7794] - -  - 502 9  HvFd K6 V K2 V
+1039 Paf                  E567746-5 Ag Ri                   { 0 }  (864-1) [7794] - -  - 502 9  HvFd K2 V K6 V
 1133 Dusk                 D589569-5 Ni Pr Mr                { -3 } (940+5) [4225] - -  - 600 9  NaXX G7 V
 1134 Bastion              C0008CF-8 As Va Ph Na Pi          { -1 } (F76-1) [B766] - -  - 825 17 NaXX F6 II M4 V D
 1136 Onnur                E510732-7 Na Pi                   { -2 } (A64-1) [9536] - -  - 700 11 HvFd F3 V M3 V
@@ -541,12 +541,12 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 1537 Klyth                BA99503-8 Ni                      { -1 } (844-1) [245A] - M  - 824 13 HvFd F0 V K5 V
 1633 Blisk                C300322-7 Va Lo                   { -2 } (721+0) [1137] - -  - 223 13 HvFd M2 III
 1634 Cilacan              C878662-8 Ni Ag O:1638            { -1 } (950-2) [755A] - -  - 620 9  HvFd F2 V
-1635 Totatrick            A995753-C Ag Pi                   { 3 }  (566+0) [6A9A] - -  - 402 7  HvFd F4 V A7 V
+1635 Totatrick            A995753-C Ag Pi                   { 3 }  (566+0) [6A9A] - -  - 402 7  HvFd A7 V F4 V
 1638 Wrostaqax            A374A87-F Hi In                   { 4 }  (B9B-3) [BE8E] - E  - 224 12 HvFd K0 V M6 V
 1640 Slurn                C977753-6 Ag Pi (minor)           { 0 }  (964+0) [3753] - -  A 320 7  HvFd F7 V M2 V
 1731 Oongiinu             C61121A-9 Ic Lo                   { -1 } (B11-2) [115C] - O  - 710 7  KkTw F5 V F7 V K9 V
 1733 Atanerpinti          C310A85-C Hi Na In (minor)        { 3 }  (D9A+0) [FD28] - M  A 325 12 HvFd G4 V
-1734 Gasony               B786506-C Ga Ni Ag Pr             { 2 }  (A46+1) [674G] - -  - 300 4  HvFd M4 V M0 V
+1734 Gasony               B786506-C Ga Ni Ag Pr             { 2 }  (A46+1) [674G] - -  - 300 4  HvFd M0 V M4 V
 1737 Besihng              E546561-5 Ni Ag O:1939            { -2 } (642-5) [5353] - -  - 804 11 HvFd K4 V M0 V
 1831 Cedar                E635759-7                         { -2 } (968+3) [3568] - -  - 404 14 NaXX G2 V
 1834 Nyenan               B687634-B Ga Ni Ag Ri             { 3 }  (758-1) [8959] - -  - 921 14 HvFd F5 V
@@ -561,17 +561,17 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 1937 Zepes                E9A4851-7 Fl Ph                   { -2 } (777+2) [B637] - -  - 100 7  HvFd M6 V
 1939 Bimihm               A788751-B Ag Ri                   { 4 }  (C6A+1) [7B59] - E  - 322 8  HvFd G3 V M9 V
 2032 Weregre              B644736-7 Ag Pi (minor)           { 1 }  (968+1) [A857] - -  A 103 12 HvFd M3 V M4 V
-2033 Bengak               A314511-A Ic Ni                   { 1 }  (846-3) [167E] - -  - 801 6  HvFd M9 V A0 V
+2033 Bengak               A314511-A Ic Ni                   { 1 }  (846-3) [167E] - -  - 801 6  HvFd A0 V M9 V
 2036 Royrehk              B527766-B Pi O:1939               { 2 }  (469-2) [5927] - -  - 100 7  HvFd K9 II D
 2037 Derehs               A868765-9 Ag Ri O:1939            { 3 }  (F6E+2) [6A45] - -  - 724 19 HvFd F3 V K0 V
 2039 Thalalb              B6B0752-8 He                      { 0 }  (A64+0) [A748] - -  - 900 11 HvFd M6 V
-2040 Loondire             E544266-4 Lo (minor) O:1939       { -3 } (611-5) [6152] - -  A 500 8  HvFd M2 V G2 V
+2040 Loondire             E544266-4 Lo (minor) O:1939       { -3 } (611-5) [6152] - -  A 500 8  HvFd G2 V M2 V
 2131 Guurr!'rr            D48369A-7 Ni Ri                   { -2 } (750+1) [B487] - O  - 603 10 KkTw M6 V
 2132 Fodo                 C732454-A Ni Po                   { 0 }  (B33-1) [143B] - -  - 513 15 NaXX M1 V
 2135 Nolidh               E584585-5 Ni Ag Pr                { -2 } (640-1) [1381] - -  - 600 9  HvFd M9 V
 2138 Dimbel               C300203-9 Va Lo                   { -1 } (611+2) [31A6] - -  - 910 11 HvFd M0 V
 2139 Letak                B120567-9 De Ni Po (minor) O:1939 { 0 }  (245+0) [8548] - M  A 300 6  HvFd A6 V
-2140 Ninu                 A344583-A Ni Ag                   { 2 }  (B45+0) [273D] - K  - 911 10 HvFd G8 V A0 V
+2140 Ninu                 A344583-A Ni Ag                   { 2 }  (B45+0) [273D] - K  - 911 10 HvFd A0 V G8 V
 2232 Analy                XAD8330-4 Lo                      { -3 } (A21+0) [1172] - -  R 701 9  NaXX M1 V
 2233 Esae                 C32072A-5 De He Na Pi Po (minor)  { -1 } (468-2) [86A3] - M  A 413 11 HvFd A5 V
 2234 Lofas                C7B4966-7 Fl Hi In O:2334         { 1 }  (58B+4) [9A53] - -  A 302 11 HvFd G4 V
@@ -581,12 +581,12 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 2339 Zeyehr               C745405-8 Ni Pa                   { -2 } (C30+0) [428A] - -  - 902 12 HvFd K0 V M3 V
 2340 Zenda                C636503-7 Ni                      { -2 } (742+0) [53A4] - -  - 202 10 HvFd F3 V
 2431 Etsoatad             C754404-8 Ni Pa                   { -2 } (G34-3) [8249] - -  - 104 12 NaXX K6 V M1 V
-2433 Bihmbi               E898756-6 Ag Pi                   { -1 } (868+1) [7628] - -  - 402 9  HvFd K5 V F0 V
+2433 Bihmbi               E898756-6 Ag Pi                   { -1 } (868+1) [7628] - -  - 402 9  HvFd F0 V K5 V
 2437 Theral               E886102-7 Ga Lo                   { -3 } (601-3) [1143] - -  - 820 13 HvFd K1 V
 2438 Berand               A437166-A Lo (minor) O:2737       { 1 }  (901+5) [428B] - E  - 302 7  HvFd M5 V
 2440 Boghas               B688873-A Ph Pa Ri                { 3 }  (E79-1) [7B77] - -  - 405 16 HvFd G1 V
-2531 Eckon                E41589A-4 Ic Ph Pi                { -2 } (675+0) [4675] - -  - 503 12 NaXX M3 V M2 V M3 V
-2532 Nousit               X671200-3 He Lo                   { -3 } (711+0) [1193] - -  R 400 9  NaXX M1 V A1 V
+2531 Eckon                E41589A-4 Ic Ph Pi                { -2 } (675+0) [4675] - -  - 503 12 NaXX M2 V M3 V M3 V
+2532 Nousit               X671200-3 He Lo                   { -3 } (711+0) [1193] - -  R 400 9  NaXX A1 V M1 V
 2533 Yihsald              BA88303-C Lo                      { 1 }  (C21-2) [542B] - K  - 233 15 HvFd G4 V M5 V
 2535 Pizih                E335506-7 Ni                      { -3 } (441+2) [2276] - -  - 801 9  HvFd M8 V
 2536 Nebhan               C98A404-7 Wa Ni                   { -2 } (933+2) [628B] - M  - 521 12 HvFd F9 V
@@ -596,7 +596,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 2636 Illetcell            C310565-A Ni (minor) O:2737       { 0 }  (D45+2) [858E] - -  A 112 8  HvFd K8 V M4 V
 2638 Tehlang              D357301-7 Lo                      { -3 } (321+0) [7137] - -  - 204 15 HvFd G1 V M7 V
 2734 Nggander             A885316-C Ga Lo                   { 1 }  (B21-5) [1459] - K  - 323 11 HvFd F3 V
-2735 Lihrehm              B667742-A Ga Ag Ri                { 4 }  (86B+1) [5B86] - -  - 103 11 HvFd M5 V A1 V
+2735 Lihrehm              B667742-A Ga Ag Ri                { 4 }  (86B+1) [5B86] - -  - 103 11 HvFd A1 V M5 V
 2737 Zoru                 B233884-B Ph Na Po                { 2 }  (875+0) [CA7D] - -  - 103 11 HvFd K4 V
 2739 Zizas                C564421-9 Ni Pa                   { -1 } (C33+0) [539A] - -  - 204 17 HvFd F9 V
 2740 Bedend               D373856-7 Ph Pi                   { -2 } (676+2) [7666] - -  - 405 18 HvFd M3 V M4 V
@@ -606,7 +606,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 2836 Thustrax             C766521-5 Ga Ni Ag Pr             { -1 } (640+0) [7455] - -  - 502 7  HvFd M0 V
 2839 Kaladan              C000316-9 As Va Lo                { -1 } (821-1) [2279] - -  - 313 12 HvFd F0 V G2 V
 2840 Gexel                E67A525-7 Wa Ni                   { -3 } (B43+1) [7269] - -  - 913 12 HvFd K4 V
-2931 Wetsortreld          C84A89C-9 Wa Ph Pi                { 0 }  (47B-2) [5884] - -  - 700 12 NaXX M6 V M1 V
+2931 Wetsortreld          C84A89C-9 Wa Ph Pi                { 0 }  (47B-2) [5884] - -  - 700 12 NaXX M1 V M6 V
 2934 Hingka               B655954-B Ga Hi                   { 4 }  (48A+4) [DD48] - NS - 402 12 NaXX K0 V M2 V
 2935 Este                 D46658A-7 Ni Ag Pr                { -2 } (840+0) [8388] - -  - 203 13 NaXX A4 V
 2938 Eruwa                E72558A-7 Ni                      { -3 } (A41-1) [6233] - -  - 322 12 NaXX M1 V M6 V
@@ -623,7 +623,7 @@ Hex  Name                 UWP       Remarks                 {Ix}   (Ex)    [Cx] 
 3231 Lishyn               A859789-D                         { 2 }  (A65+2) [594C] - -  - 104 14 SELK G3 V M2 V
 3232 Din Rash             C6A4464-A Fl Ni O:3231            { 0 }  (933+2) [4448] - -  - 210 4  SELK G7 V K4 V
 3233 Odak-Kest            C59266A-8 He Ni O:3231            { -2 } (853-2) [443A] - -  - 822 12 SELK K1 V M3 V
-3235 Enge                 A556420-8 Ni Pa                   { -1 } (B30+1) [5365] - -  - 300 10 NaXX M3 V G6 V
+3235 Enge                 A556420-8 Ni Pa                   { -1 } (B30+1) [5365] - -  - 300 10 NaXX G6 V M3 V
 3236 Whastou              C251100-7 Lo Po                   { -2 } (801+1) [1168] - -  - 410 13 KrPr F3 V
 3238 Elysed               A8437C7-8 Pi Po                   { 0 }  (968+0) [8768] - -  - 102 12 KrPr M2 V
 3239 Jiouldpren           C330630-9 De Ni Na Po             { -1 } (655-2) [45A9] - -  - 400 9  NaXX F8 V M8 V


### PR DESCRIPTION
Clean up stellar data in M1105 Numbis.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is swapped into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).