### PR TITLE
Fix stellar data in Jim Kundert's sectors, round 1

### DIFF
--- a/res/Sectors/M1105/Gur.tab
+++ b/res/Sectors/M1105/Gur.tab
@@ -1,6 +1,6 @@
 Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 0102	Maiden	XAD7000-0		Ba		034	NaHu	K1 V M4 V	{ -3 }	(500-5)	[0000]		14
-0103	Flotsam Station	D561112-6		Lo		524	NaHu	G2 V G0 IV	{ -3 }	(700+3)	[1147]		15
+0103	Flotsam Station	D561112-6		Lo		524	NaHu	G0 IV G2 V	{ -3 }	(700+3)	[1147]		15
 0127	Kagragha	C89A3QK-B	K	Wa Lo		534	Kk	G8 V	{ 0 }	(D20+1)	[236F]		17
 0128	Ookraua	C6539RK-D		Hi Po		324	Kk	M3 V BD	{ 2 }	(G89+1)	[8B4E]		16
 0129	Reeaxkkrukkta	D300000-0		Va Ba		000	Kk	K2 V	{ -3 }	(700+1)	[0000]		9
@@ -135,13 +135,13 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 1437		B6619RK-D		Hi Pr		721	Kk	K8 V	{ 3 }	(886+1)	[8C3D]		12
 1438		B7464QK-C	K	Ni Pa		214	Kk	M3 V	{ 1 }	(F33-5)	[853A]		15
 1440		E549000-0		Ba		024	Kk	K8 V	{ -3 }	(800+1)	[0000]		15
-1502	Nebu	E555000-0		Ba		002	NaHu	M4 V M0 V	{ -3 }	(700+1)	[0000]		8
-1505		E636200-8		Lo		112	NaHu	M5 V M0 V	{ -3 }	(910-3)	[116A]		13
+1502	Nebu	E555000-0		Ba		002	NaHu	M0 V M4 V	{ -3 }	(700+1)	[0000]		8
+1505		E636200-8		Lo		112	NaHu	M0 V M5 V	{ -3 }	(910-3)	[116A]		13
 1521	Mandolin	X683000-0		Ba Di(NaPhentok)		010	NaXX	M8 V	{ -3 }	(600+1)	[0000]		9
 1528	K'eeugre	D6254QK-A		Ni		205	Kk	A4 V	{ -1 }	(A33+3)	[231E]		11
 1529	Akrkrokreena	E5765QK-9	K	Ni Ag		601	Kk	M7 V	{ -1 }	(B44-1)	[745B]		10
 1531		E000000-0		As Va Ba		012	Kk	K4 III	{ -3 }	(900+1)	[0000]		10
-1533		B552756-A	K	Po Giru6 Ciru4		124	KC	M4 V M3 V	{ 2 }	(E6E+1)	[6999]		16
+1533		B552756-A	K	Po Giru6 Ciru4		124	KC	M3 V M4 V	{ 2 }	(E6E+1)	[6999]		16
 1534		B6724QK-C		He Ni		302	Kk	M0 V M6 V	{ 1 }	(436-2)	[253E]		9
 1537		C4013QK-C		Ic Va Lo		805	Kk	K8 V K9 V	{ 0 }	(D20+1)	[535B]		11
 1538		A5598RK-E	K	Ph		724	Kk	G7 V K0 V	{ 2 }	(G76+1)	[6A1B]		17

--- a/res/Sectors/M1105/Kilong.tab
+++ b/res/Sectors/M1105/Kilong.tab
@@ -6,11 +6,11 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 0110	Kat'kee	A5749RK-E	K	Hi In		424	Kk	M7 V	{ 4 }	(D8B+3)	[8D5F]		18
 0112	Kuraake Nu	E000000-0		As Va Ba		004	Kk	M9 V	{ -3 }	(500-1)	[0000]		17
 0113	Katr'uu	E400000-0	K	Va Ba		022	Kk	M5 V	{ -3 }	(600-1)	[0000]		11
-0116	Axirra	A463ARK-F	K	Hi		112	Kk	K9 V M5 V K7 V	{ 3 }	(A9B+2)	[8D6G]		14
+0116	Axirra	A463ARK-F	K	Hi		112	Kk	K7 V M5 V K9 V	{ 3 }	(A9B+2)	[8D6G]		14
 0120	'Kuurkerr	B8356RK-E		Ni		100	Kk	K4 V M1 V	{ 1 }	(855+1)	[575D]		7
 0121	K'teri	A3818RK-F		Ph Ri		424	Kk	K8 V	{ 3 }	(D78+1)	[7B6F]		14
 0122	Alur!!	E5585QK-9		Ni Ag		100	Kk	K5 V K5 V	{ -1 }	(740+1)	[545A]		6
-0124	Gzaakre	C8936RK-C		Ni		213	Kk	K4 V K1 V	{ 0 }	(B54-1)	[665C]		12
+0124	Gzaakre	C8936RK-C		Ni		213	Kk	K1 V K4 V	{ 0 }	(B54-1)	[665C]		12
 0126	Xugraki	C3725QK-B		He Ni		504	Kk	K7 V M3 V	{ 0 }	(C43+1)	[556A]		9
 0128	Kun'gra	D3365QK-A		Ni		134	Kk	F7 V G2 V	{ -1 }	(E41+1)	[545B]		16
 0129	Aakarang	B764ARK-F	K	Hi		404	Kk	K4 V	{ 3 }	(C9A+2)	[8D4G]		8
@@ -19,8 +19,8 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 0137	Ghiiroa	A97A4QK-E		Wa Ni		211	Kk	M9 V	{ 1 }	(932-1)	[556E]		9
 0201	Krakaarran	E120000-0		De Ba Po		000	Kk	K5 V M8 V	{ -3 }	(500-1)	[0000]		5
 0202	Gnantarr'	A5326RK-F	K	Ni Na Po		410	Kk	F9 III G0 V	{ 1 }	(954+1)	[675E]		7
-0204	Aakik	D6355QK-A	K	Ni		124	Kk	K4 V K3 V M1 V	{ -1 }	(D41+1)	[5459]		18
-0206	Nirare	E210000-0		Ba		003	Kk	K5 V K4 V	{ -3 }	(600-1)	[0000]		11
+0204	Aakik	D6355QK-A	K	Ni		124	Kk	K3 V K4 V M1 V	{ -1 }	(D41+1)	[5459]		18
+0206	Nirare	E210000-0		Ba		003	Kk	K4 V K5 V	{ -3 }	(600-1)	[0000]		11
 0211	K'kruukong	E74A000-0	K	Wa Ba		034	Kk	M2 V M3 V	{ -3 }	(800-1)	[0000]		13
 0213	Rooxreeka	A6376RK-E		Ni		624	Kk	K5 V M8 V	{ 1 }	(E54+1)	[675D]		13
 0214	Atranxar	B5775QK-D	K	Ni Ag		222	Kk	K1 V M1 V	{ 2 }	(B45+1)	[475D]		13
@@ -28,7 +28,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 0220	Ureghar	C3334QK-B	K	Ni Po		722	Kk	G0 III G4 V	{ 0 }	(A31+1)	[445B]		9
 0222	Kee'gh' Nuat	B0003QK-D	K	As Va Lo		223	Kk	M1 V M7 V	{ 1 }	(C21+1)	[345C]		16
 0224	Aturi	E9B3000-0		Fl Ba		010	Kk	K8 V M9 V	{ -3 }	(800-1)	[0000]		10
-0225	K'rooa Nu	B000456-C	O	As Va Ni Giru3 Tilp7		812	KC	A4 V A2 V	{ 1 }	(A34+1)	[556D]		14
+0225	K'rooa Nu	B000456-C	O	As Va Ni Giru3 Tilp7		812	KC	A2 V A4 V	{ 1 }	(A34+1)	[556D]		14
 0227	Mir'kar	B6887RK-F	K	Ag Ri		310	Kk	G4 V	{ 4 }	(96C+1)	[5B4F]		8
 0228	Agharror	D855ARK-D	K	Ga Hi		811	Kk	M9 V	{ 1 }	(A98+1)	[8B5D]		12
 0229	Kalaket	C4966RK-C	K	Ni Ag		724	Kk	G0 V M2 V	{ 1 }	(E55+1)	[674C]		17
@@ -170,7 +170,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 0932	K'xgarrga	E100000-0		Va Ba		014	Kk	K1 V M8 V	{ -3 }	(400+1)	[0000]		12
 0934	Kooarrk'	D5547RK-B	K	Ag		202	Kk	M2 V	{ 1 }	(C68-3)	[587B]		9
 0935	Iil'rrra	A7748RK-E	K	Ph Pa Pi		124	Kk	G4 V	{ 2 }	(C7B-1)	[8A69]		14
-0937	Kalarar	E7A0000-0		He Ba		000	Kk	M9 V M3 V	{ -3 }	(A00-5)	[0000]		5
+0937	Kalarar	E7A0000-0		He Ba		000	Kk	M3 V M9 V	{ -3 }	(A00-5)	[0000]		5
 0938	Paaarghexk	B2013QK-B	K	Ic Va Lo		225	Kk	M2 V	{ 1 }	(D21+1)	[6458]		17
 0939	Ktokikoor	A5956RK-F	K	Ni Ag		512	Kk	K0 V	{ 2 }	(957-1)	[785E]		6
 1001	Auxna	A6659RK-E	K	Ga Hi Pr		323	Kk	M1 V	{ 3 }	(H8C-4)	[7C2F]		11
@@ -218,10 +218,10 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 1211	Hk'kkaat	B554ARK-F	K	Hi		202	Kk	F0 V G0 IV	{ 3 }	(A9B-2)	[9D6J]		14
 1212	Arradla	C9568RK-D	K	Ph Pa		522	Kk	G7 IV K1 V M3 V	{ 1 }	(A7A+4)	[797D]		14
 1215	Anina	C6515QK-A	K	Ni Po		700	Kk	M3 V M5 V M5 V	{ 0 }	(845+1)	[156A]		12
-1217	Tiulg!	E7A35QK-B	K	Fl Ni		334	Kk	M3 V M0 V	{ -1 }	(G45+3)	[544C]		18
+1217	Tiulg!	E7A35QK-B	K	Fl Ni		334	Kk	M0 V M3 V	{ -1 }	(G45+3)	[544C]		18
 1219	Narakrra	C3746RK-B	K	Ni Ag		124	Kk	F8 III	{ 1 }	(F57+1)	[975C]		18
 1222	Aghaa Kuo'	B4829RK-F		Hi Pr		413	Kk	M8 V	{ 3 }	(D89+1)	[8C6F]		12
-1223	Taruka	C5559RK-D	K	Hi		722	Kk	M8 V M7 V	{ 2 }	(A8B+2)	[9BAJ]		11
+1223	Taruka	C5559RK-D	K	Hi		722	Kk	M7 V M8 V	{ 2 }	(A8B+2)	[9BAJ]		11
 1225	Ar'rla	E6383QK-8	K	Lo		823	Kk	M4 V M9 V M6 V	{ -3 }	(D20+2)	[2158]		17
 1228	Engkarre	C4344QK-C	K	Ni		400	Kk	M2 V M0 V	{ 0 }	(635+2)	[146B]		7
 1230	Kux'kta	B264ARK-E		Hi		312	Kk	M0 V BD	{ 3 }	(D99+1)	[6D5D]		11
@@ -275,9 +275,9 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 1618	Aght'rkra	C5447RK-B	O	Ag Pi		311	Kk	G1 V	{ 2 }	(566-1)	[896A]		6
 1619	Karkaraa	C75A5QK-B	O	Wa Ni		714	Kk	M5 V	{ 0 }	(D45-1)	[656C]		14
 1621	Rur'ki	D5549RK-C		Hi		933	Kk	M9 III M7 V	{ 1 }	(E88+1)	[DA1A]		12
-1622	Kragh'righ	C5516RK-B	K	Ni Po		734	Kk	M8 V M4 V	{ 0 }	(G55+1)	[865E]		15
+1622	Kragh'righ	C5516RK-B	K	Ni Po		734	Kk	M4 V M8 V	{ 0 }	(G55+1)	[865E]		15
 1624	Lakruurrgna	E6647RK-A		Ag Ri		520	Kk	G2 V M8 V	{ 2 }	(869+1)	[794A]		10
-1625	Krunak'	C5345QK-B	O	Ni		103	Kk	M8 V M1 V M3 V	{ 0 }	(842+1)	[154C]		12
+1625	Krunak'	C5345QK-B	O	Ni		103	Kk	M1 V M8 V M3 V	{ 0 }	(842+1)	[154C]		12
 1629	Xeetag'	A5447RK-E	K	Ag Pi		503	Kk	M7 V	{ 3 }	(C6B-2)	[9A6J]		7
 1630	Karamii	E53A000-0	K	Wa Ba		024	Kk	M8 V BD	{ -3 }	(200+1)	[0000]		15
 1632	Koorrreeki	D5436RK-B	K	Ni Po		502	Kk	K5 V	{ -1 }	(754-2)	[5588]		7
