### PR TITLE
Fix stellar data in Underdeveloped Sectors, round 6

### DIFF
--- a/res/Sectors/M1105/Angfutsag.sec
+++ b/res/Sectors/M1105/Angfutsag.sec
@@ -51,7 +51,7 @@ Angfutsag
 .             1206 X666000-0    Ba Lo Ni           012 --     F6V 
 .             1706 X405000-0    Ba Ic Lo Ni Va     002 --     M7V 
 .             2206 X330000-0    Ba De Lo Ni Po     003 --     K0V M4V
-.             3206 X7B3000-0    Ba Fl Lo Ni        006 --     M2V K2V
+.             3206 X7B3000-0    Ba Fl Lo Ni        006 --     K2V M2V
 .             0907 X200000-0    Ba Lo Ni Va        014 --     F9V M3V
 .             1007 X100000-0    Ba Lo Ni Va        001 --     M8V 
 .             1207 X546000-0    Ba Lo Ni           000 --     F0V M8V
@@ -95,7 +95,7 @@ Angfutsag
 .             0612 X130000-0    Ba De Lo Ni Po     000 --     F0V 
 .             0812 X543000-0    Ba Lo Ni Po        002 --     F4V 
 .             1012 X362000-0    Ba Lo Ni           000 --     F0V 
-.             1212 X130000-0    Ba De Lo Ni Po     029 --     M7V M3V G9V
+.             1212 X130000-0    Ba De Lo Ni Po     029 --     G9V M3V M7V
 .             1412 X241000-0    Ba Lo Ni Po        022 --     F2V 
 .             1512 X364000-0    Ba Lo Ni           001 --     F7V 
 .             1912 X633000-0    Ba Lo Ni Po        003 --     F6V 
@@ -174,7 +174,7 @@ Angfutsag
 .             1221 X9B7000-0    Ba Fl Lo Ni        022 --     M4V 
 .             1721 X97A000-0    Ba Lo Ni Wa        005 --     F5V 
 .             2821 X535000-0    Ba Lo Ni           001 --     M2III M2V
-.             3021 X410000-0    Ba Lo Ni           006 --     M8V M7V
+.             3021 X410000-0    Ba Lo Ni           006 --     M7V M8V
 .             3221 X6A0000-0    Ba De Lo Ni        001 --     M8V 
 .             0122 X110000-0    Ba Lo Ni           014 --     A1V 
 .             0622 X444000-0    Ba Lo Ni           004 --     F5V 
@@ -183,7 +183,7 @@ Angfutsag
 .             3022 X300000-0    Ba Lo Ni Va        003 --     F0V 
 .             0123 X231000-0    Ba Lo Ni Po        002 --     M1V 
 .             0223 X765000-0    Ba Lo Ni           003 --     F9V 
-.             1123 X110000-0    Ba Lo Ni           002 --     M3V M0V
+.             1123 X110000-0    Ba Lo Ni           002 --     M0V M3V
 .             1223 X864000-0    Ba Lo Ni           024 --     K1V 
 .             1423 X552000-0    Ba Lo Ni Po        004 --     G5V 
 .             2123 X484000-0    Ba Lo Ni           021 --     G3V M7V
@@ -248,14 +248,14 @@ Angfutsag
 .             3029 X466000-0    Ba Lo Ni           004 --     F5V M0V
 .             3229 X447000-0    Ba Lo Ni           000 --     F6V 
 .             0430 X776000-0    Ba Lo Ni           003 --     F9V 
-.             2130 X658000-0    Ba Lo Ni           008 --     F8V M3V F3V M3V
+.             2130 X658000-0    Ba Lo Ni           008 --     F3V M3V F8V M3V
 .             2730 X666000-0    Ba Lo Ni           021 --     F4V 
 .             2830 X75A000-0    Ba Lo Ni Wa        003 --     F7V M7V 
 .             2930 X576000-0    Ba Lo Ni           003 --     G3V 
 .             3030 X000000-0    As Ba Lo Ni        017 --     F5III M4V 
 .             1031 X361000-0    Ba Lo Ni           012 --     G9V 
 .             1531 X655000-0    Ba Lo Ni           007 --     F2V M2V
-.             1931 X768000-0    Ba Lo Ni           00A --     F8V M7V F3V
+.             1931 X768000-0    Ba Lo Ni           00A --     F3V M7V F8V
 .             2331 X241000-0    Ba Lo Ni Po        004 --     G4V 
 .             2431 X454000-0    Ba Lo Ni           014 --     F3V 
 .             2631 X666000-0    Ba Lo Ni           000 --     G5V 
