### PR TITLE
Fix stellar data in CORE Sectors, round 1

### DIFF
--- a/res/Sectors/M1105/esai-yo.sec
+++ b/res/Sectors/M1105/esai-yo.sec
@@ -33,18 +33,18 @@ P: Aeie
 Teahyoei           0132 B473520-7 N Ni                602 As F1 V
 Eiiykh             0133 D301444-4   Ic Ni Va          311 As M6 V
 Syulrelrehei       0135 C546742-3   Ag                114 As F8 V
-Oi                 0137 D400997-9 S Hi Na Va          805 As F1 V M9 D
+Oi                 0137 D400997-9 S Hi Na Va          805 As F1 V M9 V
 Ahyelekh           0138 D445000-4   Ba Lo Ni          915 As F3 V
 0226               0226 X646003-0   Lo Ni             012 Na F8 V
 Elrosa             0237 D689102-5 S Lo Ni             404 As F0 V
 Uhea'iai           0238 D442776-5 S Po                201 As K5 V
-Khasaheiktew       0239 D473442-8 S Ni                100 As F6 V M3 D M7 D
-Yalukhye           0330 C644227-4 S Lo Ni             410 As F7 V M2 D
+Khasaheiktew       0239 D473442-8 S Ni                100 As F6 V M3 V M7 V
+Yalukhye           0330 C644227-4 S Lo Ni             410 As F7 V M2 V
 Ohteaea            0332 EAA8866-6   Fl                804 As F6 V
 Aktalr             0334 C233346-8 S Lo Ni Po          204 As M7 IV
 Laoe'              0337 D657546-7 S Ag Ni             504 As F1 V
 Hkaihal            0338 D575224-4   Lo Ni             624 As G1 V
-Olrao              0339 D548669-1 S Ag Ni             713 As F0 V M2 D
+Olrao              0339 D548669-1 S Ag Ni             713 As F0 V M2 V
 Eihea              0340 D120549-A   De Ni Po          923 As K4 V
 Khyasoireeye       0438 E264764-2   Ag Ri             611 As F2 V
 Sealeyoweh         0532 E410533-6   Ni                924 As K3 V
@@ -57,72 +57,72 @@ Yakhea             0640 E373A8C-8   Hi In             410 As F2 V
 Tlyo               0727 D8989A6-3 S Hi In             804 As G1 V
 Aieae              0730 C681555-9   Ni                504 As F1 V
 Lyohew             0735 E652100-5   Lo Ni Po          403 As F7 V
-Ui                 0737 E511420-8   Ic Ni             503 As G5 V M1 D
+Ui                 0737 E511420-8   Ic Ni             503 As G5 V M1 V
 Eouftaeafaih       0739 E759646-7   Ni                110 As F3 V
 Elas               0840 E88A105-A   Lo Ni Wa          504 As G8 V
-0916               0916 X676000-3   Ba Lo Ni          003 Na K4 V M0 D M1 D
+0916               0916 X676000-3   Ba Lo Ni          003 Na K4 V M0 V M1 V
 Wa'ye'e            0932 A656103-B   Lo Ni             623 As F9 V
 Iy'ehoireri        0934 A54887B-A                     803 As F1 V
 Iy'a               0935 B260135-7   De Lo Ni          513 As G8 V
-Khiykal            0940 C54467A-5 S Ag Ni             200 As F7 V M0 D
+Khiykal            0940 C54467A-5 S Ag Ni             200 As F7 V M0 V
 Ahfewaeatas        1031 A734435-E 2 Ni                503 As G6 V
-Tlyesos            1032 A261554-E   Ni                903 As F4 V M5 D
+Tlyesos            1032 A261554-E   Ni                903 As F4 V M5 V
 Ilrai              1035 BAA48A8-B   Fl                703 As F0 V
 Wariwasorl         1129 C375357-8 S Lo Ni             313 As F5 V
 Aaoh               1131 A7C1768-9 2 Fl                414 As M9 II M0 V
 Tloireei           1134 A685547-8   Ag Ni             723 As M4 V
-Tuitreaaaih        1137 A584665-9 N Ag Ni Ri          204 As F5 V M8 D
+Tuitreaaaih        1137 A584665-9 N Ag Ni Ri          204 As F5 V M8 V
 Houhahayolar       1139 C00089A-9 S As Na             800 As F1 V