@@ -310,7 +310,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 1838	Kanaakrr'	CAE36RK-D	O	Ni		523	Kk	K3 V	{ 0 }	(951+1)	[565H]		12
 1901	Abukal	A684ARK-F	K	Hi		604	Kk	G8 V	{ 3 }	(B9C+1)	[6D4F]		16
 1903	Koo'man	E540000-0		De He Ba Po		023	Kk	M5 V M9 V	{ -3 }	(600+2)	[0000]		17
-1906	Ghieta	C5895QK-C		Ni Pr		114	Kk	M1 V M0 V BD	{ 0 }	(B42-4)	[855D]		11
+1906	Ghieta	C5895QK-C		Ni Pr		114	Kk	M0 V M1 V BD	{ 0 }	(B42-4)	[855D]		11
 1909	'Krlagu	A5427RK-F		He Pi Po		714	Kk	K2 V	{ 2 }	(B66+2)	[399L]		14
 1919	Oonggzudku	X431000-0	K	Ba Po	R	003	Kk	K9 V	{ -3 }	(A00+1)	[0000]		9
 1922	Xag'u	X300000-0		Va Ba	R	023	Kk	A1 V	{ -3 }	(800+1)	[0000]		15
@@ -323,7 +323,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 2006	'Rtaargna	B729556-9	K	Ni Giru4 Tilp6		110	Kk	K1 V K8 V K5 V M8 V	{ 0 }	(842+3)	[352B]		11
 2008	Me'kaxta	DAA885A-V	K	Fl Ph (Me’kax)		723	Kk	K2 V	{ 1 }	(A7A-3)	[394V]		11
 2011	Taklaru	B5304QK-D	K	De Ni Po		813	Kk	M9 V	{ 1 }	(B37-5)	[153B]		12
-2012	Iriix	C9A64QK-B		Fl Ni		324	Kk	M4 V M1 V	{ 0 }	(D34+1)	[344B]		16
+2012	Iriix	C9A64QK-B		Fl Ni		324	Kk	M1 V M4 V	{ 0 }	(D34+1)	[344B]		16
 2018	Auugnu	X76A000-0	K	Wa Ba	R	003	Kk	G3 V	{ -3 }	(800+1)	[0000]		13
 2019	Eerrkragha	X562000-0	K	Ba	R	025	Kk	G1 III	{ -3 }	(400+1)	[0000]		14
 2021	Gnixkakroo	X687000-0		Ga Ba	R	024	Kk	M0 V	{ -3 }	(200-3)	[0000]		11
@@ -362,7 +362,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 2225	Kagaama Tuak	C9965QK-B	K	Ni Ag		813	Kk	G5 V D	{ 1 }	(C46+1)	[162B]		10
 2226	Atr'hka	C5537RK-C		Po		311	Kk	M3 V M1 V	{ 1 }	(768+2)	[786C]		10
 2227	Hkaaluum	B7775QK-C	K	Ni Ag		714	Kk	G8 V	{ 2 }	(C45+5)	[2719]		15
-2228	Rukaniim	B6668RK-F	K	Ga Ph Pa Ri		500	Kk	M3 V M1 V	{ 3 }	(877+3)	[BB1D]		5
+2228	Rukaniim	B6668RK-F	K	Ga Ph Pa Ri		500	Kk	M1 V M3 V	{ 3 }	(877+3)	[BB1D]		5
 2229	Nuuuugnoor	C75A4QK-A	K	Wa Ni		814	Kk	M1 V M7 V	{ 0 }	(C32-3)	[741B]		12
 2232	Ikrgari	D897556-A	K	Ni Ag Giru7 Tilp3		420	Kk	M6 V	{ 0 }	(842+1)	[6585]		9
 2237	Teeiang	C4243QK-A	O	Lo		311	Kk	M1 V	{ 0 }	(720-2)	[433C]		5
@@ -373,9 +373,9 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 2308	Kuga Kiiaar	C5559RK-E	K	Hi		604	Kk	K5 V	{ 2 }	(789+1)	[AB9E]		14
 2309	Gar!rtu	C5637RK-C	O	Ri		400	Kk	M5 V	{ 2 }	(56B-5)	[99AH]		10
 2311	Kiapt'	C5606RK-C	K	De Ni Ri		223	Kk	K4 V M7 V	{ 1 }	(G53-2)	[375C]		17
-2313	Aghoorkiiru	C6558RK-E	O	Ga Ph Pa		600	Kk	G9 V G3 V	{ 1 }	(478+1)	[898G]		8
+2313	Aghoorkiiru	C6558RK-E	O	Ga Ph Pa		600	Kk	G3 V G9 V	{ 1 }	(478+1)	[898G]		8
 2314	Rrunaatan	E302000-0	K	Ic Va Ba		013	Kk	K1 V	{ -3 }	(600-3)	[0000]		16
-2320	Utanga Kaba	B6887RK-E	O	Ag Ri		112	Kk	M7 V M5 V	{ 4 }	(B6G+1)	[6B7D]		12
+2320	Utanga Kaba	B6887RK-E	O	Ag Ri		112	Kk	M5 V M7 V	{ 4 }	(B6G+1)	[6B7D]		12
 2324	Gnukau	A664ARK-F	K	Hi		303	Kk	A1 V G5 IV	{ 3 }	(C9D+1)	[CD6F]		13
 2328	Kutruulmba	D8492PK-8	O	Lo		221	Kk	F2 V D	{ -3 }	(A10-2)	[1158]		14
 2333	Ungakkuu	E8B43QK-9		Fl Lo		723	Kk	K5 V M2 V	{ -2 }	(920+1)	[318C]		14
@@ -383,9 +383,9 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 2340	Ghoogrraa	C3263QK-B	K	Lo		810	Kk	G7 V	{ 0 }	(420+1)	[137B]		6
 2405	Gzak'gne	E200000-0		Va Ba		024	Kk	K8 V M0 V	{ -3 }	(500-3)	[0000]		14
 2406	Akiikraa	C6617RK-D	K	Ri		300	Kk	M6 V	{ 2 }	(86B+1)	[894C]		9
-2410	'Nkiioo	C5724QK-B	K	He Ni		503	Kk	M8 V M2 V BD	{ 0 }	(A31+1)	[545C]		8
+2410	'Nkiioo	C5724QK-B	K	He Ni		503	Kk	M2 V M8 V BD	{ 0 }	(A31+1)	[545C]		8
 2414	Rreegh!'kroo	E400000-0		Va Ba		011	Kk	K7 V	{ -3 }	(600-4)	[0000]		8
-2416	Neergak'	D8A35QK-A	K	Fl Ni		723	Kk	G9 V G2 V K4 V	{ -1 }	(C42+2)	[6449]		16
+2416	Neergak'	D8A35QK-A	K	Fl Ni		723	Kk	G2 V G9 V K4 V	{ -1 }	(C42+2)	[6449]		16
 2419	Ta'la	A684ARK-F	K	Hi		504	Kk	M4 V M7 V	{ 3 }	(99C-1)	[8D6L]		17
 2420	Aghkrarlur	E210000-0		Ba		023	Kk	G1 V	{ -3 }	(500-3)	[0000]		12
 2421	Iuka A'ta	B8986RK-D	K	Ni Ag		502	Kk	F6 V	{ 2 }	(854+4)	[4869]		10
@@ -394,7 +394,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 2424	Uaax	B6465QK-C	O	Ni Ag		134	Kk	G5 V	{ 2 }	(C44+3)	[874C]		19
 2426	A'lkar	E5546RK-B		Ni Ag		120	Kk	K3 V	{ 0 }	(E52+3)	[665A]		10
 2427	Ikaga	A654ARK-F	K	Hi		202	Kk	F1 V	{ 3 }	(99B+2)	[CD3D]		7
-2429	Gzanaoorr	A8689RK-F	K	Hi Pr		602	Kk	F6 V G3 V M6 V F1 V	{ 3 }	(48B-3)	[BC6D]		12
+2429	Gzanaoorr	A8689RK-F	K	Hi Pr		602	Kk	F1 V G3 V M6 V F6 V	{ 3 }	(48B-3)	[BC6D]		12
 2433	Traleerrba	B7678RK-E	O	Ga Ph Pa Ri		222	Kk	G1 V M2 V	{ 3 }	(B77+1)	[7B4H]		12
 2439	Aakkug Zoong	E420000-0	K	De He Ba Po		035	Kk	M0 V	{ -3 }	(300+4)	[0000]		16
 2501	Kaabighir	C6538RK-C	O	Ph Po		320	Kk	G7 V G7 V	{ 1 }	(776-1)	[D97B]		10
@@ -409,7 +409,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 2521	R!!uulgan	C4114QK-C		Ic Ni		904	Kk	M4 V BD	{ 0 }	(D35+2)	[247B]		11
 2525	Eroe	DAE5976-8		Hi (Hicroa)	A	525	KC	K1 V M0 V D	{ -1 }	(D87+1)	[48A8]		14
 2527	'Umkre	B84A4QK-C	K	Wa Ni		423	Kk	K6 V M5 V M0 V	{ 1 }	(D33-4)	[45AH]		13
-2529	Mbea!r	C5896RK-B		Ni Ri		214	Kk	M5 V M0 V	{ 1 }	(D57-4)	[975A]		12
+2529	Mbea!r	C5896RK-B		Ni Ri		214	Kk	M0 V M5 V	{ 1 }	(D57-4)	[975A]		12
 2530	Nakria Aa	C79A3QK-B	K	Wa Lo		510	Kk	K5 V	{ 0 }	(820+1)	[733F]		8
 2532	Rookekrax	A9897RK-F	K	Ri		503	Kk	A7 V K4 V	{ 3 }	(A69+3)	[BA5F]		10
 2535	Aaktukr	B7486RK-E		Ni Ag		313	Kk	M2 V	{ 2 }	(858-2)	[684E]		13
@@ -417,10 +417,10 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 2602	Gikagar	A5589RK-E	K	Hi		823	Kk	M5 V BD	{ 3 }	(D8B+2)	[CC4G]		18
 2603	Kaarru	X9B6000-0		Fl Ba	R	013	Kk	G0 V	{ -3 }	(300-1)	[0000]		12
 2604	Raghaka	C6263QK-A	O	Lo		324	Kk	G9 V	{ 0 }	(B20+1)	[135B]		13
-2605	Kihkooxtoo	C6336RK-D	K	Ni Na Po		613	Kk	G4 V G3 V K3 V	{ 0 }	(B54+1)	[5619]		9
+2605	Kihkooxtoo	C6336RK-D	K	Ni Na Po		613	Kk	G3 V G4 V K3 V	{ 0 }	(B54+1)	[5619]		9
 2606	A!gha	C7A5557-A		Fl Ni Giru6 Klah4		413	Kk	K3 V M1 V	{ 0 }	(D45+1)	[857A]		16
 2610	Kiagnoo	E220000-0	K	De Ba Po		021	Kk	M3 V BD	{ -3 }	(A00-3)	[0000]		15
-2611	Tiigtau	C9475QK-A	K	Ni Ag		322	Kk	G6 V M5 V G1 V	{ 1 }	(B47-5)	[665A]		14
+2611	Tiigtau	C9475QK-A	K	Ni Ag		322	Kk	G1 V M5 V G6 V	{ 1 }	(B47-5)	[665A]		14
 2614	Nux!ghee	C7456RK-C		Ni Ag		323	Kk	K0 V	{ 1 }	(955-3)	[479A]		11
 2615	Ookurgna	A657ARK-F		Ga Hi		724	Kk	K8 V	{ 3 }	(E9D+4)	[BD5G]		17
 2619	Grairi	D75A6RK-B	K	Wa Ni		500	Kk	M0 V BD M7 V	{ -1 }	(B53+4)	[753E]		11
@@ -448,8 +448,8 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 2740	Rakun'n	CA8A5QK-C	K	Oc Ni Pr		124	Kk	G7 V	{ 0 }	(A46+2)	[355C]		11
 2801	Krikn'ee	E210000-0		Ba		003	Kk	G9 V	{ -3 }	(700-3)	[0000]		10
 2805	Akimkaa	B7926RK-F		He Ni		123	Kk	G6 V M6 V D	{ 1 }	(A56+4)	[874G]		11
-2814	Kakghatoo	B6984QK-E	K	Ni Pa		614	Kk	G7 V G5 V	{ 1 }	(B37+3)	[554E]		9
-2815	Rugr'rrra	BAD66RK-F		Ni		420	Kk	M5 V M2 V	{ 1 }	(A57+2)	[774H]		12
+2814	Kakghatoo	B6984QK-E	K	Ni Pa		614	Kk	G5 V G7 V	{ 1 }	(B37+3)	[554E]		9
+2815	Rugr'rrra	BAD66RK-F		Ni		420	Kk	M2 V M5 V	{ 1 }	(A57+2)	[774H]		12
 2816	N'lgagex	E5465QK-9	K	Ni Ag		313	Kk	A9 V	{ -1 }	(941-1)	[541B]		13
 2820	Kaagnalka	E100000-0		Va Ba		000	Kk	K5 V	{ -3 }	(700+1)	[0000]		13
 2822	Morgua	A5519RK-F	K	Hi Po		924	Kk	M8 V BD	{ 3 }	(C8A+1)	[EC4B]		14
