### PR TITLE
Update Iwahfuah.tab

### DIFF
--- a/res/Sectors/M1105/Iwahfuah.tab
+++ b/res/Sectors/M1105/Iwahfuah.tab
@@ -109,7 +109,7 @@ Iwah	J	0927	Owis	X679169-5		Lo Fo O:0924	R	110	AsTv	M0 V M1 V	{ -3 }	(300-2)	[21
 Iwah	N	0938	Khaisyo	EAB5347-8		Fl Lo		812	AsMw	M0 V	{ -3 }	(820-3)	[3158]		10	-48
 Iwah	B	1001	Seauahe'	A588454-E		Ni Pa		200	AsVc	F0 V M8 V	{ 1 }	(634-1)	[253C]		11	-72
 Iwah	B	1002	Ouhwya	D5816AA-6		Ni Ri Da	A	202	AsTv	K0 V	{ -2 }	(852+1)	[8478]		6	80
-Iwah	B	1007	Yahwouh	B5A5883-B		Fl Ph		723	AsT2	M2 V M2 V	{ 2 }	(F7C-1)	[5A28]		15	-1260
+Iwah	B	1007	Ihoio	B5A5883-B		Fl Ph		723	AsT2	M2 V M2 V	{ 2 }	(F7C-1)	[5A28]		15	-1260
 Iwah	F	1013	Oasi	E55448B-5		Ni Pa Chir7		505	AsVc	G1 IV	{ -3 }	(631-1)	[6177]		15	-18
 Iwah	F	1015	New Sydney	C663683-8		Ni Ri Huma6		803	AsTz	K4 V	{ -1 }	(B53-4)	[3525]		12	-660
 Iwah	J	1021	Oiwereahuw	C587597-9		Ag Ni Pr		104	AsT6	K0 V	{ 0 }	(B44+1)	[5559]		13	176


### PR DESCRIPTION
Solomani and Aslan mentions a world in Iwahfuah named lhoio, a Syoisuis clan dominated world. Starport B, Medium Size, Exotic Atm, Wet Hyd, Mod Pop, Low Law, High Stellar." I didn't find a match in the current data, but Yahwouh (Iwahfuah 1007 B5A5883-B), allegiance AsT3 Is a remarkably close match. Recommend renaming the "Yahwouh" system "lhoio"