-Ftiykhtuiao        1234 E100853-7   Na Va             914 As F5 V M4 D
-Ka                 1236 E685633-2   Ag Ni             313 As F9 V M3 D
+Ftiykhtuiao        1234 E100853-7   Na Va             914 As F5 V M4 V
+Ka                 1236 E685633-2   Ag Ni             313 As F9 V M3 V
 Yawahte            1237 E659A77-B   Hi                405 As G2 V
 Tarluaea           1240 C100455-C   Ni Va             514 As M4 V
 Hreahtoa           1333 A524323-E   Lo Ni             210 As K0 V
 Eweh               1336 C96A112-B   Lo Ni Wa          622 As G2 V
-Foaatlois          1338 C865330-5   Lo Ni             113 As F5 V M7 D
-Koaao              1339 C000561-C S As Ni             714 As K4 V M8 V M6 D
-Feilr              1340 C120122-9 S De Lo Ni Po       614 As M4 V M1 D
-Railr              1433 C86AACA-C   Hi Wa             505 As F4 V M7 D
+Foaatlois          1338 C865330-5   Lo Ni             113 As F5 V M7 V
+Koaao              1339 C000561-C S As Ni             714 As K4 V M8 V M6 V
+Feilr              1340 C120122-9 S De Lo Ni Po       614 As M4 V M1 V
+Railr              1433 C86AACA-C   Hi Wa             505 As F4 V M7 V
 Hweiuihiyrla       1528 A581878-B   Ri                904 As F0 V
-Ouyer              1532 A448657-C N Ag Ni             200 As F1 V M7 D
-Kheiftu            1533 B686356-B N Lo Ni             212 As F3 V M6 D
+Ouyer              1532 A448657-C N Ag Ni             200 As F1 V M7 V
+Kheiftu            1533 B686356-B N Lo Ni             212 As F3 V M6 V
 Erouliysoiei       1536 C726787-4                     425 As F4 V M1 V
 Aiahtoa'yu         1538 C89A664-A   Ni Wa             213 As F3 V
 Siy                1633 B657689-6 S Ag Ni             103 As F2 V
-Wiheieaseaw        1634 A440764-C N De Po             410 As F1 V M0 D
+Wiheieaseaw        1634 A440764-C N De Po             410 As F1 V M0 V
 Eisi'aresi         1638 C7B4332-8   Fl Lo Ni          322 As F1 IV
-Lea                1726 C573999-8   Hi In             803 As G1 V M7 D
+Lea                1726 C573999-8   Hi In             803 As G1 V M7 V
 E'or               1731 E62489B-6                     112 As F0 V
-Taheihoihei        1733 E798889-3                     805 As F8 V M6 D
+Taheihoihei        1733 E798889-3                     805 As F8 V M6 V
 Aryewarlua         1829 D734753-8 S                   903 As M2 IV
 Kheaifeseaya       1832 C3438BC-5   Po                924 As K4 V
 Ehtaoh             1833 E87A444-9   Ni Wa             713 As F7 V
-Teleleikea         1837 A7A5230-D   Fl Lo Ni          302 As M9 V M5 D
-Hkaohti            1839 A584459-B   Ni                905 As F8 V M2 D
-Aulrelreir         1840 B5979DA-7 N Hi In             604 As F8 V M2 D
-Haaoa              1930 C89A99E-C   Hi In Wa          805 As G8 V M1 D
+Teleleikea         1837 A7A5230-D   Fl Lo Ni          302 As M9 V M5 V
+Hkaohti            1839 A584459-B   Ni                905 As F8 V M2 V
+Aulrelreir         1840 B5979DA-7 N Hi In             604 As F8 V M2 V
+Haaoa              1930 C89A99E-C   Hi In Wa          805 As G8 V M1 V
 Aohkeilyur         1936 E424886-4                     103 As F3 V
 Etui               1939 B310599-D N Ni                301 As M7 V
 Yuhya'             1940 B3537BB-8   Po                202 As F5 V
-Wiyhkaoea          2028 E557203-5   Lo Ni             500 As F9 V M7 D
-Yoreeah            2029 C658203-6   Lo Ni             502 As F8 V M6 D
-Aeiroaeaiykh       2035 E455552-7   Ag Ni             900 As F8 V M0 D
+Wiyhkaoea          2028 E557203-5   Lo Ni             500 As F9 V M7 V
+Yoreeah            2029 C658203-6   Lo Ni             502 As F8 V M6 V
+Aeiroaeaiykh       2035 E455552-7   Ag Ni             900 As F8 V M0 V
 Yahaleyeaw         2126 C411440-A S Ic Ni             100 As M1 V
 Oraoafe            2127 C444773-6   Ag                202 As F8 V
 Liyolailou         2131 E8A066B-2   De Ni             424 As M9 V
