### PR TITLE
Fix main-sequence dwarfs in Ktiin'gzat sector

### DIFF
--- a/res/Sectors/M1105/Ktiingzat.sec
+++ b/res/Sectors/M1105/Ktiingzat.sec
@@ -46,15 +46,15 @@ P: Inunugishshaa
 
 ****************************************************************************
 Angekhiirgasigag   0302 A343366-A   Lo Ni Po           602 Va A0 V
-Arsuthgvirr        0305 D000379-A   Lo Ni As           513 Va M5 D M5 V
+Arsuthgvirr        0305 D000379-A   Lo Ni As           513 Va M5 V D
 Maarsigudumuudu    0307 B478200-C   Lo Ni              102 Va K1 V
 Angerar            0310 BA9A202-9 G Lo Ni Wa           802 Va G4 V
 Kserre             0410 C456374-5 G Lo Ni              604 Va G6 V
 Magashi            0502 E120000-0   Ba Lo Ni Po De     013 -- K1 V
 Fhoztsoagvong      0510 C687677-7   C1 Ag Ni Tp        902 Va G6 V
 Oufudzersag        0601 A100676-B   Na Ni Va           302 Va M7 V
-Gaakershakaangu    0603 E9867BF-1   Ag Tp              602 Va F3 V F2 D
-Oloil              0609 A432574-D   Ni Po              100 Va G9 V G8 D M3 V
+Gaakershakaangu    0603 E9867BF-1   Ag Tp              602 Va F3 V D
+Oloil              0609 A432574-D   Ni Po              100 Va G9 V D M3 V
 Kenapii            0610 B355556-B G Ag Ni              700 Va K2 V M4 V
 U Muursa           0710 C7A2622-6 G Fl Ni              803 Va K5 V M8 V M2 V M1 V
 Tressavuessfux     0801 D63297A-5 C Dw Na Hi Po Rs     300 Dr F1 V
@@ -62,7 +62,7 @@ Aggiima            0804 D789489-7   Ni Tp              900 Va K8 V M4 V
 U Igha             0806 C583779-5                      100 Va M0 V
 Kisham             0808 E646000-0   Ba Lo Ni Tp        014 -- G7 V M6 V
 Rigeliigali        0810 D440541-7   Ni Po De           134 Va G9 V M9 V
-Shushir            0902 C300300-8   Lo Ni Va           613 Va G8 V M9 V M5 D
+Shushir            0902 C300300-8   Lo Ni Va           613 Va G8 V M9 V D
 Allas              1001 B100974-F G Na Hi In Va        702 Va M3 V
 Mim Narshaanzir    1004 C596465-6   Ni                 224 Va G7 V
 Iishiliigurankar   1006 B897442-6 G Ni Tp              325 Va K5 V M8 V
@@ -83,7 +83,7 @@ Lelimi             1604 B99437B-A G Lo Ni              600 Va M4 V M4 V
 Anushkudi          1606 E7A3000-0   Fl Ba Lo Ni        000 -- M5 V
 Dekgadur           1608 X764110-3   Lo Ni Tp St        404 Va G3 V
 Garikhanar         1609 B656300-A   C0 Lo Ni Tp        100 Va F9 V M5 V
-Odzgoin            1610 B66557B-A G C6 Ag Ni Tp        115 Va F4 V M7 V F9 D
+Odzgoin            1610 B66557B-A G C6 Ag Ni Tp        115 Va F4 V M7 V D
 Oa Oufuurrknu      1701 D798874-5 C C1 Tp              504 Va K2 V M1 V M3 V
 Pegegirirarshug    1705 A351202-B G Lo Ni Po           823 Va G5 V
 Muuzo              1708 D1207A6-8 C Na Po De           401 Va F2 V
@@ -94,7 +94,7 @@ Zigupa             1805 C796300-6 C Lo Ni Tp           811 Va G5 V K2 V
 Ki Ushuuguna       1901 B967544-8 G Ag Ni Tn           102 Va K1 V
 Keminkhuli         1909 C435522-B G Ni                 811 Va F2 V M7 V
 Idaelekoadheughz   1910 C56697B-7   Hi                 100 Va A2 V G4 V