@@ -470,7 +470,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 2919	Kr'ookrkat	E327000-0		Ba		022	Kk	M0 V BD	{ -3 }	(700+2)	[0000]		11
 2921	Unraxkat	EAA4000-0		Fl Ba		012	Kk	G8 V M8 V	{ -3 }	(400-3)	[0000]		13
 2925	Gn'rkalux	A5976RK-E	K	Ni Ag		924	Kk	M2 V	{ 2 }	(G58-2)	[284D]		11
-2930	Ankreur	E410000-0		Ba		000	Kk	M5 V M3 V	{ -3 }	(200+2)	[0000]		4
+2930	Ankreur	E410000-0		Ba		000	Kk	M3 V M5 V	{ -3 }	(200+2)	[0000]		4
 2931	Tam'rak	E5605QK-B		De Ni Pr		403	Kk	G8 III K0 V	{ -1 }	(B44-3)	[844C]		15
 2938	Ghakgneirr	B5517RK-D	K	Po		802	Kk	K6 V	{ 2 }	(568+2)	[894C]		11
 3001	Kr'ata	E449000-0		Ba		002	Kk	M9 V	{ -3 }	(500+3)	[0000]		9
@@ -491,10 +491,10 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 3027	Ighmiri	C4355QK-B	O	Ni		511	Kk	M0 V M8 V	{ 0 }	(C45-3)	[5578]		11
 3033	Kiaarir	B8687RK-E	K	Ag Ri		434	Kk	G2 V	{ 4 }	(D6F-2)	[9B2E]		15
 3034	Nekaul	E510000-0	K	Ba		022	Kk	G6 V	{ -3 }	(400-3)	[0000]		13
-3037	Uugharo	D5464QK-B		Ni Pa		603	Kk	M8 V M5 V	{ -1 }	(D35+3)	[5368]		10
+3037	Uugharo	D5464QK-B		Ni Pa		603	Kk	M5 V M8 V	{ -1 }	(D35+3)	[5368]		10
 3103	Gnattaka	B7457RK-E	K	Ag Pi		312	Kk	G7 V	{ 3 }	(D6C-2)	[AA5D]		12
 3105	Ingkrur'	C5323QK-B	K	Lo Po		800	Kk	K9 V	{ 0 }	(820-2)	[1339]		8
-3106	Muugnait	E420000-0	K	De He Ba Po		023	Kk	M6 V M4 V	{ -3 }	(600-1)	[0000]		12
+3106	Muugnait	E420000-0	K	De He Ba Po		023	Kk	M4 V M6 V	{ -3 }	(600-1)	[0000]		12
 3107	Ogromax	C6A23QK-A	O	Fl He Lo		203	Kk	M6 V M9 V BD	{ 0 }	(C20-1)	[137B]		12
 3108	Gh!'rambi	E69A2PK-7		Wa Lo		613	Kk	M6 V	{ -3 }	(710+2)	[1128]		14
 3110	Tingrran!'m	C8494QK-A	O	Ni		211	Kk	G1 IV M4 V	{ 0 }	(733+3)	[2465]		13
@@ -509,7 +509,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 3207	Apmurung	B5234QK-E	K	Ni Po		224	Kk	G2 V	{ 1 }	(D32-5)	[158E]		10
 3212	Kanarr'	C7975QK-B	O	Ni Ag		524	Kk	K6 V K7 V	{ 1 }	(845+1)	[8619]		12
 3217	Kruuka Gall	X764ACA-4		Hi (Galliph)	R	303	KC	F5 V D	{ -1 }	(697+1)	[A962]		11
-3218	Uxrakra	E230000-0	K	De Ba Po		004	Kk	M4 V M3 V	{ -3 }	(900+2)	[0000]		8
+3218	Uxrakra	E230000-0	K	De Ba Po		004	Kk	M3 V M4 V	{ -3 }	(900+2)	[0000]		8
 3219	Gn'kroka	B5897RK-F	K	Ri		614	Kk	M1 V BD M4 V	{ 3 }	(A68+1)	[CAAD]		10
 3225	Okkutat	B0002PK-C		As Va Lo		303	Kk	G2 V	{ 1 }	(911+1)	[133A]		10
 3226	Kakau	E87A000-0	K	Wa Ba		024	Kk	G4 V	{ -3 }	(400+4)	[0000]		11

--- a/res/Sectors/M1105/Ktiingzat.sec
+++ b/res/Sectors/M1105/Ktiingzat.sec
@@ -99,7 +99,7 @@ Shiimimir          2010 C647547-6 G Ag Ni Tp           112 Va F3 V
 Mizukalash         2107 B410766-8 G Na                 134 Va K8 V
 Aas Khi            2202 B8A4247-C G Fl Lo Ni           501 Va M8 V
 Kuu Nelagii        2206 B4509EG-D G Hi Po De           523 Va G9 V
-Uedoa              2208 BAC6474-8 G C1 Fl Ni           200 VC M5 V M3 V
+Uedoa              2208 BAC6474-8 G C1 Fl Ni           200 VC M3 V M5 V
 Luugkoug           2209 D510778-7   Na                 304 VC M6 V
 Matepma            2310 A98998B-B   Hi Tp              112 VC G2 V
 Irudirzukhed       2401 B440555-A   Ni Po De           300 Va K2 V
@@ -116,7 +116,7 @@ Taang              2704 C564677-4   Ag Ni              100 VC G9 V
 Luk Tzeung         2708 B764878-8   Tp St              914 VC G9 V
 End Egikerlo       2709 E567534-2 C Ag Ni              523 VC G4 V K1 V
 Cererra            2801 C534565-7   Ni                 100 Na K6 III
-Tanith Republic    2802 A410343-B   Lo Ni              801 Na M5 V M4 V M4 V
+Tanith Republic    2802 A410343-B   Lo Ni              801 Na M4 V M5 V M4 V
 Neredi             2804 B753524-A   C4 Ni Po Tp        423 VC K6 V D
 Deferrane          2806 A579787-8                      702 VC G6 V M1 V
 Rolu Rigayite      2809 C664696-8   D1 Ag Ni Ri Tp     613 VC K8 V M0 V
@@ -156,7 +156,7 @@ Ibisdiisadar       1119 B677422-6 G Ni Tp              102 Va G9 V M1 V
 Gakkimanin         1120 A663338-A   Lo Ni Tp           101 Va K6 V
 Gishzaasush        1211 B446757-9   Ag                 800 Va M0 V
 Kurusukiguluum     1319 B784987-C   Hi Tp St           914 Va F1 V
-Akamlagepmishi     1320 D989499-6 G Ni Tp              714 Va K9 V K4 V
+Akamlagepmishi     1320 D989499-6 G Ni Tp              714 Va K4 V K9 V
 Agurkurduda        1412 D465669-5 C Ag Ni Ri           100 Va K7 V
 Uu Efhenmmadh      1511 E465577-4   Ag Ni              402 Va G4 V
 Ruguulagesh        1517 A454865-8 G                    924 Va K0 V D
@@ -186,10 +186,10 @@ Milar              2114 A334413-D C Ni                 500 Va M0 V D
 Diikeme            2115 B736254-8 C C1 Lo Ni           323 Va K6 V
 Va Usotheg         2119 D8C6555-6 G Fl Ni              613 VC G2 IV
 Oizeurrgeeng       2313 D679477-3 C Ni Tp              623 VC K1 V M8 V
-Atirxitisof        2315 B343104-B G C9 Lo Ni Po        501 VC K6 V K5 V
+Atirxitisof        2315 B343104-B G C9 Lo Ni Po        501 VC K5 V K6 V
 Fuvedut Se         2317 B4147A9-B   Ic                 514 VC G5 V
 Esetranniftho      2318 E1307BE-5 C Na Po De           200 VC F7 V K8 V
-Oag Khang          2319 C41077B-A C Na                 301 VC M8 V M3 V
+Oag Khang          2319 C41077B-A C Na                 301 VC M3 V M8 V
 Fisape Aso         2320 B453353-8 G D1 Lo Ni Po        123 VC A1 V
 Pioypeutse         2414 A4281X1-A   Dw Lo Ni Rs        324 VC F6 V M9 V
 Uunbuzu            2416 B989388-8 C Lo Ni Tp           212 Va K8 V
@@ -227,13 +227,13 @@ E Reli             3115 B646786-5 G Ag Tp              302 VC G6 V M1 V
 Ceaseata           3119 D421688-7 C Na Ni Po           502 VC G5 V M9 V
 Etoyed             3213 C45379A-6   Po                 703 VC G8 V M0 V
 De De I            3214 B8A6253-D   Fl Lo Ni           501 VC M2 V
-Fagzllawghuuth     3219 C77A974-7 G Hi In Wa           723 VC K7 V K0 V
+Fagzllawghuuth     3219 C77A974-7 G Hi In Wa           723 VC K0 V K7 V
 Ueghzmadh          0126 C7A377B-7 C Fl                 100 Va M6 V
 Ka Dudiguulaa      0130 B597567-A   Ag Ni              100 Va F3 V
 Gaanakar           0225 C698210-5   Lo Ni Tp           722 Va K5 V
 Foinriraw          0229 C462300-7   Lo Ni              600 Va G6 V
 Uguerz             0424 C665875-4 G Tp                 700 Va K1 V
-Shaban             0425 C110545-9 G Ni                 401 Va M2 V M1 V
+Shaban             0425 C110545-9 G Ni                 401 Va M1 V M2 V
 Adasekaagi         0427 A655347-A G C4 Lo Ni Tp        400 Va K9 V
 I Lashaagir        0529 C338004-B   Lo Ni              102 Va F7 V D
 Uan Fhoghzigzufa   0530 A549478-B C Ni                 400 Va K3 V
@@ -293,7 +293,7 @@ Tidonefhe          2022 B635304-8 G C9 Lo Ni           200 VC M0 V M1 V
 Nonenorom          2024 A674687-A   Ag Ni Tp           303 VC A4 V K7 V G5 V
 Shashagamezurlan   2029 B8C56A6-9   Fl Ni              301 Va M2 V
 Idirkamirkushin    2030 B759356-8 G C9 Lo Ni Tp        803 Va K5 V D
-Ofesevopar         2121 A9C6497-B G Fl Ni              722 VC K5 V K4 V
+Ofesevopar         2121 A9C6497-B G Fl Ni              722 VC K4 V K5 V
 Onsukethyo         2122 B534896-6                      700 VC G9 V M5 V M8 V
 Tidethmintsi       2124 D753265-2   Lo Ni Po Tp        811 VC G7 V
 Dakhuguu           2125 B687001-C   Lo Ni              800 Va M5 V M8 V
@@ -303,7 +303,7 @@ Iriirgidiimla      2129 C444340-9 G Lo Ni              123 Va F8 V
 Ecunan             2222 C787555-A C Ag Ni Tp           220 VC K5 V
 Sotaramagu         2223 A5517CA-9 G Po                 400 VC K0 V
 Amgurnelenkap      2225 B682211-B G Lo Ni              723 Va K7 V M4 V D
-Enar Khukmuu       2226 B72968A-A   Ni                 713 Va K6 V K2 V
+Enar Khukmuu       2226 B72968A-A   Ni                 713 Va K2 V K6 V
 Iidershaam         2227 C779574-7   Ni Tp              810 Va G7 V D
 Adishaa            2228 E120459-9 C Ni Po De           814 Va F6 V
 Disikhe            2230 A22678A-D G                    224 Va A5 V G7 V
@@ -327,7 +327,7 @@ Lagular            2630 B871210-9 C Lo Ni              424 Va G0 V
 En Rahin           2723 D97A69C-7 C Ni Wa              402 VC F8 V
 Otxo               2824 C325330-7   Lo Ni              320 VC K6 V
 Uminanumakum       2827 E7A7000-0   Fl Ba Lo Ni        004 -- K4 V
-Enmuy              2921 A50258B-D   Ni Va Ic           900 VC M8 V M3 V
+Enmuy              2921 A50258B-D   Ni Va Ic           900 VC M3 V M8 V
 Doli               2924 C7B0332-A   Lo Ni De           700 VC M0 V
 Knourthog          2927 X87A87A-4 C Wa                 501 Va K1 V M3 V
 Khimgakgumdiker    2928 C765ABB-8   Hi Tn St           413 Va K7 V M9 V
@@ -355,7 +355,7 @@ Kaluunugindirlii   0231 X742556-4 C Ni Po              701 Va K1 V
 Grekroinokhoiz     0235 BAE4776-9   Fl                 802 J- K5 V
 Uen Oirr           0237 B554477-8   Ni                 702 J- K4 V M1 V
 Midbeshad          0331 A120353-G G Lo Ni Po De        823 Va A3 IV F4 V