-Hryuwoukhei        2132 E310337-6   Lo Ni             322 As G9 V M9 D
-Eaoar              2134 E878AAA-9   Hi In             504 As F6 V M8 D
+Hryuwoukhei        2132 E310337-6   Lo Ni             322 As G9 V M9 V
+Eaoar              2134 E878AAA-9   Hi In             504 As F6 V M8 V
 Ei'eilreas         2137 C878796-5 S Ag                103 As F4 V
 Eil                2140 B425488-C N Ni                120 As M1 V
 Ouleie             2222 E9D9410-4   Fl Ni             203 As M0 V
 Yafirih            2226 C558001-4 S Lo Ni             903 As F4 V
 Eaeae              2228 E526525-3   Ni                500 As K4 III M6 V
 Ftiyailyasei       2229 E44296A-7   Hi In Po          605 As F6 V
-Heiei              2235 E482884-2   Ri                804 As F9 V M4 D
-Akhtahtosa'        2236 C94A463-B S Ni Wa             914 As K3 V M4 D
+Heiei              2235 E482884-2   Ri                804 As F9 V M4 V
+Akhtahtosa'        2236 C94A463-B S Ni Wa             914 As K3 V M4 V
 Aiyhwi             2239 B210002-A   Lo Ni             700 As M3 V
 Tautoiyawa         2324 D9A4746-5 S Fl                103 As M5 V
-Ehlel              2325 E100644-8   Na Ni Va          800 As M5 V M2 D
+Ehlel              2325 E100644-8   Na Ni Va          800 As M5 V M2 V
 Asaweasea          2327 C37666A-6   Ag Ni             720 As F0 V
 Orokhehyakh        2329 E000740-9   As Na             102 As M8 V
 Iyhao              2332 E347664-7   Ag Ni             202 As F2 V
@@ -130,73 +130,73 @@ Hihesai            2337 C8A3ACA-8   Fl Hi             200 As F5 V
 Kyohfiywaue        2340 B2479DG-A N Hi In             603 As F7 V
 Ftakaileitai       2429 E130300-8   De Lo Ni Po       903 As M0 V
 Yu                 2435 E684431-3   Ni                120 As F0 V
-Feftea             2436 E110764-7   Na                904 As M8 V M8 D
+Feftea             2436 E110764-7   Na                904 As M8 V M8 V
 Oueaaoye           2439 C9E2685-5 S Fl Ni             800 As M1 V
 Earlerlarorl       2440 C9A4357-9 S Fl Lo Ni          702 As K8 V M3 V
-Laosihea           2522 C420A8A-A S De Hi In Na Po    410 As G9 V M8 D
+Laosihea           2522 C420A8A-A S De Hi In Na Po    410 As G9 V M8 V
 Ita'ahea           2523 C448645-7 S Ag Ni             325 As F3 V
 Tryewaw            2527 B546304-B N Lo Ni             211 As K3 V
 Iyatehi            2528 D96A301-A S Lo Ni Wa          913 As F0 V
 Rawiy              2529 D451634-3 S Ni Po             814 As F8 V
 Fetyaye            2533 A356787-A N Ag                801 As K9 V
-Aoloufaya          2534 A273465-E   Ni                903 As F5 V M6 D M9 D
-Ayawuiiyha         2623 B585344-A   Lo Ni             210 As G5 V M7 D M1 D
+Aoloufaya          2534 A273465-E   Ni                903 As F5 V M6 V M9 V
+Ayawuiiyha         2623 B585344-A   Lo Ni             210 As G5 V M7 V M1 V
 Styaea             2624 B546688-6 2 Ag Ni             100 As F5 V
 Eisalealiyl        2630 C200879-5   Na Va             824 As F6 V
 Oelawaal           2631 B4517BG-7   Po                905 As F9 V
 Eaheasakhao'       2632 B692267-B   Lo Ni             203 As F0 V
-Aleei              2723 C595311-4   Lo Ni             203 As G5 V M7 D
+Aleei              2723 C595311-4   Lo Ni             203 As G5 V M7 V
 Eahas              2725 C344102-A   Lo Ni             502 As G9 V
 Ayewyoh            2732 A200799-C N Na Va             102 As G4 V
 Iy                 2740 A211325-F S Ic Lo Ni          802 As K2 IV