-Fhuul              2002 D787876-1 C Tp                 701 Va F1 V A4 D M1 V M3 V
+Fhuul              2002 D787876-1 C Tp                 701 Va F1 V D M1 V M3 V
 Shiimimir          2010 C647547-6 G Ag Ni Tp           112 Va F3 V
 Mizukalash         2107 B410766-8 G Na                 134 Va K8 V
 Aas Khi            2202 B8A4247-C G Fl Lo Ni           501 Va M8 V
@@ -106,18 +106,18 @@ Irudirzukhed       2401 B440555-A   Ni Po De           300 Va K2 V
 Veti Egawi         2408 C000210-8 G Lo Ni As           214 VC F3 V K2 V
 Gariseki           2502 C65A79C-8   Wa                 814 Va K2 V M6 V
 Guu Gagigerulesh   2503 C657787-6 C Ag Tp              313 Va G4 V K7 V
-E Itilafinu        2505 B778367-B G Lo Ni Tp           500 VC G9 V G8 D
+E Itilafinu        2505 B778367-B G Lo Ni Tp           500 VC G9 V D
 Angaidzvranoigae   2506 CA81977-B C Hi                 910 VC M6 V
 Itanucel           2604 C998321-9 G D1 Lo Ni Tp        112 VC K6 V M0 V
 Susu Thotra        2605 B8A0859-8 G De                 300 VC M5 V
-Theas              2609 A565657-D G Ag Ni Ri           600 VC K2 V K6 D
+Theas              2609 A565657-D G Ag Ni Ri           600 VC K2 V D
 Surend             2610 C440586-A C Ni Po De           701 VC F3 V
 Taang              2704 C564677-4   Ag Ni              100 VC G9 V
 Luk Tzeung         2708 B764878-8   Tp St              914 VC G9 V
 End Egikerlo       2709 E567534-2 C Ag Ni              523 VC G4 V K1 V
 Cererra            2801 C534565-7   Ni                 100 Na K6 III
 Tanith Republic    2802 A410343-B   Lo Ni              801 Na M5 V M4 V M4 V
-Neredi             2804 B753524-A   C4 Ni Po Tp        423 VC K6 V A2 D
+Neredi             2804 B753524-A   C4 Ni Po Tp        423 VC K6 V D
 Deferrane          2806 A579787-8                      702 VC G6 V M1 V
 Rolu Rigayite      2809 C664696-8   D1 Ag Ni Ri Tp     613 VC K8 V M0 V
 Etsigemnerrgua     2810 EA77879-6 C                    524 VC G0 V M4 V
@@ -131,7 +131,7 @@ Dedothufthi        3007 E6A1444-8   Fl Ni              613 VC M3 V
 Hegadetid          3008 C20047A-A   Ni Va              200 VC M5 II M5 V
 Oerlkeghaksgvai    3105 A000573-E G Ni As              702 Va K0 V M2 V
 Ulksongorghu       3107 B401463-B G Ni Va Ic           800 Va K1 V
-Capstan            3202 C759137-A   Lo Ni Tp           610 Na G4 V A0 D
+Capstan            3202 C759137-A   Lo Ni Tp           610 Na G4 V D
 Bessel             3203 B566776-A   Ag Ri              313 Na K5 V
 Shusagugii         3206 A573750-D G C3                 302 Va K0 V M6 V
 I Shar             3209 E463127-7   Lo Ni              321 Va A1 V
@@ -151,7 +151,7 @@ Mukhira            0911 C764211-5   Lo Ni Tp St        800 Va F8 V M5 V
 Diga Uugkamakhi    1011 C450312-8   Lo Ni Po De        302 Va K1 V
 Arure              1017 X200457-7   Ni Va              103 Va M1 V M7 V
 Giguursambelar     1020 E400745-7   Na Va              113 Va M2 V M8 V
-Khu A Ki Iish      1113 B130440-9 G Ni Po De           514 Va K3 V K4 D
+Khu A Ki Iish      1113 B130440-9 G Ni Po De           514 Va K3 V D
 Ibisdiisadar       1119 B677422-6 G Ni Tp              102 Va G9 V M1 V
 Gakkimanin         1120 A663338-A   Lo Ni Tp           101 Va K6 V
 Gishzaasush        1211 B446757-9   Ag                 800 Va M0 V