-Sorzvinotheza      0339 B200543-A   Ni Va              500 Ef M6 V M0 V
+Sorzvinotheza      0339 B200543-A   Ni Va              500 Ef M0 V M6 V
 Mikudimarshigur    0433 C230755-7 G Na Po De           401 Va K1 V
 Igdzeng            0437 B642110-7   Lo Ni Po           703 Ef G7 V
 Egro Khusa         0438 C5868CH-8 C                    812 Ef G1 V
@@ -425,14 +425,14 @@ Irlidikhesema      2039 E534412-6   Ni                 634 Va G0 V K8 V
 Vraavruk           2131 E330576-6   Ni Po De           700 Va M0 V M8 V
 Ar Luugirir        2132 D8A3598-4   C0 Fl Ni           803 Va M0 V M2 V
 Dhuanknogorzking   2133 CAA5157-9 G Fl Lo Ni           300 Va A9 V
-Outronga           2134 A995877-C G C8 Tp              133 Va F9 V F2 V
+Outronga           2134 A995877-C G C8 Tp              133 Va F2 V F9 V
 Ga Dush            2135 C68AAEF-D   Hi Wa              400 Va K7 V D
 Gera Lukimir       2136 A400447-D G Ni Va              200 Va M5 V M7 V
 Gisuushukhur       2139 A6A0100-D G Lo Ni De           924 Va K2 V
 Kirurminurima      2232 B8B8444-A C Fl Ni              103 Va M0 V M7 V
 Kii Igan           2233 B889224-C   Lo Ni Tp           803 Va K6 V D
 Makisha            2235 C434000-9   Lo Ni              702 Va F2 V M5 V
-Ru Mikisikimme     2237 E856598-4   Ni                 903 Va M7 V M4 V
+Ru Mikisikimme     2237 E856598-4   Ni                 903 Va M4 V M7 V
 Inbugaashag        2239 B585233-6   Lo Ni              303 Va M0 V M8 V
 Ku Sharmashasha    2240 E776559-5 C Ag Ni Tn           513 Va F8 V M2 V
 Gam Nishi          2331 E593000-0   Ba Lo Ni           000 -- K2 V

--- a/res/Sectors/M1105/Nuughe.tab
+++ b/res/Sectors/M1105/Nuughe.tab
@@ -28,7 +28,7 @@ Hex	Name	UWP	Remarks	{ Ix }	( Ex )	[ Cx ]	N	B	Z	PBG	W	A	Stellar
 0322	orogeer	?160???-?	Co De  				-	-	-	111	A	Kk	F8 V K8 V
 0323	Teekr!kakr	?967???-?					-	-	-	100	C	Kk	F5 V
 0329		?624???-?	 				-	-	-	533	E	Na	G0 V G9 V
-0331		?338???-?	Co 				-	-	-	402	A	Na	G7 V G2 V
+0331		?338???-?	Co 				-	-	-	402	A	Na	G2 V G7 V
 0332		?688???-?	Tz				-	-	-	403	D	Na	M9 V D
 0333		?59A???-?	Wa				-	-	-	200	9	Na	G3 III
 0340		?200???-?	Lk Sa Va				-	-	-	530	B	Na	K2 V D
@@ -51,7 +51,7 @@ Hex	Name	UWP	Remarks	{ Ix }	( Ex )	[ Cx ]	N	B	Z	PBG	W	A	Stellar
 0520	Ghaaxkorab	?669???-?					-	-	-	621	G	Kk	F4 V
 0525		?566???-?					-	-	-	421	B	Na	F7 III
 0529		?683???-?	Sa				-	-	-	131	C	Na	M4 V
-0531		?556???-?					-	-	-	302	7	Na	G1 V G0 V K4 V M3 V D
+0531		?556???-?					-	-	-	302	7	Na	G0 V G1 V K4 V M3 V D
 0533		?130???-?	De Po Sa				-	-	-	501	A	Na	M2 V D
 0535		?533???-?	Po				-	-	-	430	C	Na	G1 V
 0606	Tr'krurit'leeraax	?200???-?	Va				-	-	-	731	E	Kk	K5 V M1 V M2 V M0 V D
@@ -118,7 +118,7 @@ Hex	Name	UWP	Remarks	{ Ix }	( Ex )	[ Cx ]	N	B	Z	PBG	W	A	Stellar
 1028		?450???-?	Co De Po				-	-	-	421	D	Na	F2 V G6 V
 1030		?560???-?	De 				-	-	-	733	D	Na	F9 V
 1032		?543???-?	Po				-	-	-	402	8	Na	K2 V
-1036		?6319EJ-?	Lk Po Sa				-	-	-	601	7	Na	G8 V G0 V K1 V K4 V
+1036		?6319EJ-?	Lk Po Sa				-	-	-	601	7	Na	G0 V G8 V K1 V K4 V
 1039		?679???-?					-	-	-	501	9	Na	K7 V M9 V M4 V
 1103	Kog	?877???-?	Lk Sa				-	-	-	301	C	Kk	K5 V D
 1104	Ghakruruuk	?534???-?	Ho Sa				-	-	-	320	D	Kk	G7 V K4 V
@@ -239,14 +239,14 @@ Hex	Name	UWP	Remarks	{ Ix }	( Ex )	[ Cx ]	N	B	Z	PBG	W	A	Stellar
 2110	Gheex!krur	?100???-?	Va				-	-	-	301	7	Kk	K1 V D
 2113	Eekukuti	?621???-?	He Po				-	-	-	330	9	K8	G0 V
 2114	Uk'ghoor!lir!	?666???-?	Ga Tz				-	-	-	400	7	K8	M5 V M6 V
-2115	KREENGOORU	?546???-?	Lk Sa				-	-	-	404	F	K8	K3 V K1 V
+2115	KREENGOORU	?546???-?	Lk Sa				-	-	-	404	F	K8	K1 V K3 V
 2116	K!lu	?373???-?					-	-	-	800	A	K8	F2 V D
 2130		?788???-?					-	-	-	122	7	Na	K7 V
 2131		?500???-?	Va				-	-	-	812	D	Na	F4 III
 2134		?434???-?	Lk Sa				-	-	-	102	A	Na	G2 IV M8 V K5 V
 2135		?456???-?					-	-	-	631	A	Na	G8 V K9 V
 2140		?248???-?	Sa				-	-	-	431	C	Na	A6 V G2 V
-2204	Roo	?56A???-?	Tz Wa				-	-	-	431	9	Kk	G8 V K5 V G1 V K0 V K2 V
+2204	Roo	?56A???-?	Tz Wa				-	-	-	431	9	Kk	G1 V K5 V G8 V K0 V K2 V
 2205	Rarrikit!!xk	?568???-?	Co				-	-	-	723	C	Kk	K1 V M6 V D
 2206	Ruuraar'lu	?332???-?	Po				-	-	-	600	7	Kk	G8 V
 2208	Kungiit	?8D8???-?					-	-	-	404	D	Kk	G1 IV M8 V M7 V
@@ -267,7 +267,7 @@ Hex	Name	UWP	Remarks	{ Ix }	( Ex )	[ Cx ]	N	B	Z	PBG	W	A	Stellar
 2335		?422???-?	He Po				-	-	-	810	9	Na	M2 II D
 2402	Ixugapukik	?495???-?	Co 				-	-	-	913	E	Kk	G0 V
 2408	Gn'lerripeel'	?488???-?					-	-	-	402	9	Kk	G3 V M5 V K4 V K2 V
-2413	Ex!reki	?866???-?	Ga Ho Tr Tz				-	-	-	922	C	KC	K7 V K0 V
+2413	Ex!reki	?866???-?	Ga Ho Tr Tz				-	-	-	922	C	KC	K0 V K7 V
 2419		?236???-?	Lk Sa				-	-	-	402	A	Na	G8 V
 2421		?210???-?	Ho Tz				-	-	-	?23	C	Na	K5 V
 2427		?775???-?					-	-	-	311	9	Na	G0 V
@@ -279,7 +279,7 @@ Hex	Name	UWP	Remarks	{ Ix }	( Ex )	[ Cx ]	N	B	Z	PBG	W	A	Stellar
 2506	Teeratukr!r'm	?567???-?	Co  				-	-	-	302	B	Kk	K2 V M0 V
 2512		?444???-?					-	-	-	231	B	Na	F0 V
 2515		?895???-?	Co Tu Tz				-	-	-	433	C	Na	M2 V M8 V D
-2516		?300???-?	Tz Va				-	-	-	313	F	Na	K9 V K3 V
+2516		?300???-?	Tz Va				-	-	-	313	F	Na	K3 V K9 V
 2518		?EDA???-?	Lk Oc Sa				-	-	-	222	B	Na	M0 V M2 V D
 2522		?434???-?					-	-	-	100	8	Na	K3 V
 2523		?454???-?					-	-	-	434	E	Na	M9 III
@@ -288,8 +288,8 @@ Hex	Name	UWP	Remarks	{ Ix }	( Ex )	[ Cx ]	N	B	Z	PBG	W	A	Stellar
 2604		?559???-?					-	-	-	602	E	Na	G3 V M2 V
 2608		?686???-?	Co Ga Tu				-	-	-	101	C	Na	A7 III A6 V
 2610		?887???-?	Ga 				-	-	-	223	B	Na	K6 V
-2613		?420???-?	De He Po				-	-	-	601	C	Na	K4 V K0 V
-2615		?320???-?	De He Lk Po Sa				-	-	-	203	9	Na	G3 V G1 V M1 V
+2613		?420???-?	De He Po				-	-	-	601	C	Na	K0 V K4 V
+2615		?320???-?	De He Lk Po Sa				-	-	-	203	9	Na	G1 V G3 V M1 V
 2616		?635???-?					-	-	-	?01	E	Na	F7 V
 2618		?335???-?	Tz				-	-	-	602	8	Na	M8 V
 2619		?665???-?	Ga Sa				-	-	-	102	7	Na	G4 V
@@ -299,7 +299,7 @@ Hex	Name	UWP	Remarks	{ Ix }	( Ex )	[ Cx ]	N	B	Z	PBG	W	A	Stellar
 2631		?994???-?	Tz				-	-	-	922	C	Na	M4 V M4 V
 2633		?763???-?	Sa				-	-	-	331	B	Na	F9 V K9 V
 2636		?654???-?	Tz				-	-	-	121	B	Na	K3 V
-2638		?99A???-?	Wa				-	-	-	102	8	Na	G5 V G4 V
+2638		?99A???-?	Wa				-	-	-	102	8	Na	G4 V G5 V
 2640		?000???-?	As				-	-	-	?10	9	Na	K1 V M4 V
 2704		?300???-?	Lk Sa Va				-	-	-	930	B	Na	F8 III
 2706		?744???-?	Ho Tr				-	-	-	100	C	Na	A8 III
@@ -337,9 +337,9 @@ Hex	Name	UWP	Remarks	{ Ix }	( Ex )	[ Cx ]	N	B	Z	PBG	W	A	Stellar
 2929		?748???-?	Co Sa				-	-	-	301	9	Na	G1 IV
 2931		?444???-?	Tz				-	-	-	200	7	Na	M1 II
 2938		?224???-?	Ho 				-	-	-	400	7	Na	F2 V
-2939		?400???-?	Va				-	-	-	401	A	Na	K8 V K5 V K7 V
+2939		?400???-?	Va				-	-	-	401	A	Na	K5 V K8 V K7 V
 3004		?656???-?	Ga Ho Tr				-	-	-	603	9	Na	G4 V M3 V
-3005		?521???-?	He Lk Po Sa				-	-	-	401	8	Na	M2 V M2 V M0 V
+3005		?521???-?	He Lk Po Sa				-	-	-	401	8	Na	M0 V M2 V M2 V
 3009		?267???-?	Co 				-	-	-	430	8	Na	M1 III D
 3016		?977???-?	Sa				-	-	-	232	D	Na	M6 II
 3023		?120???-?	De Po Sa				-	-	-	302	7	Na	M0 V D
@@ -350,7 +350,7 @@ Hex	Name	UWP	Remarks	{ Ix }	( Ex )	[ Cx ]	N	B	Z	PBG	W	A	Stellar
 3031		?8A4???-?	Fl Ho				-	-	-	?23	A	Na	A3 III
 3032		?300???-?	Va				-	-	-	711	B	Na	G0 V K0 V
 3036		?342???-?	He Po				-	-	-	904	C	Na	F2 V
-3037		?66A???-?	Wa				-	-	-	203	B	Na	G8 V M5 V G1 V
+3037		?66A???-?	Wa				-	-	-	203	B	Na	G1 V M5 V G8 V
 3102		?430???-?	De				-	-	-	801	8	Na	G2 IV
 3105		?625???-?	 				-	-	-	902	7	Na	G5 V K5 V M7 V K6 V
 3108		?200???-?	Lk Sa Va				-	-	-	501	A	Na	G6 V