@@ -287,7 +287,7 @@ Angfutsag
 .             3134 X443000-0    Ba Lo Ni Po        017 --     F6V M2V
 Kfoersarsaz   0335 B884001-9    Lo Ni              535 Va     F4V M8V
 .             1435 X220000-0    Ba De Lo Ni Po     000 --     K2V 
-.             1935 X544000-0    Ba Lo Ni           015 --     K4V F6V M0V
+.             1935 X544000-0    Ba Lo Ni           015 --     F6V K4V M0V
 .             2435 X997000-0    Ba Lo Ni           020 --     F2V 
 .             2535 X678000-0    Ba Lo Ni           023 --     F9V M3V
 .             2835 X120000-0    Ba De Lo Ni Po     002 --     F5II 

--- a/res/Sectors/M1105/Dfotseth.sec
+++ b/res/Sectors/M1105/Dfotseth.sec
@@ -16,7 +16,7 @@ Dfotseth
 .             3002 X120000-0    Ba De Lo Ni Po     000 --     M6V 
 .             0303 X140000-0    Ba De Lo Ni Po     000 --     F2V 
 .             2703 X699000-0    Ba Lo Ni           002 --     M7V 
-.             0404 X532000-0    Ba Lo Ni Po        027 --     K1II G2V 
+.             0404 X532000-0    Ba Lo Ni Po        027 --     K1II G2V
 .             0704 X576000-0    Ba Lo Ni           014 --     F5V M6V
 .             2104 X95A000-0    Ba Lo Ni Wa        010 --     F3V M4V
 .             0605 X99A000-0    Ba Lo Ni Wa        003 --     F9V 
@@ -94,7 +94,7 @@ Dfotseth
 .             1118 X224000-0    Ba Lo Ni           000 --     M2V 
 .             1818 X100000-0    Ba Lo Ni Va        000 --     M1V M4V 
 .             1918 X574000-0    Ba Lo Ni           011 --     F1V 
-.             2618 X763000-0    Ba Lo Ni           002 --     K8V G1V 
+.             2618 X763000-0    Ba Lo Ni           002 --     G1V K8V
 .             3018 X241000-0    Ba Lo Ni Po        014 --     F0V 
 .             0519 X421000-0    Ba Lo Ni Po        000 --     M3V 
 .             0719 X526000-0    Ba Lo Ni           003 --     M6V 
@@ -130,7 +130,7 @@ Dfotseth
 .             0924 X242000-0    Ba Lo Ni Po        002 --     F8V 
 .             1224 X536000-0    Ba Lo Ni           002 --     K4V M3V
 .             1624 X897000-0    Ba Lo Ni           020 --     F0V M4V
-.             2224 X343000-0    Ba Lo Ni Po        004 --     F7V F5V 
+.             2224 X343000-0    Ba Lo Ni Po        004 --     F5V F7V
 .             3224 X565000-0    Ba Lo Ni           020 --     F4V 
 .             0425 X8B3000-0    Ba Fl Lo Ni        005 --     M8V 
 .             0625 X202000-0    Ba Ic Lo Ni Va     026 --     M1V M7V
@@ -139,10 +139,10 @@ Dfotseth
 .             1425 X774000-0    Ba Lo Ni           015 --     F3V M8V
 .             1525 X000000-0    As Ba Lo Ni        006 --     M1V M2V 
 .             1925 X689000-0    Ba Lo Ni           006 --     F3V M1V F5V M7V
-.             2025 X567000-0    Ba Lo Ni           007 --     G1V G0V 
+.             2025 X567000-0    Ba Lo Ni           007 --     G0V G1V
 .             2125 X556000-0    Ba Lo Ni           005 --     F5V M1V
 .             2325 X9B6000-0    Ba Fl Lo Ni        005 --     M4V M5V
-.             2425 X562000-0    Ba Lo Ni           003 --     F5V F2V M2V
+.             2425 X562000-0    Ba Lo Ni           003 --     F2V F5V M2V
 .             2825 X649000-0    Ba Lo Ni           020 --     F4V 
 .             2925 X322000-0    Ba Lo Ni Po        004 --     F6V 
 .             3025 X97A000-0    Ba Lo Ni Wa        002 --     F3V 


### PR DESCRIPTION
@inexorabletash asked me to, when submitting bulk sector-data fixen, break up said fixen PRs into different classes of sectors, so here goes with squaring up the stellar data in Undeveloped Sectors.
I'm not making any deliberate attempt to canonicalise star sizes as per T5.10 Book 3 p 28.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is _swapped_ into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).

Doesn't seem to be any stragglers from previous rounds, so it looks like this PR will finish up the base square-ups in the Underdeveloped Sectors.