### PR TITLE
Update waroatah.sec

### DIFF
--- a/res/Sectors/M1105/waroatah.sec
+++ b/res/Sectors/M1105/waroatah.sec
@@ -476,7 +476,7 @@ Asealrela'    0236 E110477-8    Ni                 914 As
 Khtir         0237 E9E78A8-2    Fl                 314 As
 Kteilraoeaar  0238 E327353-6    Lo Ni              510 As
 Kouarearleh   0239 E59679B-4    Ag                 800 As
-Ouh           0333 A567754-D    Ag Ri              314 As
+Ouh           0333 A567884-D  N Ag Ri              914 As
 Ioakhuikha    0335 A787524-A    Ag Ni              604 As
 Iruawoisoil   0339 E566365-6    Lo Ni              504 As
 Huateeh       0532 B9B4334-9  N Fl Lo Ni           104 As


### PR DESCRIPTION
Ouh (Waroatahe 0333) established as clanworld of the Eakhtiyho/Hrasua clan in the Deep and the Dark