### PR TITLE
Fix UWP size digit of Kruse 3023 - 5, not S.

### DIFF
--- a/res/Sectors/M1105/Kruse.txt
+++ b/res/Sectors/M1105/Kruse.txt
@@ -243,7 +243,7 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 2928 Forssei              E864601-0 Ag Lt Ni (Human Minor)                      901   Na M0 V                 
 3021 Luomala 0601         X100000-0 Ba Va                                       001   Na M6 V                 
 3022 Luomala 0602         X545000-0 Ba                                          004   Na K2 V                 
-3023 Franklin             XSA7000-0 Ba Fl                                       001   So M7 V                 
+3023 Franklin             X5A7000-0 Ba Fl                                       001   So M7 V                 
 3027 Luomala 0607         X110000-0 Ba                                          011   Na M9 V                 
 3029 Luomala 0609         X97A000-0 Ba Wa                                       002   Na K3 V                 
 3122 Luomala 0702         X4A0000-0 Ba                                          012   Na K4 V                 


### PR DESCRIPTION
This looks like either a transcription goof or an OCR typo that, for whatever reason, didn't get caught.