-Uiseawo            2812 C684ACH-C   Hi                415 As F2 V M2 D
+Uiseawo            2812 C684ACH-C   Hi                415 As F2 V M2 V
 Yaeahiyha          2818 D865462-5   Ni                602 As F0 V
-Ao'awyu            2819 C584332-4   Lo Ni             313 As F5 V M9 D
+Ao'awyu            2819 C584332-4   Lo Ni             313 As F5 V M9 V
 Uaui               2822 C445644-6   Ag Ni             110 As G8 V
 Yalreal            2829 C44798D-6   Hi In             313 As F5 V
 Elahuirl           2834 C240243-8   De Lo Ni Po       312 As G7 V
-Ktikh              2835 C322464-6 S Ni Po             203 As M6 V M3 D
-Hluaasaw           2917 B377545-9 2 Ag Ni             702 As F4 V M6 D
-Huiehur            2918 C764686-3   Ag Ni Ri          124 As F9 V M3 D M4 D
-Eaoieaail          2925 C626977-9 S Hi In             304 As F6 V M1 D
+Ktikh              2835 C322464-6 S Ni Po             203 As M6 V M3 V
+Hluaasaw           2917 B377545-9 2 Ag Ni             702 As F4 V M6 V
+Huiehur            2918 C764686-3   Ag Ni Ri          124 As F9 V M3 V M4 V
+Eaoieaail          2925 C626977-9 S Hi In             304 As F6 V M1 V
 Itletye            2927 CAA6320-A   Fl Lo Ni          101 As M5 III
 Ealrawea           2929 C486100-A   Lo Ni             403 As F3 V
-Lauhiahakh         2932 A451563-E   Ni Po             415 As F5 V M2 D
+Lauhiahakh         2932 A451563-E   Ni Po             415 As F5 V M2 V
 Uas                2937 C210577-7 S Ni                400 As F7 II
 Wuih               2938 A532496-C   Ni Po             103 As K2 V
-Eihoikhahau        2940 A6399EF-C N Hi In             604 As F7 V M7 D
+Eihoikhahau        2940 A6399EF-C N Hi In             604 As F7 V M7 V
 Iea                3012 C524645-7 S Ni                302 As F4 III
-Alasiwekh          3013 DA8A635-6   Ni Wa             123 As G9 V M3 D
+Alasiwekh          3013 DA8A635-6   Ni Wa             123 As G9 V M3 V
 Oiyo               3015 C569313-6 S Lo Ni             405 As F4 V
-Oh                 3020 B975898-A                     805 As K7 V M5 D
-Tyeuaihiya         3023 C794310-6   Lo Ni             102 As F8 V M7 D
+Oh                 3020 B975898-A                     805 As K7 V M5 V
+Tyeuaihiya         3023 C794310-6   Lo Ni             102 As F8 V M7 V
 Oheatlaoa          3024 C763644-3 S Ni Ri             224 As F8 V
 Eahtoalrei         3029 C342434-6   Ni Po             513 As G9 V
 Hkyekeah           3030 C52A540-7   Ni Wa             705 As M2 V
 Khteayelei         3031 A76577A-B N Ag Ri             120 As F4 V
 Eilra'iyhokh       3032 B424033-7   Lo Ni             702 As F9 IV
-Ahrulaya           3034 A4845A8-E N Ag Ni             302 As G2 V M6 D
+Ahrulaya           3034 A4845A8-E N Ag Ni             302 As G2 V M6 V
 Aiyalao            3111 D236410-7 S Ni                603 As M6 V
 Arlew              3116 D210855-6 S Na                904 As G4 V
-Htoirlawyeo        3117 D243523-7 S Ni Po             805 As F6 V M7 D
-Taiktaye           3118 D200855-4   Na Va             703 As G7 V M9 D
+Htoirlawyeo        3117 D243523-7 S Ni Po             805 As F6 V M7 V
+Taiktaye           3118 D200855-4   Na Va             703 As G7 V M9 V
 Ktuiktiys          3120 B9A6566-A N Fl Ni             904 As K8 V
 Kheyaao            3125 C654101-6   Lo Ni             404 As F3 V
 Alraweoih          3126 C688423-9 S Ni                524 As F4 V
 Aiiywerlo          3131 B639474-A N Ni                202 As K2 V
-Hteaheayukh        3132 B6B17A6-B S Fl                110 As M0 V M9 D
+Hteaheayukh        3132 B6B17A6-B S Fl                110 As M0 V M9 V
 Syawah             3135 B696463-7   Ni                925 As G7 V