@@ -367,8 +367,8 @@ Hex	Name	UWP	Remarks	{ Ix }	( Ex )	[ Cx ]	N	B	Z	PBG	W	A	Stellar
 3209		?566???-?	Sa				-	-	-	201	8	Na	F5 V
 3215		?300???-?	Va				-	-	-	601	8	Na	G8 V
 3216		?610???-?	Tz				-	-	-	632	D	Na	M4 V D
-3217		?225???-?					-	-	-	400	B	Na	K6 V K3 V D
-3225		?672???-?	He Tz				-	-	-	500	4	Na	M3 V M3 V M2 V
+3217		?225???-?					-	-	-	400	B	Na	K3 V K6 V D
+3225		?672???-?	He Tz				-	-	-	500	4	Na	M2 V M3 V M3 V
 3229		?797???-?	Lk Sa				-	-	-	631	G	Na	M1 V
 3230		?875???-?	Ho Tr Tz				-	-	-	200	6	Na	K3 V D
 3231		?943???-?	Po				-	-	-	303	E	Na	K3 V M2 V D

--- a/res/Sectors/M1105/Ruupiin.txt
+++ b/res/Sectors/M1105/Ruupiin.txt
@@ -39,7 +39,7 @@ Hex  Name            UWP       Remarks              {Ix} (Ex) [Cx] N B Z PBG W A
 0117 Netib!          E8B2000-0 Ba Fl                               - K - 023   Kk K0 V
 0119 Tr!gakengr'     C5715QK-B Ni                                  - O - 233   Kk G8 V
 0120 K'paarkt'       A74A3QK-F Lo Wa                               - - - 623   Kk M4 V BD BD
-0212 Urrar           A766A77-D Hi (Ciruwar)                        - - - 124   KC K9 V K6 V
+0212 Urrar           A766A77-D Hi (Ciruwar)                        - - - 124   KC K6 V K9 V
 0213 'Kutuu Aupa     C7A46RK-C Ni Fl                               - K - 611   Kk K7 V M5 V
 0214 Gr'uukra        A7879RK-F Hi                                  - - - 603   Kk G4 V K1 V M2 V
 0215 Gha'm'          C5336RK-D Ni                                  - K - 213   Kk G5 V M2 V M5 V
@@ -81,9 +81,9 @@ Hex  Name            UWP       Remarks              {Ix} (Ex) [Cx] N B Z PBG W A
 0222 Unokee Bur      A3629RK-F Hi                                  - - - 611   Kk M6 V
 0225 Kulogh'rr       A6787RK-F                                     - - - 123   Kk M3 V
 0322 Itruuxang       A5458RK-E Ph                                  - - - 324   Kk G3 V
-0323 Tognixra        X420000-0 Ba De                               - - R 000   Kk M9 V BD M3 V
+0323 Tognixra        X420000-0 Ba De                               - - R 000   Kk M3 V BD M9 V
 0325 R'gexki         B3113QK-D Lo                                  - K - 203   Kk G5 V
-0330 Gniirr Nu       C000597-C As Ni Ciru9 Giru1                   - K - 714   KC K5 V M4 V K2 V
+0330 Gniirr Nu       C000597-C As Ni Ciru9 Giru1                   - K - 714   KC K2 V M4 V K5 V
 0424 Ram Nikia       B454ARK-E Hi                                  - - - 113   Kk G2 V
 0425 Apaatgha        CAB62PK-A Fl                                  - K - 922   Kk A1 V F0 V
 0426 Ghalreme        D565000-6 Di (Pviri)                          - O A 002   Na G5 V K1 V
@@ -101,7 +101,7 @@ Hex  Name            UWP       Remarks              {Ix} (Ex) [Cx] N B Z PBG W A
 0825 Ka Kiikr        B410356-C Ciru9 Giru1                         - - - 920   KC M3 III
 0828 Naauutar        B7777RK-F                                     - K - 224   Kk K7 V
 0135 Aunatr'         E664000-8 Di (Hiko)                           - K R 004   Na M5 V M7 V
-0137 K'neea          E300000-0 Ba                                  - - - 022   Na M5 V M3 V M0 V
+0137 K'neea          E300000-0 Ba                                  - - - 022   Na M0 V M3 V M5 V
 0139 Chuurrra        B424531-C                                     - N - 324   K4 M0 V
 0233 R'nakuu         A8508RK-E                                     - - - 124   Kk K8 V
 0236 Rakaa Iru       X522000-5 Di (Beroda)                         - - R 014   Na M9 V
@@ -140,10 +140,10 @@ Hex  Name            UWP       Remarks              {Ix} (Ex) [Cx] N B Z PBG W A
 1001 Krookkeerai     E5323QK-A Lo                                  - - - 502   Kk M1 V
 1002 Kraghapiu       B6347RK-E                                     - K - 723   Kk M6 V
 1008 Taraoomee       B6477QK-E                                     - K - 102   Kk G0 V
-1010 Elak'kki        E210000-0 Ba                                  - - - 024   Kk K9 V K3 V M1 V
+1010 Elak'kki        E210000-0 Ba                                  - - - 024   Kk K3 V K9 V M1 V
 1101 Agn'ngtexarr    B8476RK-F Ni                                  - K - 603   Kk K0 IV
 1102 Iim'xkeembaap   B4415QK-D Ni                                  - K - 413   Kk M3 V
-1103 Rak'kara        E000000-0 As Ba                               - - R 021   Kk M8 V M4 V M7 V
+1103 Rak'kara        E000000-0 As Ba                               - - R 021   Kk M4 V M8 V M7 V
 1105 K'atriirar      B200456-D Ni GiruW                            - K - 100   Kk G5 IV
 1106 Tox'uuxrak      C6849RK-F Hi                                  - K - 322   Kk K1 V
 1107 Eeamaarkru      B7474QK-D Ni                                  - K - 222   Kk K8 V M0 V
@@ -152,7 +152,7 @@ Hex  Name            UWP       Remarks              {Ix} (Ex) [Cx] N B Z PBG W A
 1204 Tak'tagho       A8898RK-E Ph                                  - K - 421   Kk K7 V
 1205 Kuungakerrnan   E100000-0 Ba                                  - K - 022   Kk M0 V
 1207 Egigrrruta      C8A45QK-B Fl                                  - O - 423   Kk K7 V K6 V
-1208 An'rghai        E300000-0 Ba Va                               - - - 034   Kk G1 V K7 V G8 IV K3 V
+1208 An'rghai        E300000-0 Ba Va                               - - - 034   Kk G8 IV K7 V G1 V K3 V
 1301 Liitrukaxad     B6888RK-F Ph                                  - K - 200   Kk K3 V
 1302 Tekikrero       A5549RK-D Hi                                  - K - 303   Kk M2 V M6 V
 1303 Alaakum!'       C4355QK-A Ni                                  - O - 104   Kk M0 V
@@ -305,7 +305,7 @@ Hex  Name            UWP       Remarks              {Ix} (Ex) [Cx] N B Z PBG W A
 2004 Eerranlari      E100000-0 Ba Va                               - K - 004   Kk F3 V
 2006 Rarriokram      C2102PK-9 Lo Na                               - K - 413   Kk K9 V M0 V
 2007 Akiiaak         A7C23QK-E Fl Lo                               - K - 112   Kk G2 V M8 V
-2008 Kiioagh!        C4628RK-C Ph                                  - O - 302   Kk M8 V M7 V
+2008 Kiioagh!        C4628RK-C Ph                                  - O - 302   Kk M7 V M8 V
 2009 Aterrruee       E6B3000-0 Ba Fl                               - - - 002   Kk M5 V M7 V
 2101 Tukukuurrxa     B200457-D Ni Va                               - K - 422   Kk M8 V
 2102 Kilgateeguur    E6559RK-B Hi                                  - K - 211   Kk K5 V
@@ -371,7 +371,7 @@ Hex  Name            UWP       Remarks              {Ix} (Ex) [Cx] N B Z PBG W A
 1921 Tu Trargning    C6568RK-D Ph                                  - O - 133   Kk G4 V
 1927 Krahkagreel     C6374QK-C Ni                                  - - - 500   Kk K8 II
 1929 Rag Parrgho     B2226RK-E Ni Po                               - - - 123   Kk M5 V
-2021 Berteexktul     C5737RK-D                                     - O - 111   Kk M0 V M4 V M1 V
+2021 Berteexktul     C5737RK-D                                     - O - 111   Kk M0 V M1 V M4 V
 2023 Rigat Mei       A6539RK-F Hi Po                               - K - 415   Kk F5 V
 2026 Tilux Nua       E000000-0 As Va                               - - - 002   Kk M0 V
 2027 Kralaprrak      A6365QK-F Ni                                  - K - 314   Kk K4 V
@@ -380,7 +380,7 @@ Hex  Name            UWP       Remarks              {Ix} (Ex) [Cx] N B Z PBG W A
 2124 Gzeek Aru       B4275QK-E Ni                                  - - - 610   Kk M9 V M2 V
 2223 R!!gnugh        A7926RK-D Ni                                  - K - 503   Kk M8 V
 2226 Tur' Larkru     B7794QK-C Ni                                  - K - 732   Kk M5 V
-2321 Kuuxgnua        E100000-0 Ba Na Va                            - K - 020   Kk M7 V M0 V
+2321 Kuuxgnua        E100000-0 Ba Na Va                            - K - 020   Kk M0 V M7 V
 2325 Kee Anarrag     E5527RK-A Po                                  - - - 623   Kk M2 V
 2326 Rroorratruu     C6466RK-C Ni                                  - K - 300   Kk M2 V
 2327 Mangla Ika      E9C9000-0 Fl                                  - - - 023   Kk M7 IV M6 V
@@ -413,7 +413,7 @@ Hex  Name            UWP       Remarks              {Ix} (Ex) [Cx] N B Z PBG W A
 2136 Pab Axtuumr'    B7949RK-E Hi In                               - K - 213   Kk G0 V
 2138 Kam 'Ata        B5335QK-B Ni Po                               - - - 224   Kk K6 III M7 V
 2139 Ghoorr          A75A7RK-E Wa                                  - - - 124   Kk M3 V BD
-2140 Kart'ka         E110000-0 Ba Na                               - K - 013   Kk M8 V M1 V
+2140 Kart'ka         E110000-0 Ba Na                               - K - 013   Kk M1 V M8 V
 2233 Makrikoor       B5746RK-D Ag Ni                               - - - 103   Kk G1 V M5 V
 2235 Xartuugrla      B9765QK-C Ag Ni                               - K - 112   Kk G6 V D
 2237 Eeakrorr        C4302PK-9 De Lo Na Po                         - - - 103   Kk M7 V M0 V
@@ -459,11 +459,11 @@ Hex  Name            UWP       Remarks              {Ix} (Ex) [Cx] N B Z PBG W A
 2516 Axtuukaa        A4778RK-F Ph                                  - K - 224   Kk K6 V
 2520 Kr'k!ka         C3254QK-A                                     - K - 514   Kk G1 V G2 V
 2611 Tekaakrgzagr    E3222PK-9 Lo Na Po                            - - - 114   Kk A2 V
-2612 Gh'rreerra      D6686RK-B Ni                                  - - - 512   Kk M8 V M7 V
+2612 Gh'rreerra      D6686RK-B Ni                                  - - - 512   Kk M7 V M8 V
 2613 Tuugami         E200000-0 Ba Va                               - - - 014   Kk M1 V
 2615 N'magha         C99A874-6 Ph Wa (Numnill)                     - K A 432   KC A4 IV
 2617 Raturrkre       A6448RK-F Ph                                  - K - 304   Kk M6 V
-2711 Xt'tagi         E7C0000-0 Ba De                               - - - 011   Kk M4 V M1 V
+2711 Xt'tagi         E7C0000-0 Ba De                               - - - 011   Kk M1 V M4 V
 2713 Gzagn!!luk      A3256RK-F Ni                                  - K - 113   Kk K5 V
 2716 M!atra Nu       B000568-D As Na Giru6 Rakk4                   - K - 214   Kk K7 IV
 2717 R'eeuu          C5476RK-B Ni                                  - O - 900   Kk M4 V BD BD
@@ -511,7 +511,7 @@ Hex  Name            UWP       Remarks              {Ix} (Ex) [Cx] N B Z PBG W A
 2823 Kr'gzikar       A5326RK-F Ic Na Va                            - K - 424   Kk K5 V M9 V
 2824 Roogheegha      B73A2PK-A Lo Wa                               - K - 124   Kk M3 V
 2825 Ighant't        A4104QK-F Ni                                  - K - 410   Kk G3 V K5 V
-2830 Atrua 'R'prak   E510000-0 Ba                                  - K - 014   Kk K7 V K0 V K8 V
+2830 Atrua 'R'prak   E510000-0 Ba                                  - K - 014   Kk K0 V K7 V K8 V
 2921 Ta'kaat         B78A6RK-E Ni Ri Wa                            - - - 412   Kk K8 IV M4 V
 2922 Kagnarrtul      B6948RK-F Ph                                  - - - 714   Kk F7 V
 2924 Ukarrx'         C7A54QK-B Fl Ni                               - O - 803   Kk G8 V