@@ -159,8 +159,8 @@ Kurusukiguluum     1319 B784987-C   Hi Tp St           914 Va F1 V
 Akamlagepmishi     1320 D989499-6 G Ni Tp              714 Va K9 V K4 V
 Agurkurduda        1412 D465669-5 C Ag Ni Ri           100 Va K7 V
 Uu Efhenmmadh      1511 E465577-4   Ag Ni              402 Va G4 V
-Ruguulagesh        1517 A454865-8 G                    924 Va K0 V K0 D
-Akhiishbe          1520 D350526-5 G Ni Po De           700 Va K4 V A4 D
+Ruguulagesh        1517 A454865-8 G                    924 Va K0 V D
+Akhiishbe          1520 D350526-5 G Ni Po De           700 Va K4 V D
 Uugekir            1611 E697000-0   Ba Lo Ni Tp        000 -- M0 V
 Khikanru           1613 D7C5489-8 C Fl Ni              703 Va M0 V
 Uth Orthmoing      1618 C100974-D C Na Hi In Va        200 Va K3 V M2 V
@@ -175,14 +175,14 @@ Adurshe            1818 C57768C-5   Ag Ni              203 Va K4 V
 Sus Erladgegiida   1912 E534000-0   Ba Lo Ni           000 -- G9 V M2 V K2 V
 Zerrton            1913 C6A297A-A H Fl Hi              803 Va K7 V M8 V
 Liirigkhupeshu     1914 E685422-3 C Ni Tp              502 Va K2 V M4 V
-Shuganikaka        1915 E575000-0   Ba Lo Ni           010 -- G6 V G8 D
+Shuganikaka        1915 E575000-0   Ba Lo Ni           010 -- G6 V D
 Argalerga          1916 B766879-A G D3 Ri Tn           523 Va F0 V
 Isuruga            2016 X9C9000-0   Fl Ba Lo Ni        003 -- M5 III M8 V
 Ghurrilengofur     2019 C635579-7   Ni                 103 VC K9 V
 Ethoto             2020 E897794-5 C Ag Tp              100 VC K7 V M5 V
 Thellawrr          2111 C961576-9   Ni                 803 Va M1 V
-Nalanka            2113 X510747-0 C Na                 512 Va K7 V F9 D
-Milar              2114 A334413-D C Ni                 500 Va M0 V G6 D
+Nalanka            2113 X510747-0 C Na                 512 Va K7 V D
+Milar              2114 A334413-D C Ni                 500 Va M0 V D
 Diikeme            2115 B736254-8 C C1 Lo Ni           323 Va K6 V
 Va Usotheg         2119 D8C6555-6 G Fl Ni              613 VC G2 IV
 Oizeurrgeeng       2313 D679477-3 C Ni Tp              623 VC K1 V M8 V
@@ -196,7 +196,7 @@ Uunbuzu            2416 B989388-8 C Lo Ni Tp           212 Va K8 V
 Dhuuth             2512 E544775-6   C9 Ag              511 VC K4 V
 Fou Uakhiktrol     2514 C786679-8 C Ag Ni Tp           424 VC A3 V
 Goyerehponu        2516 D676452-5 G Ni Tp              714 VC F7 V
-Uerrmmeruul        2520 E210975-5   Na Hi In           825 VC G9 V M8 D
+Uerrmmeruul        2520 E210975-5   Na Hi In           825 VC G9 V D
 Ya Xidalepo        2611 B999464-A G Ni Tp              200 VC K6 V M8 V
 Onurrorrg          2612 C5A1676-9 G Fl Ni              324 VC K6 V
 Heyi Ri I          2613 B300311-9   Lo Ni Va           305 VC F9 V
@@ -208,14 +208,14 @@ Dithtiturot        2620 A440100-D G Lo Ni Po De        910 VC F8 V
 Cidemi             2712 C686521-5 C Ag Ni Tp           624 VC A1 V
 Nanetese           2713 B452443-9 G Ni Po              801 VC K7 V
 Athorehetoner      2715 D353300-7 C Lo Ni Po           112 VC K1 V