-Eakhea             3139 A774554-B   Ag Ni             303 As K0 V M3 D
+Eakhea             3139 A774554-B   Ag Ni             303 As K0 V M3 V
 Htouiheiftya       3211 D588579-3 S Ag Ni             813 As F9 V
 Teiryol            3212 C767765-3 S Ag Ri             414 As F8 V
 Ureikheilr         3214 D345A75-7   Hi In             414 As F3 V
-Kuiauekeah         3215 D482631-6 S Ni                304 As F4 V M2 D
+Kuiauekeah         3215 D482631-6 S Ni                304 As F4 V M2 V
 Eiyerlilea         3216 D130634-9   De Na Ni Po       100 As M7 II
 Eyarlo             3221 C100300-B S Lo Ni Va          201 As G9 V
-Elreaouahlea       3223 B582456-7 2 Ni                420 As F0 V M6 D
+Elreaouahlea       3223 B582456-7 2 Ni                420 As F0 V M6 V
 Alrailyei          3225 C667751-6   Ag Ri             603 As F8 V
 Hrerl              3231 B668253-7   Lo Ni             212 As F2 V
-Aoleao             3233 A87A778-B N Wa                800 As F8 V M6 D
-Talaaaoho          3234 A5667CA-8 N Ag                200 As G3 V M7 D M1 D
-Aiyea              3237 A6655AB-B S Ag Ni             535 As F9 V M3 D
+Aoleao             3233 A87A778-B N Wa                800 As F8 V M6 V
+Talaaaoho          3234 A5667CA-8 N Ag                200 As G3 V M7 V M1 V
+Aiyea              3237 A6655AB-B S Ag Ni             535 As F9 V M3 V
 Khtoe              3238 A747222-8 N Lo Ni             402 As F7 V

--- a/res/Sectors/M1105/ftaoiyekyu.sec
+++ b/res/Sectors/M1105/ftaoiyekyu.sec
@@ -31,34 +31,34 @@ P: Aeaiy
  64-80: Stellar Data
 
 0240               0240 X310020-1   Lo Ni             012 Na G9 V M6 V
-0339               0339 X447033-0   Lo Ni             024 Na F9 V M4 D
-0513               0513 XA9A000-5   Ba Lo Ni Wa       000 Na F8 V M1 D
-0537               0537 X555032-0   Lo Ni             024 Na M2 V M6 D M9 D
-0639               0639 X5A0020-0   De Lo Ni          003 Na G2 V M5 D
+0339               0339 X447033-0   Lo Ni             024 Na F9 V M4 V
+0513               0513 XA9A000-5   Ba Lo Ni Wa       000 Na F8 V M1 V
+0537               0537 X555032-0   Lo Ni             024 Na M2 V M6 V M9 V
+0639               0639 X5A0020-0   De Lo Ni          003 Na G2 V M5 V
 0708               0708 XA6A023-0   Lo Ni Wa          003 Na F5 V
 0709               0709 X9B2020-0   Fl Lo Ni          000 Na K2 V
-0739               0739 X342023-2   Lo Ni Po          023 Na G2 V M2 D
-0816               0816 X656001-0   Lo Ni             000 Na F5 V M1 D
-0915               0915 X532002-1   Lo Ni Po          012 Na G3 V M3 D M0 D
+0739               0739 X342023-2   Lo Ni Po          023 Na G2 V M2 V
+0816               0816 X656001-0   Lo Ni             000 Na F5 V M1 V
+0915               0915 X532002-1   Lo Ni Po          012 Na G3 V M3 V M0 V
 1040               1040 X414000-0   Ba Ic Lo Ni       000 Na M9 V
-1139               1139 X420001-1   De Lo Ni Po       004 Na M9 V M4 D
+1139               1139 X420001-1   De Lo Ni Po       004 Na M9 V M4 V
 1238               1238 X625000-3   Ba Lo Ni          021 Na M8 V M1 V
-1401               1401 X783026-0   Lo Ni             003 Na G7 V M6 D
+1401               1401 X783026-0   Lo Ni             003 Na G7 V M6 V
 1427               1427 X510037-0   Lo Ni             002 Na M5 II
-1431               1431 X6B1034-0   Fl Lo Ni          010 Na K1 V M7 D
+1431               1431 X6B1034-0   Fl Lo Ni          010 Na K1 V M7 V
 Aeouhyeh           1439 D8968BC-2 S                   304 As F8 V