@@ -548,14 +548,14 @@ Hex  Name            UWP       Remarks              {Ix} (Ex) [Cx] N B Z PBG W A
 2831 Irrakri         B94A3QK-C Lo Wa                               - K - 100   Kk K4 V
 2832 Kak'g'rr        E8C3000-0 Ba Fl                               - K - 022   Kk M4 V
 2837 Agnuughuur      C7746RK-C Ni                                  - - - 123   Kk K9 V
-2935 'Rakghar        DA785QK-9 Ag                                  - K - 413   Kk K3 V K6 V K0 V
+2935 'Rakghar        DA785QK-9 Ag                                  - K - 413   Kk K0 V K6 V K3 V
 2936 Gaguka          E87A000-0 Ba Wa                               - - - 034   Kk M9 V BD BD
 2938 Tuurgraaa       E510000-0 Ba                                  - - - 024   Kk K4 V M4 V
 3031 Uuregax         B5A15QK-F Ni Fl                               - K - 114   Kk K9 V K7 V
 3033 Aana T'aa       B655ARK-F Ag Ni                               - - - 424   Kk K0 V M6 V
 3034 Ragugnii        D8B35QK-B Fl Ni                               - O - 410   Kk K9 V M9 V K2 V
 3036 K'xr'kri        B4628RK-F Ph                                  - - - 823   Kk K2 IV
-3037 'Naaghuu        A4004QK-F Ni Va                               - K - 713   Kk M8 V M1 V M6 V M4 V
+3037 'Naaghuu        A4004QK-F Ni Va                               - K - 713   Kk M1 V M8 V M6 V M4 V
 3040 Tiuka           C4756RK-D Ni                                  - - - 204   Kk G2 V
 3131 Atruuta         B3567RK-F Ag                                  - O - 220   Kk M0 V
 3133 Uraka Eerir'    E200000-0 Ba Va                               - - - 025   Kk M0 V M3 V

--- a/res/Sectors/M1105/X'kug.txt
+++ b/res/Sectors/M1105/X'kug.txt
@@ -24,11 +24,11 @@ Hex  Name                         UWP       Remarks                             
 0606 Kruang                       C3006BG-A Na Ni Va                                                         -       -  - 504   K4   K1 V M0 V                           
 0608 Igtuamake                    C433512-A Ni Po                                                            -       -  - 124   K4   K9 IV                              
 0610 Krtiruat                     A56A69A-D Ni Ri Wa                                                         -       N  - 424   K4   K1 V                                
-0701 Taraxa                       A5447RK-F Ag Pi                                                            -       K  - 523   Kk   M5 V M0 V                           
+0701 Taraxa                       A5447RK-F Ag Pi                                                            -       K  - 523   Kk   M0 V M5 V                           
 0705 Reehksh                      A867699-C Ag Ga Ni Ri                                                      -       N  - 324   K4   M0 V                                
 0707 Tilua                        C43277B-A Na Po                                                            -       -  - 701   K4   M8 IV M5 V                         
 0710 Karkarlan                    C100200-C Lo Va                                                            -       -  - 624   K4   G3 V K1 V                           
-0801 Xuxkgukar                    E100000-0 Ba Va                                                            -       -  - 213   Kk   M7 V M1 V                           
+0801 Xuxkgukar                    E100000-0 Ba Va                                                            -       -  - 213   Kk   M1 V M7 V                           
 0802 Utinxiraa                    D9B54QK-A Fl Ni                                                            -       O  - 223   Kk   M9 V                                
 0803 Oot!r                        B884ARK-F Hi                                                               -       K  - 624   Kk   K2 V M0 V                           
 0806 Keeua                        E551453-5 Ni Po                                                            -       -  - 511   K4   M5 V                                
@@ -37,11 +37,11 @@ Hex  Name                         UWP       Remarks                             
 0809 Ignal                        E8B5665-9 Fl Ni O:1011                                                     -       -  - 424   K4   M1 V M5 V                           
 0810 Garansh                      B300310-D Lo Va                                                            -       -  - 714   K4   K5 V                                
 0901 Axarkata                     C6649RK-E Hi Pr                                                            -       -  - 313   Kk   M3 V                                
-0906 Treuaka                      C310561-9 Ni Cy O:1107                                                     -       -  - 201   K4   M4 V M3 V                           
+0906 Treuaka                      C310561-9 Ni Cy O:1107                                                     -       -  - 201   K4   M3 V M4 V                           
 0907 Ktuamat                      E777524-6 Ag Ni                                                            -       -  - 203   K4   K3 IV K5 V                          
 0909 Ltikrua                      B7B0669-B He Ni O:1107                                                     -       -  - 823   K4   M1 V M9 V                           
 0910 Naa Paghti                   C555A88-A Hi                                                               -       -  - 123   K4   G8 V                                
-1003 Tagn'akan                    A200557-D Ni Va GiruW                                                      -       K  - 404   KC   M7 V M1 V                           
+1003 Tagn'akan                    A200557-D Ni Va GiruW                                                      -       K  - 404   KC   M1 V M7 V                           
 1007 Kaktuak                      C5459BA-7 Hi In                                                            -       -  - 511   K4   K8 V                                
 1009 Tuaaa                        BABA665-B Fl Ni                                                            -       -  - 214   K4   K4 IV                               
 1102 U!!ghuu                      E210000-0 Ba                                                               -       -  - 002   Kk   K9 V M6 V                           
@@ -65,7 +65,7 @@ Hex  Name                         UWP       Remarks                             
 1310 Re Llakt                     C311411-A Ic Ni                                                            -       -  - 304   K4   K6 V                                
 1402 Agraghke                     D100458-A Ni Va Hagh4 Giru6                                                -       K  - 223   KC   M1 V                                
 1404 Mbur'ng                      A1003QK-E Lo Va                                                            -       K  - 402   Kk   G0 V                                
-1405 R!n!t                        D5415QK-A He Ni Po                                                         -       O  - 112   Kk   G8 V G7 V D                         
+1405 R!n!t                        D5415QK-A He Ni Po                                                         -       O  - 112   Kk   G7 V G8 V D                         
 1408 Hgak'u                       A310455-D Ni                                                               -       -  - 125   K4   K0 V K1 V                           
 1502 Trungkroo                    B4236RK-F Na Ni Po                                                         -       K  - 203   Kk   K7 V M1 V                           
 1503 Eerrat                       B2102PK-D Lo                                                               -       O  - 821   Kk   K2 IV                               
@@ -87,7 +87,7 @@ Hex  Name                         UWP       Remarks                             
 1910 Tikrial'                     B8948RK-F Pa Ph Pi                                                         -       K  - 514   Kk   K9 V                                
 2002 Raghatuugh                   C5569RK-D Hi                                                               -       O  - 325   Kk   K1 IV                               
 2004 Rakiu                        E100000-0 Ba Va                                                            -       -  - 002   Kk   K2 V M4 V                           
-2008 Ighitaa                      A868887-D Pa Ph Ri (Hagh'hg'k)                                             -       K  - 624   Kk   K9 V K2 V M6 V                      
+2008 Ighitaa                      A868887-D Pa Ph Ri (Hagh'hg'k)                                             -       K  - 624   Kk   K2 V K9 V M6 V                      
 2103 Piimkta                      D5877RK-D Ag Ri                                                            -       K  - 234   Kk   G2 V                                
 2105 Keekkat'ru                   A7888RK-F Pa Ph Ri                                                         -       K  - 721   Kk   K1 V                                
 2202 Trarut!'                     B200658-A Na Ni Va Giru4 Hagh4 Xaru                                        -       O  - 301   Kk   M8 V BD                             
@@ -111,26 +111,26 @@ Hex  Name                         UWP       Remarks                             
 2602 K'lao Hkau                   C000557-C As Ni Va Hagh5 Ciru3                                             -       K  - 225   Kk   K6 V                                
 2604 Kragaoo                      D4244QK-A Ni                                                               -       K  - 110   Kk   K5 V                                
 2605 Imbak                        C5224QK-C He Ni Po                                                         -       K  - 700   Kk   M2 V                                
-2606 Hkakgataa                    A7689RK-F Hi Pr                                                            -       K  - 823   Kk   M4 V M2 V                           
+2606 Hkakgataa                    A7689RK-F Hi Pr                                                            -       K  - 823   Kk   M2 V M4 V                           
 2608 Kehkig                       C9B46RK-C Fl Ni                                                            -       K  - 112   Kk   M3 V                                
 2609 P'toog                       D6484QK-B Ni Pa                                                            -       K  - 403   Kk   G0 V G9 V                           
 2610 Kronn'rr                     B100758-A Na Pi Va                                                         -       -  - 204   Kk   K7 V                                
 2701 Roweng                       C5365QK-C Ni                                                               -       K  - 611   Kk   M0 V                                
 2702 K'lao Tanoorr                A0004QK-F Ni As Va                                                         -       K  - 432   Kk   F2 V                                
-2706 Kiarru                       A4226QK-F He Na Ni Po                                                      -       K  - 624   Kk   A5 V A2 V                           
+2706 Kiarru                       A4226QK-F He Na Ni Po                                                      -       K  - 624   Kk   A2 V A5 V                           
 2708 Kr'gnag'                     C9A56RK-D Fl Ni                                                            -       K  - 302   Kk   G4 V M1 V                           
 2709 Reteerhki                    B6768RK-F Pa Ph Pi                                                         -       O  - 124   Kk   K5 V                                
 2801 Grarkarurr                   E300000-0 Ba Va                                                            -       -  - 924   Kk   K7 V M1 V                           
 2804 Ixingxata                    C765ARK-E Ga Hi                                                            -       K  - 404   Kk   K5 V M3 V                           
 2807 Kaxegnul                     B7255QK-E Ni                                                               -       K  - 334   Kk   K3 V                                
-2809 Laalak                       B4102PK-C Lo                                                               -       K  - 701   Kk   F6 V G0 V D F1 V K4 V               
+2809 Laalak                       B4102PK-C Lo                                                               -       K  - 701   Kk   F1 V G0 V D F6 V K4 V               
 2810 Tatost                       C7569RK-F Ga Hi                                                            -       O  - 203   Kk   G9 V K3 V M5 V                      
 2901 Ateernara                    B5956RK-F Ag Ni                                                            -       O  - 424   Kk   M6 V                                
 2903 Oqran                        C5355QK-B Ni                                                               -       -  - 700   Kk   K1 V                                
 2905 K'xat                        C5727RK-C He Pi                                                            -       -  - 610   Kk   K9 V                                
 2909 Ranaghrii                    B5629RK-F Hi Pr                                                            -       K  - 125   Kk   G7 V                                
 2910 Mbakrrakar                   D4224QK-A He Ni Po                                                         -       K  - 525   Kk   G4 V                                
-3006 Karikirruut                  A2001PK-C Lo Va                                                            -       -  - 503   Kk   M4 V M6 V M1 V                      
+3006 Karikirruut                  A2001PK-C Lo Va                                                            -       -  - 503   Kk   M1 V M6 V M4 V                      
 3007 Truuteea                     C5539RK-D Hi Po                                                            -       K  - 221   Kk   K2 V M4 V                           
 3008 Kiikak!                      C510412-A Ni                                                               -       K  - 911   Kk   G0 V                                
 3009 Tuughkak                     D5425QK-A He Ni Po                                                         -       O  - 602   Kk   A4 V K5 V                           
@@ -145,8 +145,8 @@ Hex  Name                         UWP       Remarks                             
 3204 Bakk'gnakak                  C7967RK-D Ag Pi                                                            -       O  - 314   Kk   M6 V                                
 3205 Dranendia                    B8598RK-F Ph                                                               -       -  - 724   KC   K1 V                                
 3207 Ghatargoo                    B555ARK-F Hi                                                               -       K  - 434   Kk   G8 V                                
-3209 Iila                         EAB8000-0 Ba Fl                                                            -       O  - 000   Kk   M2 V M1 V                           
-3210 Xkuxtarr                     C5538RK-C Ph Po                                                            -       -  - 723   Kk   G4 V G3 V                           
+3209 Iila                         EAB8000-0 Ba Fl                                                            -       O  - 000   Kk   M1 V M2 V                           
+3210 Xkuxtarr                     C5538RK-C Ph Po                                                            -       -  - 723   Kk   G3 V G4 V                           
 0113 T'tenga                      D5757AA-6 Ag Pi                                                            -       -  - 513   K4   M6 V                                
 0115 Kralel                       C565768-8 Ag Ri O:0215                                                     -       -  - 212   K4   K2 V                                
 0120 Ltigna                       A655572-D Ag Ga Ni                                                         -       N  - 412   K4   K6 V                                