-Aforuko            2719 B434521-9 G Ni                 401 VC G1 V G2 D
+Aforuko            2719 B434521-9 G Ni                 401 VC G1 V D
 Nilitelale         2720 XA72522-4 C Ni                 224 VC G0 V M4 V
 Ighurr             2813 EA88278-4 C Lo Ni              600 VC K4 V
 Oukhsvuel          2815 A221778-E   Na Po              322 VC K9 V
 Mnoervrge          2819 D766978-7 C Hi Tn              634 VC F3 V M3 V
 Rusathcezay        2911 B68A343-8   Lo Ni Wa           700 VC G4 V M7 V
 Otzagzoulana       2913 C511A74-C   Na Hi In Ic        510 VC K6 V M3 V
-Meathitales        2914 C568633-8   Ag Ni              800 VC G5 V A4 D
+Meathitales        2914 C568633-8   Ag Ni              800 VC G5 V D
 Etideaf            2919 C357213-8   Lo Ni              700 VC G5 V M9 V
 Thonttanufirent    2920 E648755-7 C Ag Tp              202 VC K3 V
 Earod              3013 C5276BC-8 G C9 Ni Rs           423 VC K8 V M0 V M2 V
@@ -235,7 +235,7 @@ Foinriraw          0229 C462300-7   Lo Ni              600 Va G6 V
 Uguerz             0424 C665875-4 G Tp                 700 Va K1 V
 Shaban             0425 C110545-9 G Ni                 401 Va M2 V M1 V
 Adasekaagi         0427 A655347-A G C4 Lo Ni Tp        400 Va K9 V
-I Lashaagir        0529 C338004-B   Lo Ni              102 Va F7 V M8 D
+I Lashaagir        0529 C338004-B   Lo Ni              102 Va F7 V D
 Uan Fhoghzigzufa   0530 A549478-B C Ni                 400 Va K3 V
 Mmatskfagrnurr     0624 C511A7A-8 G Na Hi In Ic        700 Va K0 V M3 V
 Lamushkaaruudara   0626 A330363-E   Lo Ni Po De        223 Va A0 V
@@ -244,9 +244,9 @@ Gazap              0726 B000562-E   Ni As              903 Va K6 V
 Shiibamnu          0729 B894022-8 C Lo Ni Tp           701 Va G8 V
 Arilaanabuba       0730 C695001-6 C Lo Ni Tp           600 Va M0 V
 Ka Ashishile       0821 B000441-D   Ni As              104 Va M0 II K9 D
-Diikuu             0823 C300565-7 G Ni Va              912 Va M7 V G9 D
+Diikuu             0823 C300565-7 G Ni Va              912 Va M7 V D
 Ernii              0825 EA8A620-8 C Ni Wa              223 Va K7 V
-Khushesminad       0826 B627542-7 G C9 Ni              400 Va K2 V F6 D
+Khushesminad       0826 B627542-7 G C9 Ni              400 Va K2 V D
 Faekgrunggueks     0827 C623376-7 G Lo Ni Po           703 Va K2 V
 Li Rar             0828 A32866A-9 G Ni                 611 Va K3 V M6 V
 Aginsubam          0921 C455842-6 C                    405 Va K7 V
@@ -281,9 +281,9 @@ Sinikikamkhaa      1721 B887100-B   Lo Ni Tp           803 Va A1 V
 Nishuudisugirmi    1724 C998596-7   Ag Ni Tp           811 Va K6 V
 Fawdhlleezlaik     1726 B78977B-B                      100 Va F6 V
 Kukilu             1727 B443589-9 C Ni Po              824 Va G5 V
-Khuggu             1730 A202788-C   Na Va Ic           204 Va F4 V G8 D
+Khuggu             1730 A202788-C   Na Va Ic           204 Va F4 V D
 Zushu              1821 A2008DD-A G C9 Na Va           723 Va K0 V M9 V
-Saggurpemamka      1824 A969563-D C Ni Tp              822 Va K7 V G4 D
+Saggurpemamka      1824 A969563-D C Ni Tp              822 Va K7 V D
 E Ikikhikaki       1825 E120356-8   Lo Ni Po De        101 Va F2 V
 Gan Diirgisha      1827 C959343-5 C Lo Ni Tp           414 Va G2 V
 Menmushuku         1828 C1207CA-9   Na Po De           424 Va G6 V
