### PR TITLE
feat: add polygon overlays to web ui

### DIFF
--- a/map.js
+++ b/map.js
@@ -1397,6 +1397,30 @@ const Util = {
           ctx.lineTo(pt.x, pt.y);
         }
         ctx.fill();
+      } else if (overlay.type === 'polygon') {
+        let pts = overlay.points;
+        let pt = this.mapToPixel(pts[0].x, pts[0].y);
+        ctx.beginPath();
+        ctx.moveTo(pt.x, pt.y);
+        for (let i = 1; i < pts.length; ++i) {
+          let pt = this.mapToPixel(pts[i].x, pts[i].y)
+          ctx.lineTo(pt.x, pt.y);
+        }
+        ctx.closePath();
+
+        if (('line' in overlay) || ('fill' in overlay)) {
+          if ('fill' in overlay) {
+            ctx.fillStyle = overlay.fill;
+            ctx.fill();
+          }
+          if ('line' in overlay) {
+            ctx.strokeStyle = overlay.line;
+            ctx.lineWidth = 'w' in overlay ? overlay.w : 1;
+            ctx.stroke();
+          }
+        } else {
+          ctx.fill();
+        }
       }
       ctx.restore();
     }


### PR DESCRIPTION
Add support for a new 'polygon' overlay type.

Testing:
- Verified, if no line or fill attributes were specified, a filled polygon was
drawn using colour specified by the style attribute
- Verified, if just the line attribute was specified, an outline polygon was
drawn using the specified colour
- Verified, if just the fill attribute was specified, a filled polygon was
drawn using the specified colour
- Verified, if the line and fill attribute were specified, the polygon was
drawn filled and outlined in the respective colours
- Verified, if the w attribute was specified when drawn an outline polygon,
the line width was set accordingly
- Verified, if the w attribute was not specified when drawn an outline
polygon, then the line width defaulted to 1 pixel
- Regression tested that rect and circle overlays still displayed correctly
when created with url queries