@@ -157,7 +157,7 @@ Hex  Name                         UWP       Remarks                             
 0220 Naa Kariti                   BA78220-B Lo (Kariti)                                                      -       -  A 200   K4   M2 V                                
 0313 Itara                        B855878-A Ga Pa Ph                                                         -       N  - 824   K4   G6 V                                
 0314 Kehkig                       C401000-0 Ba Ic Va                                                         -       -  - 001   K4   M7 V BD                             
-0315 Kaalirr                      C200778-A Na Pi Va                                                         -       -  - 522   K4   M5 V M4 V                           
+0315 Kaalirr                      C200778-A Na Pi Va                                                         -       -  - 522   K4   M4 V M5 V                           
 0317 Tarkuu                       C300533-A Ni Va                                                            -       -  - 900   K4   A4 V                                
 0319 Gaaluaua                     C000666-B As Na Ni Va O:0419                                               -       N  - 400   K4   G5 V                                
 0411 Akrua                        D300420-8 Ni Va                                                            -       -  - 101   K4   A1 V                                
@@ -168,7 +168,7 @@ Hex  Name                         UWP       Remarks                             
 0419 Alee                         A300552-D Ni Va                                                            -       N  - 802   K4   M2 IV                               
 0420 Atalua                       E7B3000-0 Ba Fl                                                            -       -  - 024   K4   M0 V                                
 0514 Meen                         E8B3000-0 Ba Fl                                                            -       -  - 023   K4   F9 V G4 V G5 V                      
-0517 Gagkua                       A647646-C Ag Ni                                                            -       N  - 312   K4   K8 V K3 V                           
+0517 Gagkua                       A647646-C Ag Ni                                                            -       N  - 312   K4   K3 V K8 V                           
 0518 Extala                       B676407-C Ni Pa                                                            -       -  - 900   K4   K8 V M0 V M9 V                      
 0519 Grakagrum                    D553201-4 Lo Po (Grumm)                                                    -       -  A 623   K4   A6 V D                              
 0612 Kireegh                      D412668-8 Ic Na Ni O:0615                                                  -       -  - 314   K4   K8 V M0 V                           
@@ -177,10 +177,10 @@ Hex  Name                         UWP       Remarks                             
 0615 Akritua                      A453776-D Po                                                               -       -  - 204   K4   K8 V                                
 0616 Chtuarri                     C88A7BB-9 Ri Wa                                                            -       N  - 112   K4   K9 V M4 V M4 V                      
 0617 Gra Grat                     B44588A-A Pa Ph Pi                                                         -       -  - 522   K4   M3 IV                               
-0618 Araghan                      A546501-D Ag Ni                                                            -       N  - 623   K4   M6 V M3 V                           
+0618 Araghan                      A546501-D Ag Ni                                                            -       N  - 623   K4   M3 V M6 V                           
 0620 Naa Kuax                     C767898-8 Ga Pa Ph Ri (Klethfoline)                                        -       -  - 723   K4   G8 V                                
 0714 Ghaikhu                      C300877-8 Na Ph Pi Va                                                      -       -  - 413   K4   F3 V K5 V                           
-0717 Geegritan                    B983989-C Hi Pr                                                            -       -  - 203   K4   M5 V M0 V                           
+0717 Geegritan                    B983989-C Hi Pr                                                            -       -  - 203   K4   M0 V M5 V                           
 0720 Rhuu Tana                    C68379C-7 Ri                                                               -       -  - 612   K4   K1 V                                
 0811 Ookh Algha                   B210586-D Ni                                                               -       N  - 111   K4   M1 V M5 V M6 V                      
 0812 Naa Xothkarr                 C658566-6 Ag Ni O:0613                                                     -       -  - 412   K4   M7 V                                
@@ -205,10 +205,10 @@ Hex  Name                         UWP       Remarks                             
 1418 Retix' Niri                  A88A7RK-E Ri Wa                                                            -       K  - 502   Kk   F6 V                                
 1511 Tigatru                      CA5A761-A Oc O:1508                                                        -       -  - 400   K4   G5 V G9 V                           
 1518 Uukreeg!                     E9A5000-0 Ba Fl                                                            -       -  - 012   Kk   M5 V M6 V                           
-1520 Rixeextuxaa                  A3A04QK-F He Ni                                                            -       O  - 634   Kk   M8 V M1 V                           
+1520 Rixeextuxaa                  A3A04QK-F He Ni                                                            -       O  - 634   Kk   M1 V M8 V                           
 1616 Okiaakak                     E310000-0 Ba                                                               -       -  - 000   Kk   M5 III BD                           
-1617 Muu K'lao                    E9A8000-0 Ba Fl                                                            -       -  - 023   Kk   M9 V M0 V                           
-1618 Xukkaarkaa                   B656ARK-F Ga Hi                                                            -       K  - 104   Kk   K6 V K3 V                           
+1617 Muu K'lao                    E9A8000-0 Ba Fl                                                            -       -  - 023   Kk   M0 V M9 V                           
+1618 Xukkaarkaa                   B656ARK-F Ga Hi                                                            -       K  - 104   Kk   K3 V K6 V                           
 1620 Tirur!                       C7466RK-C Ag Ni                                                            -       K  - 903   Kk   M0 V M3 V                           
 1711 Uhkuxan                      E100000-0 Ba Va                                                            -       -  - 012   Kk   M8 V                                
 1712 Aagale                       C97A557-B Ni Wa GiruW                                                      -       O  - 122   Kk   G2 V K0 V                           
@@ -225,7 +225,7 @@ Hex  Name                         UWP       Remarks                             
 1914 Tiikakkamux                  E7C0000-0 Ba He                                                            -       -  - 002   Kk   G8 V                                
 1915 K'era                        B4568RK-F Pa Ph                                                            -       K  - 314   Kk   M3 V                                
 1916 !Ruxpan                      E6745QK-A Ag Ni                                                            -       K  - 323   Kk   A5 V                                
-1917 Kooxat                       C2002PK-9 Lo Va                                                            -       K  - 412   Kk   M9 V M7 V                           
+1917 Kooxat                       C2002PK-9 Lo Va                                                            -       K  - 412   Kk   M7 V M9 V                           
 2012 Akeeutak                     A2004QK-E Ni Va                                                            -       K  - 422   Kk   G0 V                                
 2013 Talatrit'k                   C0002PK-C Lo As Va                                                         -       K  - 614   Kk   M4 V                                
 2015 Ukrirakan                    C98A5QK-C Ni Pr Wa                                                         -       O  - 412   Kk   G1 V                                
@@ -244,16 +244,16 @@ Hex  Name                         UWP       Remarks                             
 2316 Xuukui                       A6688RK-F Pa Ph Ri                                                         -       K  - 700   Kk   K3 V                                
 2317 Uhkii                        A666ARK-F Ga Hi                                                            -       O  - 322   Kk   G7 V M2 V G9 V                      
 2318 Gnekrparr                    E430000-0 Ba De Po                                                         -       O  - 004   Kk   M3 V M4 V                           
-2319 Geta Kagu                    CAA46RK-D Fl Ni                                                            -       K  - 211   Kk   G8 V G6 V                           
+2319 Geta Kagu                    CAA46RK-D Fl Ni                                                            -       K  - 211   Kk   G6 V G8 V                           
 2320 Tekeel'                      B8345QK-E Ni                                                               -       O  - 800   Kk   K7 IV M6 V                          
 2411 Naxra Nuu                    E200000-0 Ba Va                                                            -       -  - 704   Kk   G4 V                                
 2415 Gheeka                       C8356RK-D Ni                                                               -       K  - 121   Kk   F1 IV G4 V                          
 2416 Akaarruum                    C9992PK-8 Lo                                                               -       O  - 225   Kk   K1 III M6 V                         
-2418 Xularre                      E100000-0 Ba Va                                                            -       -  - 004   Kk   M4 V M2 V                           
-2513 Niri Kretagn'                E89A000-0 Ba Wa                                                            -       K  - 415   Kk   F5 V F4 IV M1 V                     
+2418 Xularre                      E100000-0 Ba Va                                                            -       -  - 004   Kk   M2 V M4 V                           
+2513 Niri Kretagn'                E89A000-0 Ba Wa                                                            -       K  - 415   Kk   F4 IV F5 V M1 V                     
 2514 Lingtooka                    B782ARK-F Hi                                                               -       -  - 924   Kk   M9 V                                
 2516 Xothkarr                     C2112PK-8 Ic Lo                                                            -       O  - 721   Kk   F3 V                                
-2517 Aleekit                      BA7A4QK-C Ni Oc                                                            -       O  - 200   Kk   M6 V M3 V                           
+2517 Aleekit                      BA7A4QK-C Ni Oc                                                            -       O  - 200   Kk   M3 V M6 V                           
 2519 Gn'gunom                     E9B2000-0 Ba Fl He                                                         -       K  - 021   Kk   M7 V                                
 2612 Gan Mbaai                    C100457-A Ni Va Giru7 Hagh3                                                -       -  - 403   KC   G8 V                                
 2613 Larkanu                      C5425QK-A He Ni Po                                                         -       O  - 610   Kk   A5 V A7 V G0 V                      
@@ -285,9 +285,9 @@ Hex  Name                         UWP       Remarks                             
 2920 Algha                        A3384QK-D Ni                                                               -       -  - 210   Kk   M5 V                                
 3011 Noortu                       B585ARK-E Hi                                                               -       -  - 213   Kk   M5 V                                
 3012 Ghaxkalee                    E200000-0 Ba Va                                                            -       -  - 024   Kk   G2 V                                
-3017 Gnatakaa                     E5424QK-9 He Ni Po                                                         -       -  - 922   Kk   M5 V M1 V M5 V                      
+3017 Gnatakaa                     E5424QK-9 He Ni Po                                                         -       -  - 922   Kk   M1 V M5 V M5 V                      
 3020 Mirrui                       B2225QK-D Ni Po                                                            -       K  - 423   Kk   K3 V                                
-3114 Gnaakrirkaga                 E310000-0 Ba                                                               -       -  - 722   Kk   F4 V D A3 V                         
+3114 Gnaakrirkaga                 E310000-0 Ba                                                               -       -  - 722   Kk   A3 V D F4 V                         
 3116 Graktanak                    A5427RK-F He Pi Po                                                         -       -  - 603   Kk   G8 V                                
 3118 Nat Agrita                   E200000-0 Ba Va                                                            -       -  - 002   Kk   M3 IV M6 V BD                       
 3119 Nen'rreer                    E8A0000-9 Di(Hes'fis'Tan) He                                               -       -  - 020   Kk   K5 V                                
@@ -301,17 +301,17 @@ Hex  Name                         UWP       Remarks                             
 0121 Ghilataph                    B100589-D Ni Va                                                            -       N  - 522   K4   G3 V                                
 0124 Xukikka                      E200000-0 Ba Va                                                            -       K  - 001   Kk   K5 V M8 V                           
 0125 Ixkuka                       B5627RK-F Ri                                                               -       -  - 124   Kk   K5 IV K3 V M7 V                     
-0127 Luukixkeer                   X673000-1 Di (Uulip)                                                       -       -  R 924   Kk   M7 V M2 V                           
+0127 Luukixkeer                   X673000-1 Di (Uulip)                                                       -       -  R 924   Kk   M2 V M7 V                           
 0221 Kagnuap                      D5247A7-7 Pi                                                               -       -  - 313   K4   G4 V                                
 0223 Inilud                       B5869RK-F Hi Pr                                                            -       K  - 514   Kk   M0 V M3 V                           
 0227 Kueetoorting                 B663ARK-F Hi                                                               -       -  - 320   Kk   M8 V                                
 0228 Kr'kr'k                      D5484QK-A Ni Pa                                                            -       K  - 902   Kk   K5 V                                
 0229 Ikala                        B4558RK-E Pa Ph                                                            -       K  - 414   Kk   M7 III M2 V                         
-0230 Gzurruri                     C6736RK-C Ni                                                               -       -  - 134   Kk   A4 V G0 IV                          
+0230 Gzurruri                     C6736RK-C Ni                                                               -       -  - 134   Kk   G0 IV A4 V                          
 0321 Aktuakob                     C687375-8 Ga Lo                                                            -       -  - 823   K4   G4 V                                
 0324 Kakikreel                    E8B1000-0 Ba Fl He                                                         -       -  - 014   Kk   F7 V                                
 0326 Keex'ghutrap                 C6775QK-D Ag Ni                                                            -       -  - 233   Kk   M5 V                                
-0427 Hkunakka                     C200557-C Ni Va (GiruW)                                                    -       K  - 302   Kk   G9 V G4 V                           
+0427 Hkunakka                     C200557-C Ni Va (GiruW)                                                    -       K  - 302   Kk   G4 V G9 V                           
 0428 Ekagh!                       B7868RK-F Ga Pa Ph Ri                                                      -       K  - 301   Kk   G8 IV                               
 0521 Karkamo                      C654531-7 Ag Ni                                                            -       -  - 503   K4   K4 IV                               
 0522 Tuahkarr                     C300554-A Ni Va                                                            -       -  - 603   K4   M4 V BD                             