@@ -292,7 +292,7 @@ Kiikugararku       1929 C110242-9 G Lo Ni              900 Va M2 V
 Tidonefhe          2022 B635304-8 G C9 Lo Ni           200 VC M0 V M1 V
 Nonenorom          2024 A674687-A   Ag Ni Tp           303 VC A4 V K7 V G5 V
 Shashagamezurlan   2029 B8C56A6-9   Fl Ni              301 Va M2 V
-Idirkamirkushin    2030 B759356-8 G C9 Lo Ni Tp        803 Va K5 V A2 D
+Idirkamirkushin    2030 B759356-8 G C9 Lo Ni Tp        803 Va K5 V D
 Ofesevopar         2121 A9C6497-B G Fl Ni              722 VC K5 V K4 V
 Onsukethyo         2122 B534896-6                      700 VC G9 V M5 V M8 V
 Tidethmintsi       2124 D753265-2   Lo Ni Po Tp        811 VC G7 V
@@ -302,9 +302,9 @@ Rraenoa            2127 A784675-C G Ag Ni Tp St        803 Va G0 V
 Iriirgidiimla      2129 C444340-9 G Lo Ni              123 Va F8 V
 Ecunan             2222 C787555-A C Ag Ni Tp           220 VC K5 V
 Sotaramagu         2223 A5517CA-9 G Po                 400 VC K0 V
-Amgurnelenkap      2225 B682211-B G Lo Ni              723 Va K7 V M4 V A5 D
+Amgurnelenkap      2225 B682211-B G Lo Ni              723 Va K7 V M4 V D
 Enar Khukmuu       2226 B72968A-A   Ni                 713 Va K6 V K2 V
-Iidershaam         2227 C779574-7   Ni Tp              810 Va G7 V G3 D
+Iidershaam         2227 C779574-7   Ni Tp              810 Va G7 V D
 Adishaa            2228 E120459-9 C Ni Po De           814 Va F6 V
 Disikhe            2230 A22678A-D G                    224 Va A5 V G7 V
 Rotoftesatxuda     2321 X744652-2 C Ag Ni Tp           801 VC G9 V
@@ -344,11 +344,11 @@ Nish Nakaagusin    3128 E414587-6 C Ni Ic              804 Va K7 V
 Makhoghi           3221 C767674-6 G Ag Ni Tn           904 VC G6 V K8 V K1 V
 Tematnasnaycea     3222 B335758-8   C1                 700 VC K9 V M4 V
 Ososin             3223 C767432-8 G Ni Tn              800 VC G5 V
-Genosu             3224 D88A320-5 G Lo Ni Wa           815 VC A2 V A5 D
+Genosu             3224 D88A320-5 G Lo Ni Wa           815 VC A2 V D
 Mamiish            3227 A221522-C G Ni Po              724 Va A2 V G9 V
-Gvgruakunorthez    3228 C323875-9 G Na Po              200 Va K9 V M1 D
+Gvgruakunorthez    3228 C323875-9 G Na Po              200 Va K9 V D
 Omga Dzirfanfe     3230 D845974-4   Hi In Tp           514 Va F5 V M7 V
-Khiszuza           0131 C430110-7   Lo Ni Po De        802 Va F8 V G6 D
+Khiszuza           0131 C430110-7   Lo Ni Po De        802 Va F8 V D
 Ga Kamshinina      0134 C676510-5   Ag Ni Tp           104 J- F6 V
 Ikushdashiimaka    0140 C3526AF-6   Ni Po              303 J- K8 V
 Kaluunugindirlii   0231 X742556-4 C Ni Po              701 Va K1 V
@@ -368,9 +368,9 @@ Kangakhara         0731 B542545-9 G Ni Po              722 Va G2 V
 Lenmueduengok      0734 B569410-8 C Ni                 715 Ef G1 V K0 V
 Uzaeroka           0736 C644530-9 G Ag Ni Tp           200 Ef M0 V M2 V
 Foin Lous          0738 B645320-B   Lo Ni Tp           702 Ef K9 V M0 V