-Asaalreweh         1440 D798368-4 S Lo Ni             500 As G1 V M3 D
+Asaalreweh         1440 D798368-4 S Lo Ni             500 As G1 V M3 V
 1531               1531 X515035-3   Ic Lo Ni          004 Na M5 V
 1635               1635 X260005-0   De Lo Ni          012 Na F6 V
 Aauihlaita         1638 CA89751-8 S Ri                824 As G7 V
-Ealoaheili         1738 D340144-8 S De Lo Ni Po       110 As F4 V M7 D
-Ohiluiao           1739 C554574-6   Ag Ni             402 As G1 V M3 D
-1806               1806 X303021-4   Ic Lo Ni Va       004 Na K6 V M4 D
-1816               1816 X75A000-0   Ba Lo Ni Wa       003 Na K0 V M7 D
-Auawoi'eiwao       1839 C445686-7   Ag Ni             604 As F3 V M1 D
+Ealoaheili         1738 D340144-8 S De Lo Ni Po       110 As F4 V M7 V
+Ohiluiao           1739 C554574-6   Ag Ni             402 As G1 V M3 V
+1806               1806 X303021-4   Ic Lo Ni Va       004 Na K6 V M4 V
+1816               1816 X75A000-0   Ba Lo Ni Wa       003 Na K0 V M7 V
+Auawoi'eiwao       1839 C445686-7   Ag Ni             604 As F3 V M1 V
 2035               2035 X130002-1   De Lo Ni Po       023 Na G5 V
 Aiiaol             2037 A68A135-D   Lo Ni Wa          103 As G2 V
-Feikhti            2338 A160365-E N De Lo Ni          714 As F9 V M7 D
+Feikhti            2338 A160365-E N De Lo Ni          714 As F9 V M7 V
 Yearesau           2339 A324136-A 2 Lo Ni             214 As M3 V
 Ktalurlauail       2436 A9A4356-B S Fl Lo Ni          822 As M6 V
 Eatrekter          2437 A100575-G   Ni Va             413 As M5 V
@@ -68,20 +68,20 @@ Aheaeakhealr       2536 A529577-C S Ni                531 As K8 V
 Eah                2538 B794899-7 N                   422 As F9 V
 Uweal              2539 B747345-9   Lo Ni             604 As G7 V
 Ahioasaseaw        2540 B374343-A   Lo Ni             100 As F7 V
-Khterlelrui        2639 B866454-B   Ni                303 As G2 V M8 D
-Hresa              2736 B343558-C S Ni Po             710 As F7 V M0 D M2 D
+Khterlelrui        2639 B866454-B   Ni                303 As G2 V M8 V
+Hresa              2736 B343558-C S Ni Po             710 As F7 V M0 V M2 V
 2821               2821 XAA8031-3   Fl Lo Ni          002 Na M4 V M8 V
-3030               3030 X645000-2   Ba Lo Ni          012 Na F8 V M9 D
+3030               3030 X645000-2   Ba Lo Ni          012 Na F8 V M9 V
 3031               3031 X525000-2   Ba Lo Ni          014 Na F0 V
 3032               3032 X549001-0   Lo Ni             023 Na F6 V
 3033               3033 X440002-1   De Lo Ni Po       013 Na F2 V
 Eifyelreah         3035 B639677-B N Ni                210 As M6 IV
 3131               3131 X476003-0   Lo Ni             034 Na F5 V
-Hwawarluaeia       3134 B160220-C N De Lo Ni          603 As F7 V M3 D M0 D
+Hwawarluaeia       3134 B160220-C N De Lo Ni          603 As F7 V M3 V M0 V
 3227               3227 X100000-3   Ba Lo Ni Va       004 Na K5 V
 Oheieah            3231 B311666-7 N Ic Na Ni          903 As A7 V
 Ea'iyhfeakh        3232 B988555-C   Ag Ni             724 As F1 V
 Tloulaorloal       3233 B100440-E   Ni Va             304 As G0 IV
 Steawoihkoi        3234 B695677-8 N Ag Ni             902 As F6 V
 Tlausiylryu        3237 B9A1221-8   Fl Lo Ni          714 As K6 V
-Wiyhteaie          3240 B5566BE-A N Ag Ni             323 As G5 V M1 D
+Wiyhteaie          3240 B5566BE-A N Ag Ni             323 As G5 V M1 V


### PR DESCRIPTION
@inexorabletash asked me to, when submitting bulk sector-data fixen, break up said fixen PRs into different classes of sectors, so here goes with squaring up the stellar data in the sectors by CORE
I'm not making any deliberate attempt to canonicalise star sizes as per T5.10 Book 3 p 28.

In this PR, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).