@@ -325,7 +325,7 @@ Hex  Name                         UWP       Remarks                             
 0725 N!kurul                      A3101PK-C Lo                                                               -       K  - 514   Kk   K9 V                                
 0728 Ikrorikar                    C5639RK-D Hi Pr                                                            -       K  - 800   Kk   K0 V                                
 0822 Kax'rat                      B656ARK-F Ga Hi                                                            -       K  - 622   Kk   F1 V                                
-0828 Kruurakra                    E200000-0 Ba Va                                                            -       K  - 434   Kk   M5 V M0 V M7 V                      
+0828 Kruurakra                    E200000-0 Ba Va                                                            -       K  - 434   Kk   M0 V M5 V M7 V                      
 0830 M'gharu                      A6579RK-F Ga Hi                                                            -       -  - 500   Kk   G6 V                                
 0921 Rakriiktar                   E6A0000-0 Ba He                                                            -       -  - 005   Kk   M6 V                                
 0927 N'akung                      C5426RK-D He Ni Po                                                         -       O  - 724   Kk   F4 V                                
@@ -365,7 +365,7 @@ Hex  Name                         UWP       Remarks                             
 1527 Leegugh'                     C3114QK-B Ni Ic                                                            -       K  - 323   Kk   K7 V K9 V                           
 1528 Puaxe                        B7405QK-D De He Ni Po                                                      -       K  - 835   Kk   M3 V                                
 1530 Ukeeta                       D5426RK-B He Ni Po                                                         -       K  - 124   Kk   G0 V D M2 V                         
-1622 Raabakan                     B5747RK-F Ag Pi                                                            -       O  - 404   Kk   G6 V M7 V G9 IV                     
+1622 Raabakan                     B5747RK-F Ag Pi                                                            -       O  - 404   Kk   G9 IV M7 V G6 V                     
 1624 K!!lai                       B7A25QK-D Fl He Ni                                                         -       K  - 704   Kk   M5 V                                
 1627 T'xiirr                      C5639RK-E Hi Pr                                                            -       K  - 401   Kk   F6 V K3 V                           
 1629 P'reri                       C6747RK-C Ag Pi                                                            -       K  - 502   Kk   G5 V                                
@@ -382,7 +382,7 @@ Hex  Name                         UWP       Remarks                             
 1924 Xukuoonarr                   E300000-0 Ba Va                                                            -       K  - 000   Kk   K8 V                                
 1925 Aaxtataan                    C6539RK-D Hi Po                                                            -       O  - 604   Kk   K5 V                                
 1926 Karat                        E310000-0 Ba                                                               -       K  - 021   Kk   M0 V                                
-1927 Traxe Katak                  B000658-C As Na Ni Va Hagh7 Giru3                                          -       -  - 433   KC   M8 V M6 V                           
+1927 Traxe Katak                  B000658-C As Na Ni Va Hagh7 Giru3                                          -       -  - 433   KC   M6 V M8 V                           
 1930 Rukra                        B8668RK-E Ga Pa Ph Ri                                                      -       K  - 802   Kk   M1 V M1 V                           
 2021 Anli Gzuu                    B554ARK-E Hi                                                               -       K  - 502   Kk   M6 V BD                             
 2027 Gnilria                      E100000-0 Ba Va                                                            -       -  - 024   Kk   K4 V                                
@@ -392,7 +392,7 @@ Hex  Name                         UWP       Remarks                             
 2121 Taanakku                     D86A4QK-A Ni Wa                                                            -       O  - 801   Kk   K3 V                                
 2123 Akraxruu                     E310000-0 Ba                                                               -       K  - 024   Kk   M0 V M1 V BD                        
 2124 Krukest                      B7668RK-F Ga Pa Ph Ri                                                      -       -  - 402   Kk   K7 IV                               
-2128 Grakrar                      C5464QK-A Ni Pa                                                            -       -  - 803   Kk   M1 V M0 V                           
+2128 Grakrar                      C5464QK-A Ni Pa                                                            -       -  - 803   Kk   M0 V M1 V                           
 2130 Ribaa Irau                   C5446RK-C Ag Ni                                                            -       -  - 624   Kk   K5 V                                
 2221 Kooria                       B7458RK-F Pa Ph Pi                                                         -       -  - 213   Kk   K6 V M5 V D M2 V                    
 2222 Akoo                         X535773-0 (S'geth)                                                         -       -  R 202   KC   K0 V                                
@@ -406,7 +406,7 @@ Hex  Name                         UWP       Remarks                             
 2427 Kring Pangta                 A8888RK-F Pa Ph Ri                                                         -       K  - 313   Kk   M7 V                                
 2428 Nixarnur                     B9EA774-8 Wa (Ruorrii)                                                     -       -  - 223   Kk   K5 V M5 V                           
 2525 Kritatir                     E200000-0 Ba Va                                                            -       -  - 000   Kk   K1 V                                
-2526 Gakinita                     B6384QK-B Ni                                                               -       K  - 701   Kk   M8 V M5 V                           
+2526 Gakinita                     B6384QK-B Ni                                                               -       K  - 701   Kk   M5 V M8 V                           
 2622 Uxula Nuat                   D6465QK-A Ag Ni                                                            -       K  - 124   Kk   M9 V BD                             
 2623 O'grarr                      C7848RK-D Pa Ph Ri                                                         -       K  - 312   Kk   M5 V                                
 2624 Lanau                        EAB7000-0 Ba Fl                                                            -       K  - 023   Kk   M3 V M9 V                           
@@ -422,7 +422,7 @@ Hex  Name                         UWP       Remarks                             
 2822 Uaka Iaghee                  B5484QK-C Ni Pa                                                            -       K  - 303   Kk   M9 V                                
 2824 Ghautor                      C5437RK-B Pi Po                                                            -       K  - 400   Kk   G2 V M9 V                           
 2825 Mor!kra                      C6253QK-A Lo                                                               -       O  - 122   Kk   K0 V                                
-2828 Nognanin                     A4124QK-F Ic Ni                                                            -       O  - 824   Kk   M4 V M0 V                           
+2828 Nognanin                     A4124QK-F Ic Ni                                                            -       O  - 824   Kk   M0 V M4 V                           
 2829 Aak!nar                      D5765QK-B Ag Ni                                                            -       K  - 322   Kk   M8 IV                              
 2923 Ka Toghack                   B7659RK-F Ga Hi Pr                                                         -       K  - 314   Kk   K8 V                                
 2927 Ktilai                       E100000-0 Ba Va                                                            -       K  - 024   Kk   K5 V                                
@@ -435,7 +435,7 @@ Hex  Name                         UWP       Remarks                             
 3126 Lxrutat                      E4A0000-0 Ba He                                                            -       -  - 000   Kk   G4 V                                
 3128 Aanaru                       E300000-0 Ba Va                                                            -       -  - 023   Kk   M7 V                                
 3223 Oakap Ema                    E430000-0 Ba De Po                                                         -       -  - 000   Kk   K1 V M6 V                           
-3226 Ghikri                       B66A5QK-D Ni Pr Wa                                                         -       -  - 724   Kk   M5 V M0 V                           
+3226 Ghikri                       B66A5QK-D Ni Pr Wa                                                         -       -  - 724   Kk   M0 V M5 V                           
 0133 Xikuul                       C6766RK-D Ag Ni                                                            -       -  - 910   Kk   F7 V                                
 0136 N'gha                        E210000-0 Ba                                                               -       K  - 322   Kk   G1 V                                
 0233 Kr'kirii                     D9B34QK-B Fl Ni                                                            -       K  - 423   Kk   M3 V                                
@@ -482,7 +482,7 @@ Hex  Name                         UWP       Remarks                             
 1333 K!aga                        E200000-0 Ba Va                                                            -       -  - 024   Kk   K7 V M4 V M9 V                      
 1334 Raruuga                      D7725QK-A He Ni                                                            -       K  - 323   Kk   M1 V M6 V                           
 1336 Nilula                       B5957RK-F Ag Pi                                                            -       K  - 922   Kk   K3 IV                               
-1431 K!nikett'                    A687ARK-F Ga Hi                                                            -       K  - 124   Kk   M4 V M2 V                           
+1431 K!nikett'                    A687ARK-F Ga Hi                                                            -       K  - 124   Kk   M2 V M4 V                           
 1432 Niri Natak                   A98A7RK-E Ri Wa                                                            -       -  - 202   Kk   K6 V                                
 1433 Eeghanun                     E100000-0 Ba Va                                                            -       -  - 003   Kk   K6 V                                
 1434 K'tinook                     E8B0000-0 Ba He                                                            -       K  - 010   Kk   G9 V                                
@@ -514,13 +514,13 @@ Hex  Name                         UWP       Remarks                             
 2231 Kaalaa                       C6754QK-B Ni Pa                                                            -       -  - 912   Kk   G5 V                                
 2232 'Xaagil                      B412558-B Ic Ni Giru4 Hagh6                                                -       K  - 224   KC   M2 V                                
 2240 K'bunakkra                   B9775QK-D Ag Ni                                                            -       K  - 811   Kk   K1 IV M8 V                          
-2336 Kirkragr                     C5356RK-C Ni                                                               -       -  - 720   Kk   K3 V K2 V                           
+2336 Kirkragr                     C5356RK-C Ni                                                               -       -  - 720   Kk   K2 V K3 V                           
 2337 Klao 'Aka                    A0004QK-F As Ni Va                                                         -       K  - 620   Kk   K7 V                                
 2338 Unakee                       C5354QK-A Ni                                                               -       O  - 125   Kk   K1 V                                
 2339 Uahkakraa                    E300000-0 Ba Va                                                            -       -  - 024   Kk   K2 V                                
 2431 Gniiurit                     B4023QK-D Ic Lo Va                                                         -       K  - 134   Kk   K4 V                                
 2440 Eekaakruung                  A9879RK-F Hi Pr                                                            -       K  - 822   Kk   K2 V                                
-2531 L!raataa                     B3324QK-C Ni Po                                                            -       K  - 302   Kk   G6 V G3 V                           
+2531 L!raataa                     B3324QK-C Ni Po                                                            -       K  - 302   Kk   G3 V G6 V                           
 2532 Naaril                       A89A5QK-E Ni Wa                                                            -       K  - 900   KC   G2 V M2 V                           
 2533 Ekruk                        E200000-0 Ba Va                                                            -       -  - 015   Kk   K0 V M7 V                           
 2534 G'k'lirr                     C8435QK-A Ni Po                                                            -       K  - 824   Kk   G0 V                                
@@ -535,7 +535,7 @@ Hex  Name                         UWP       Remarks                             
 2831 Kughular                     A6678RK-F Ga Pa Ph Ri                                                      -       K  - 802   Kk   M6 V                                
 2832 Magakrarrni                  A7679RK-E Ga Hi Pr                                                         -       K  - 301   Kk   M1 V                                
 2834 Etugra                       E5313QK-A Lo Po                                                            -       -  - 400   Kk   G6 V                                
-2837 Kr'knakati                   E300000-0 Ba Va                                                            -       -  - 600   Kk   K9 V K2 V M7 V                      
+2837 Kr'knakati                   E300000-0 Ba Va                                                            -       -  - 600   Kk   K2 V K9 V M7 V                      
 2838 Gaangruui                    C6877RK-C Ag Ga Ri                                                         -       K  - 400   Kk   K7 V                                
 2839 Miiurak                      C5436RK-D Ni Po                                                            -       K  - 822   Kk   K8 V                                
 2840 Nereck                       C5549RK-E Hi                                                               -       K  - 525   Kk   K6 V M9 V                           
@@ -550,7 +550,7 @@ Hex  Name                         UWP       Remarks                             
 3036 Kr!aku                       E410000-0 Ba                                                               -       -  - 000   Kk   G1 V                                
 3039 Gharot'                      C7775QK-A Ag Ni                                                            -       K  - 823   Kk   K3 V M2 V                           
 3040 Aa'ktun                      A5468RK-F Pa Ph Pi                                                         -       K  - 403   Kk   G0 V                                
-3131 Garuram                      E5744QK-9 Ni Pa                                                            -       -  - 702   Kk   M6 V M4 V M9 V                      
+3131 Garuram                      E5744QK-9 Ni Pa                                                            -       -  - 702   Kk   M4 V M6 V M9 V                      
 3132 Eekegni                      E7252PK-A Lo                                                               -       -  - 714   Kk   M6 V                                
 3133 Klisusia                     B777775-9 Ag Pi (Susmata)                                                  -       K  - 223   KC   M9 V                                
 3134 Etoorrla                     E420000-0 Ba De He Po                                                      -       -  - 015   Kk   M4 V                                


### PR DESCRIPTION
@inexorabletash asked me to, when submitting bulk sector-data fixen, break up said fixen PRs into different classes of sectors, so here goes with squaring up the stellar data in the sectors by Jim Kundert.
I'm not making any deliberate attempt to canonicalise star sizes as per T5.10 Book 3 p 28.

In this PR, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, system star is swapped to the primary.