-Sokugzaghzodull    0739 C7B4243-7   Fl Lo Ni           522 Ef K9 V F3 D
+Sokugzaghzodull    0739 C7B4243-7   Fl Lo Ni           522 Ef K9 V D
 Allirzughoith      0833 E443457-5   Ni Po              200 Ef K7 V M6 V
-Eggheng            0835 B555597-B   C6 Ag Ni Rs        501 Ef G4 V K7 D
+Eggheng            0835 B555597-B   C6 Ag Ni Rs        501 Ef G4 V D
 Llotree            0839 A210AA7-G C Na Hi In           502 Ef M3 V
 Umarlesa           0931 C464000-8   Lo Ni              802 Va K3 V
 Embadesashi        0932 B999300-C G D4 Lo Ni Tp        302 Va F2 V
@@ -384,7 +384,7 @@ Vrgaarrmmigvi      1037 B000304-C G Lo Ni As           503 Ef K8 V
 Goergvgruul        1132 A342978-A   Hi In Po           625 Va F1 V
 Fhuudhaa           1134 B547413-7   Ni                 502 Ef K4 V
 Oroun              1137 B444872-6                      403 J- K3 V
-Kfi Emollra        1139 E465402-7 C Ni                 124 Ef F3 V K8 D
+Kfi Emollra        1139 E465402-7 C Ni                 124 Ef F3 V D
 Le Awzonllaa       1140 D221369-4   Lo Ni Po           110 Ef F6 V M8 V
 Adlirgiimadadzi    1231 E6689DD-4 C Hi Tp              604 Va M0 V
 Giilakhishegula    1233 B787554-C   Ag Ni Tp           433 Va G2 V
@@ -412,7 +412,7 @@ Urmuriimgumudar    1732 C799355-9 C Lo Ni Tp           314 Va A1 V
 Muushkikhu         1733 D5886B9-2 C Ag Ni              301 Va G5 V
 Khurmikurulir      1832 B5769AD-A   Hi In              813 Va M0 V
 Kigkishasha        1833 E410000-0   Ba Lo Ni           001 -- M8 V
-Ad Ked Dulish      1834 C410487-B   Ni                 620 Va M5 V F8 D
+Ad Ked Dulish      1834 C410487-B   Ni                 620 Va M5 V D
 Kaa Ushkamarikii   1835 B646222-9   Lo Ni Tp           222 Va K4 V
 Arsiruruugumem     1931 A767025-8   Lo Ni              904 Va F1 V
 Kidikhiishum       1936 C223997-B   Na Hi In Po        503 Va G2 V K6 V
@@ -426,20 +426,20 @@ Vraavruk           2131 E330576-6   Ni Po De           700 Va M0 V M8 V
 Ar Luugirir        2132 D8A3598-4   C0 Fl Ni           803 Va M0 V M2 V
 Dhuanknogorzking   2133 CAA5157-9 G Fl Lo Ni           300 Va A9 V
 Outronga           2134 A995877-C G C8 Tp              133 Va F9 V F2 V
-Ga Dush            2135 C68AAEF-D   Hi Wa              400 Va K7 V M3 D
+Ga Dush            2135 C68AAEF-D   Hi Wa              400 Va K7 V D
 Gera Lukimir       2136 A400447-D G Ni Va              200 Va M5 V M7 V
 Gisuushukhur       2139 A6A0100-D G Lo Ni De           924 Va K2 V
 Kirurminurima      2232 B8B8444-A C Fl Ni              103 Va M0 V M7 V
-Kii Igan           2233 B889224-C   Lo Ni Tp           803 Va K6 V G4 D
+Kii Igan           2233 B889224-C   Lo Ni Tp           803 Va K6 V D
 Makisha            2235 C434000-9   Lo Ni              702 Va F2 V M5 V
 Ru Mikisikimme     2237 E856598-4   Ni                 903 Va M7 V M4 V
 Inbugaashag        2239 B585233-6   Lo Ni              303 Va M0 V M8 V
 Ku Sharmashasha    2240 E776559-5 C Ag Ni Tn           513 Va F8 V M2 V
 Gam Nishi          2331 E593000-0   Ba Lo Ni           000 -- K2 V
-Shir Kish          2332 BAA5201-9 G Fl Lo Ni           323 Va G6 V M9 D
+Shir Kish          2332 BAA5201-9 G Fl Lo Ni           323 Va G6 V D
 Akudaa             2433 B793485-8   Ni                 600 Va M3 V
 Irkiirkir          2435 A130676-A   Na Ni Po De        520 Va A1 V
-Irenanikhu         2438 E200201-7   Lo Ni Va           904 Va M2 V K4 D
+Irenanikhu         2438 E200201-7   Lo Ni Va           904 Va M2 V D
 De Kiidilumadu     2439 C746899-3   Tp                 602 Va M0 V M7 V M9 V
 Iishekemgii        2531 D2328B8-8 C Na Po              500 Va F1 V
 Arkumi             2533 D748620-5 C Ag Ni Tp           903 Va K4 V M9 V
@@ -455,8 +455,8 @@ Idraniingu         2835 D756688-1 C Ag Ni Tp           303 Va G7 V
 Zirigunsii         2836 A545312-9   Lo Ni              203 Va G7 V
 Indurshuugirsa     2840 E573883-4 C                    303 Va K7 V
 Ushuzugur          2931 D593633-6 C Ni                 801 Va K4 V M2 V
-Ekak Aagidbunup    2933 B553446-A   Ni Po              702 Va K0 V K6 D
-Uu Khuurka         2934 C313300-8   Lo Ni Ic           801 Va K0 V A1 D
+Ekak Aagidbunup    2933 B553446-A   Ni Po              702 Va K0 V D
+Uu Khuurka         2934 C313300-8   Lo Ni Ic           801 Va K0 V D
 Nedbushe           2935 C476869-7 C                    901 Va K5 V
 Akuumagadgim       2939 E565586-5   Ag Ni              422 Va G9 V M1 V
 Enilankakigam      3037 E765256-3 C Lo Ni Tn St        104 Va G8 V

--- a/res/Sectors/M1105/Ktiingzat.sec
+++ b/res/Sectors/M1105/Ktiingzat.sec
@@ -243,7 +243,7 @@ Ou Oathuu          0627 B896A75-B G Hi In Tp           623 Va G5 V
 Gazap              0726 B000562-E   Ni As              903 Va K6 V
 Shiibamnu          0729 B894022-8 C Lo Ni Tp           701 Va G8 V
 Arilaanabuba       0730 C695001-6 C Lo Ni Tp           600 Va M0 V
-Ka Ashishile       0821 B000441-D   Ni As              104 Va M0 II K9 D
+Ka Ashishile       0821 B000441-D   Ni As              104 Va M0 II K9 V
 Diikuu             0823 C300565-7 G Ni Va              912 Va M7 V D
 Ernii              0825 EA8A620-8 C Ni Wa              223 Va K7 V
 Khushesminad       0826 B627542-7 G C9 Ni              400 Va K2 V D
@@ -354,7 +354,7 @@ Ikushdashiimaka    0140 C3526AF-6   Ni Po              303 J- K8 V
 Kaluunugindirlii   0231 X742556-4 C Ni Po              701 Va K1 V
 Grekroinokhoiz     0235 BAE4776-9   Fl                 802 J- K5 V
 Uen Oirr           0237 B554477-8   Ni                 702 J- K4 V M1 V
-Midbeshad          0331 A120353-G G Lo Ni Po De        823 Va A3 IV F4 D
+Midbeshad          0331 A120353-G G Lo Ni Po De        823 Va A3 IV F4 V
 Sorzvinotheza      0339 B200543-A   Ni Va              500 Ef M6 V M0 V
 Mikudimarshigur    0433 C230755-7 G Na Po De           401 Va K1 V
 Igdzeng            0437 B642110-7   Lo Ni Po           703 Ef G7 V


### PR DESCRIPTION
What it says on the tin.

Main-sequence "dwarfs" (eg `G3 D`) that are companions of size I-IV stars are promoted to size V (`G3 V`).
Main-sequence "dwarfs" that are companions of main sequence stars lose their spectral class (example becoming plain `D`).