### PR TITLE
Fix stellar data in Zhodani sectors, round 1

### DIFF
--- a/res/Sectors/M1105/Eiaplial.tab
+++ b/res/Sectors/M1105/Eiaplial.tab
@@ -78,7 +78,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 0613	Broshzhensh	B41089A-B	KM	Ph Na Pi		520	ZhMe	G7 V	{ 3 }	(779+3)	[8B5D]		9
 0614	Zhdiechplia	C7A6988-9		Fl Hi In		100	ZhMe	K1 V K4 V	{ 2 }	(88E-2)	[AB35]		11
 0616	Plabrkier	C66487C-7	KM	Ph Pa Ri		122	ZhMe	G9 V	{ 1 }	(87B-2)	[8959]		11
-0619	Shakiavinch	X7B1000-0		Fl He Ba	F	003	ZhMe	K9 VI M4 VI K1 VI	{ -3 }	(600+2)	[0000]		11
+0619	Shakiavinch	X7B1000-0		Fl He Ba	F	003	ZhMe	K1 VI M4 VI K9 VI	{ -3 }	(600+2)	[0000]		11
 0620	Shajzdenchta	C5699DB-9		Hi Pr		123	ZhMe	M9 V BD BD M3 VI	{ 1 }	(D89-3)	[CA26]		14
 0714	Fozhenkiebld	E857874-4		Ga Ph Pa		200	ZhMe	M6 II M6 VI BD	{ -2 }	(478-3)	[C691]		9
 0715	Iepldliap	C575868-8		Ph Pa Pi		213	ZhMe	G5 V M9 VI M8 VI	{ -1 }	(F72+3)	[673C]		13
@@ -90,13 +90,13 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 0817	Etsdrnshdi	C66AAC7-B		Wa Hi		121	ZhMe	A9 V F8 V	{ 2 }	(699+1)	[5C78]		11
 0818	Tleqlianzh	D000789-8		As Va Na Pi		623	ZhMe	K4 V	{ -2 }	(B67-1)	[7529]		11
 0819	Reqlzhdea	X000000-0		As Va Ba	F	000	ZhMe	K6 V	{ -3 }	(600-1)	[0000]		9
-0911	Zhde'shtinj	B547647-A	KM	Ni Ag		125	ZhMe	A7 V A3 V	{ 3 }	(C54-4)	[8948]		14
+0911	Zhde'shtinj	B547647-A	KM	Ni Ag		125	ZhMe	A3 V A7 V		{ 3 }	(C54-4)	[8948]		14
 0913	Jichdrietl	B5539B8-7		Hi Po		923	ZhMe	K0 V	{ 1 }	(988-2)	[AA95]		12
 0915	Shiantie	C566845-8		Ph Pa Ri		834	ZhMe	K3 IV K9 VI BD	{ 0 }	(D72+0)	[C85A]		16
 0917	Tlrdla	B6668C7-8		Ga Ph Pa Ri		413	ZhMe	G1 V G0 VI G3 VI	{ 1 }	(87D+2)	[C936]		13
 0918	Echzi	A0008CE-C		As Va Ph Na Pi		514	ZhMe	M4 V	{ 2 }	(975+5)	[5A39]		13
 0919	Ninzhshter	A7626AD-B		Ni Ri		112	ZhMe	K5 V BD	{ 2 }	(655+1)	[8819]		12
-1011	Entsshodrep	B68A999-C		Wa Hi Pr		221	ZhMe	K9 VI K2 VI M0 VI	{ 3 }	(88A-4)	[8C4E]		11
+1011	Entsshodrep	B68A999-C		Wa Hi Pr		221	ZhMe	K2 VI K9 VI M0 VI	{ 3 }	(88A-4)	[8C4E]		11
 1012	Iaedl	A632445-D	D	Ni Po		433	ZhMe	K3 V	{ 2 }	(C36+0)	[362A]		13
 1014	Ilrevchtin	B000799-B		As Va Na Pi		123	ZhMe	G4 V D	{ 2 }	(G67+0)	[693E]		15
 1017	Chiejaze	A766554-C	D	Ga Ni Ag Pr		925	ZhMe	G9 V	{ 3 }	(D46-3)	[787F]		16
@@ -178,7 +178,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 3012	Zenchdref	A647669-8	KM	Ni Ag		125	ZhMe	K3 III	{ 1 }	(E54-2)	[3787]		12
 3014	Anzhej	A525655-E		Ni		312	ZhMe	K7 V M3 VI K0 VI	{ 1 }	(C52-2)	[474E]		12
 3020	Tlibrdish	A654769-C	KM	Ag		635	ZhMe	M6 V BD BD	{ 4 }	(K6B-2)	[BB5D]		14
-3112	Vrecha	C524887-8		Ph Pi		110	ZhMe	G6 VI G8 VI G0 VI	{ -1 }	(771+0)	[374C]		8
+3112	Vrecha	C524887-8		Ph Pi		110	ZhMe	G0 VI G8 VI G6 VI	{ -1 }	(771+0)	[374C]		8
 3113	Bievransh	X528000-0		Ba	F	012	ZhMe	G1 IV M3 V	{ -3 }	(B00+4)	[0000]		12
 3114	Naiaqrtla	B531754-A	KM	Na Po		322	ZhMe	M3 V D D BD	{ 3 }	(A69+1)	[2A4D]		15
 3116	Zhiedlazdi	A87A666-B		Wa Ni		724	ZhMe	M6 II D M0 V	{ 1 }	(H54+0)	[676A]		14
@@ -235,7 +235,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 2126	Brria	A7A4445-D		Fl Ni		223	ZhMe	G0 II	{ 1 }	(G37+1)	[952B]		10
 2221	Enshchtiadrd	X526000-0		Ba	F	003	ZhMe	G4 V	{ -3 }	(A00+1)	[0000]		11
 2223	Vleshiezhden	A8D6866-C	KM	Ph		112	ZhMe	K8 V M1 VI	{ 3 }	(979+1)	[7B5D]		13
-2224	Ezhsha	B55978A-B	KM			712	ZhMe	M6 VI M3 VI BD	{ 3 }	(868+0)	[6A6E]		16
+2224	Ezhsha	B55978A-B	KM			712	ZhMe	M3 VI M6 VI BD	{ 3 }	(868+0)	[6A6E]		16
 2226	Zdiantseienzh	B100999-F	KM	Va Hi Na In		102	ZhMe	M3 V M6 VI	{ 5 }	(68A-4)	[BE2J]		11
 2229	Dle'il	B44278C-A		He Pi Po		323	ZhMe	G8 V D	{ 2 }	(965+0)	[599C]		13
 2327	Rezhja'	B6A2768-A	KM	Fl He		200	ZhMe	F7 V	{ 3 }	(86B-1)	[6A59]		12
@@ -253,7 +253,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 2527	Lobliabr	B512551-8	KM	Ic Ni		323	ZhMe	M7 V BD BD	{ 0 }	(944+0)	[7575]		12
 2529	Ibrosa	A242779-C	D	Pi Po		404	ZhMe	G3 V	{ 3 }	(B66-2)	[4A3A]		13
 2626	Stablanj	A583745-B		Ri		133	ZhMe	K0 IV	{ 3 }	(C69+1)	[4A19]		19
-2721	Tlelniabr	E000569-9		As Va Ni		104	ZhMe	A7 V A6 V K6 VI	{ -2 }	(B40-2)	[7327]		9
+2721	Tlelniabr	E000569-9		As Va Ni		104	ZhMe	A6 V A7 V K6 VI	{ -2 }	(B40-2)	[7327]		9
 2722	Iebr	A52499C-F	KM	Hi In		113	ZhMe	M3 II	{ 5 }	(989+0)	[9E6F]		14
 2724	Zdika	A67579B-C		Ag Pi		103	ZhMe	G1 II K9 V	{ 3 }	(869+2)	[6AAA]		11
 2726	Chrshedr	A8338CA-A	KM	Ph Na Po		424	ZhMe	F1 V G7 VI	{ 3 }	(A7E+4)	[9B4B]		18
@@ -278,7 +278,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 3224	Srptier	C693798-6		Pi		103	ZhMe	A5 V G2 VI	{ -1 }	(565+2)	[9667]		14
 3228	Minzhblinzh	B6B3545-A	KM	Fl Ni		500	ZhMe	F8 V G7 VI	{ 2 }	(947+5)	[178D]		6
 3229	Fleqlqlashch	B662488-B	KM	Ni		114	ZhMe	G9 V M5 VI M8 VI M6 VI K8 VI	{ 2 }	(A35-3)	[466C]		13
-0133	Qlavrr-28	X683000-0		Ba		000	NaXX	G7 V D G0 V	{ -3 }	(A00-3)	[0000]		4
+0133	Qlavrr-28	X683000-0		Ba		000	NaXX	G0 V D G7 V	{ -3 }	(A00-3)	[0000]		4
 0136	Zdiaztl-73	X7B7000-0		Fl Ba		014	NaXX	G4 V M9 VI	{ -3 }	(600+2)	[0000]		15
 0231	Iplpaf	X766000-0		Ga Ba		024	NaXX	G3 V	{ -3 }	(300+0)	[0000]		14
 0332	Breentebr-1	X586000-0		Ba		033	NaXX	F9 IV G9 V	{ -3 }	(600+2)	[0000]		16

--- a/res/Sectors/M1105/Sidiadl.tab
+++ b/res/Sectors/M1105/Sidiadl.tab
@@ -16,7 +16,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 1003	Rerkleblmie	X555000-0		Ba		021	NaXX	M4 V	{ -3 }	(B00-2)	[0000]		13
 1105	Plrbl-17	X689000-0		Ba		002	NaXX	M6 V	{ -3 }	(700+2)	[0000]		14
 1208	Pied-35	X200000-0		Va Ba		002	NaXX	K8 V	{ -3 }	(900+1)	[0000]		11
-1210	Ieshjepenshi	X654000-0		Ba		024	NaXX	F9 V F4 V G8 V	{ -3 }	(900+0)	[0000]		14
+1210	Ieshjepenshi	X654000-0		Ba		024	NaXX	F4 V F9 V G8 V	{ -3 }	(900+0)	[0000]		14
 1306	Iezhklienz	X641000-0		He Ba Po		033	NaXX	G3 IV M5 V	{ -3 }	(600+0)	[0000]		10
 1308	Iaieqr-47	X532000-0		Ba Po		010	NaXX	A5 II G9 VI	{ -3 }	(400-1)	[0000]		5
 1410	Ietpl-92	X568000-0		Ba		022	NaXX	K2 IV BD D	{ -3 }	(600+2)	[0000]		14
@@ -81,7 +81,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 0618	Ieqlninch-5	X9B5000-0		Fl Ba		014	NaXX	A4 III D F5 V	{ -3 }	(900-3)	[0000]		11
 0713	Shtodr-59	X656000-0		Ga Ba		021	NaXX	M4 III	{ -3 }	(900-2)	[0000]		11
 0912	Tlarqief	X8B0000-0		He Ba		003	NaXX	G3 IV G4 V K1 VI	{ -3 }	(A00-3)	[0000]		16
-0913	Onzhqriechch	X627000-0		Ba		021	NaXX	G9 V M8 VI G4 V	{ -3 }	(400+3)	[0000]		11
+0913	Onzhqriechch	X627000-0		Ba		021	NaXX	G4 V M8 VI G9 V	{ -3 }	(400+3)	[0000]		11
 1011	Abrpredlavrz	X427000-0		Ba		003	NaXX	K1 V K6 VI BD	{ -3 }	(600+1)	[0000]		9
 1014	Iadrdlaq	X685000-0		Ga Ba		002	NaXX	M8 II BD	{ -3 }	(500-1)	[0000]		12
 1015	Ieshsiench	X100000-0		Va Ba		024	NaXX	M8 V BD	{ -3 }	(A00-4)	[0000]		15
@@ -94,7 +94,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 1216	Dlrn-72	X679000-0		Ba		024	NaXX	G6 V	{ -3 }	(500+4)	[0000]		17
 1217	Fanzhmi'tlazh	C421578-7		He Ni Po		104	NaHu	G2 V K4 VI G8 V	{ -2 }	(741-2)	[5315]		9
 1219	Iapria-47	X86A000-0		Wa Ba		000	NaXX	G9 V K2 VI K8 VI	{ -3 }	(800+1)	[0000]		8
-1316	Rzhets-74	X634000-0		Ba		023	NaXX	G8 V M2 V G6 V K8 VI	{ -3 }	(B00+1)	[0000]		12
+1316	Rzhets-74	X634000-0		Ba		023	NaXX	G6 V M2 V G8 V K8 VI	{ -3 }	(B00+1)	[0000]		12
 1319	Blef-22	X98A000-0		Wa Ba		000	NaXX	F1 V	{ -3 }	(900+1)	[0000]		7
 1320	Ianzhzhosh	X627000-0		Ba		000	NaXX	G2 V	{ -3 }	(400+0)	[0000]		7
 1411	Plalqliapl	X8B7000-0		Fl Ba		004	NaXX	G2 V M5 VI	{ -3 }	(A00+2)	[0000]		13
@@ -111,7 +111,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 1818	Qetsniem	X541000-0		He Ba Po		000	NaXX	G4 IV G7 V	{ -3 }	(600+0)	[0000]		11
 1820	Zdanshpifedr	X626000-0		Ba		012	NaXX	M9 V M5 VI	{ -3 }	(700+4)	[0000]		13
 1913	Qrepr-48	X576000-0		Ba		024	NaXX	K1 V M0 VI	{ -3 }	(600+1)	[0000]		13
-1914	Deziad-87	X642000-0		He Ba Po		020	NaXX	K5 V D K0 V BD	{ -3 }	(500-1)	[0000]		10
+1914	Deziad-87	X642000-0		He Ba Po		020	NaXX	K0 V D K5 V BD	{ -3 }	(500-1)	[0000]		10
 1915	Pidlinshdlie	X776000-0		Ba		000	NaXX	G3 V G9 VI	{ -3 }	(400-1)	[0000]		11
 1918	Zdeqpanshkrr	X622000-0		He Ba Po		010	NaXX	A4 V	{ -3 }	(600+0)	[0000]		13
 1920	Frdanj	E454863-7		Ph Pa		923	NaHu	G9 V	{ -2 }	(C75-2)	[4668]		10
@@ -156,7 +156,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 3215	Tliaiadl	X523000-0		Ba Po		022	NaXX	G1 V K3 VI K3 VI M8 VI	{ -3 }	(900+1)	[0000]		12
 3218	Evrzheprev	C685477-4		Ga Ni Pa		821	ZhMe	K9 V	{ -2 }	(630+3)	[3244]		10
 3219	Evkriezmienj	X556000-0		Ba	F	012	ZhMe	F8 V	{ -3 }	(500-2)	[0000]		7
-0126	Sieflat	X202000-0		Ic Va Ba		000	NaXX	M5 V M1 V	{ -3 }	(700+1)	[0000]		7
+0126	Sieflat	X202000-0		Ic Va Ba		000	NaXX	M1 V M5 V	{ -3 }	(700+1)	[0000]		7
 0127	Azhzdi-56	X633000-0		Ba Po		023	NaXX	K8 V	{ -3 }	(700+0)	[0000]		16
 0129	Drtlia-82	X764000-0		Ba		004	NaXX	G8 V M7 VI M0 VI M2 VI	{ -3 }	(500+1)	[0000]		15
 0221	Chtia-19	X421000-0		He Ba Po		024	NaXX	G0 V M7 VI	{ -3 }	(500-1)	[0000]		16
@@ -215,7 +215,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 1930	Lienians	X675000-0		Ba		025	NaXX	G2 V K4 VI	{ -3 }	(800-1)	[0000]		16
 2023	Qrazhkra	D667475-2		Ga Ni Pa	A	122	NaHu	G7 V	{ -3 }	(630+4)	[7161]		11
 2024	Ekchtad-81	X110000-0		Ba		000	NaXX	A3 Ia	{ -3 }	(300-3)	[0000]		7
-2027	Brabltlikr	X665000-0		Ga Ba		013	NaXX	G6 V G7 V G0 V	{ -3 }	(700+4)	[0000]		11
+2027	Brabltlikr	X665000-0		Ga Ba		013	NaXX	G0 V G7 V G6 V	{ -3 }	(700+4)	[0000]		11
 2030	Krartspliana	D855455-4		Ga Ni Pa		104	ZhMe	K8 V	{ -3 }	(830+3)	[5125]		8
 2126	Chepzdi	X566000-0		Ba		010	NaXX	F3 III F1 V	{ -3 }	(500+2)	[0000]		9
 2129	Vieen	X545000-0		Ba		003	NaXX	F6 VI G4 VI	{ -3 }	(800-5)	[0000]		10
@@ -308,7 +308,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 1736	Shiazi	A520445-E	KM	De He Ni Po		503	ZhMe	M1 II	{ 2 }	(938+2)	[163K]		9
 1737	Dijiekr	A100656-F	KM	Va Ni Na		400	ZhMe	G1 V	{ 2 }	(A56-1)	[385F]		5
 1832	Dianzhdo	A552447-D	KM	Ni Po		614	ZhMe	K2 V	{ 2 }	(D34-1)	[365H]		14
-1833	Shtrvrpiadrc	C5459DA-6		Hi In		314	ZhMe	K9 V K5 V	{ 1 }	(48B+1)	[BA44]		9
+1833	Shtrvrpiadrc	C5459DA-6		Hi In		314	ZhMe	K5 V K9 V	{ 1 }	(48B+1)	[BA44]		9
 1834	Jonjqie	A444685-B		Ni Ag		422	ZhMe	G8 V	{ 2 }	(E53+0)	[685A]		14
 1835	Zhiache'	C594459-6		Ni Pa		823	ZhMe	K0 V	{ -2 }	(830-2)	[6297]		15
 1837	Chtieie	C636A75-8		Hi		324	ZhMe	F0 III	{ 0 }	(997-2)	[7A16]		15

--- a/res/Sectors/M1105/Tsadra.sec
+++ b/res/Sectors/M1105/Tsadra.sec
@@ -49,7 +49,7 @@ Allegiance:
 #PlanetName   Loc. UPP Code   B   Notes         Z  PBG Al LRX *
 #----------   ---- ---------  - --------------- -  --- -- --- ---
               0102 X8A3000-0    Ba Fl Ni           313 Na G4V
-              0107 X69A000-0    Ba Ni Wa           911 Na M8V M3V
+              0107 X69A000-0    Ba Ni Wa           911 Na M3V M8V
               0110 X7A7000-0    Ba Fl Ni           403 Na G3II
               0204 X748000-0    Ba Ni              603 Na M3V
               0301 X210000-0    Ba Ni Po           125 Na K1IV
@@ -59,7 +59,7 @@ Allegiance:
               0310 X100000-0    Ba Ni Va           101 Na M4V
               0402 X596000-0    Ag                 722 Na M0V M8V
               0406 XA6A000-0    Ba Ni Wa           410 Na F0V
-              0408 X520000-0    Ba De Ni Po        112 Na M6V M2V
+              0408 X520000-0    Ba De Ni Po        112 Na M2V M6V
               0410 X468000-0    Ba Ni              424 Na F5V
               0503 X976000-0    Ba Ni              522 Na M8V
 ADRABLAR      0505 A867954-B  A Ag Hi In Cp        202 Na G3IV
@@ -85,7 +85,7 @@ Shitrav       0907 C511427-8  M Ic Ni              702 Na M2V M2V
 Zhobard       0910 C6A6531-7    Ag Fl Ni           400 Tn M1V M2V M3V
 Yieleba       1002 C766310-5  M Lo Ni              310 Na M7V
 Capistra      1009 C8B7000-0    Ba Fl Lo Ni        411 Na G8V M5V
-Izmali        1101 X320000-0    Ba De Ni           804 Na M3V M0V
+Izmali        1101 X320000-0    Ba De Ni           804 Na M0V M3V
 Lavelier      1104 A777530-B  N Ag Ni              702 Ed G6V
 Chaviets      1107 B352553-C  N Ni Po              220 Ed M9V
 Mietle        1110 C987659-9    Ri                 423 Tn M6V
@@ -94,7 +94,7 @@ Monteselo     1203 D513264-7    Ic Lo Ni           512 Na G3V
 Senjakr       1205 B867876-B    Ag Ri              103 Ed M8V
 Piza          1207 B000357-9  M As Lo Ni        R  500 Ed F0V
 Dubrovnik     1209 A7566B9-B  N Lo Ni              912 Tn G0V M7V
-Milan         1305 B343679-8    Po                 504 Ed M8V M1V
+Milan         1305 B343679-8    Po                 504 Ed M1V M8V
 Shrek         1310 C9678A5-B    Ri Ni              202 Tn M2III
 Quasi         1401 B795484-7    Ni                 414 Ed M1V M6V
 Iachav        1402 B8A7652-A  N Ag Fl Ni           213 Ed G2V
@@ -127,9 +127,9 @@ Pummerin      1903 B445634-8    Ag Ni              221 Ed M5V
 DOLENS        1904 B6759CA-B  A Hi In              410 Ed M3IV
 TSAR          1905 D5449DB-5    Hi In              802 Ed F9V
 Geert         1907 B655400-B    Ni                 422 Ed M2V
-Sigismund     2003 B554730-9    Ag                 512 Ed M9V F2V
+Sigismund     2003 B554730-9    Ag                 512 Ed F2V M9V
 Bongdeoksa    2005 B535463-A    Ni                 101 Ed K2III
-NOTRE DAME    2006 C8B69A7-A    Fl Hi In           922 Ed F7V M1IV
+NOTRE DAME    2006 C8B69A7-A    Fl Hi In           922 Ed M1IV F7V
 Cha           2101 B6437C8-9  Z Po                 403 Zh G3IV
 Gloriosa      2106 A9EA573-D  D Fl Ni Wa           100 Ed F4V
 Vie           2110 E210300-9    Lo Ni              714 Na M2III
@@ -137,16 +137,16 @@ Tiadesi       2202 B87659A-B  Z Ag Ni              312 Zh M3IV
 Lutine        2205 B101303-C  N Ic Lo Ni Va        114 Ed F2III
 NEXRABL       2206 C856AE9-9    Hi In              103 Ed M8V
 TASH          2207 A88A954-D  A Hi In Wa Cp        504 Ed M6V
-Dlebavien     2210 E375215-5    Lo Ni              713 Na M9V M6D
+Dlebavien     2210 E375215-5    Lo Ni              713 Na M6V M9V
 Nebadle       2304 C86A679-8    Ni Ri Wa           214 Zh M5V
 Viesiensh     2309 E66796B-7    Hi In              123 Zh M3V
-Chatsie       2310 B73A658-B  Z Ni Wa              200 Zh M8Iv
-Elba          2401 C665543-6    Ag Ni              800 Zh F4v
+Chatsie       2310 B73A658-B  Z Ni Wa              200 Zh M8IV
+Elba          2401 C665543-6    Ag Ni              800 Zh F4V
 Neenjtsi      2404 B557742-8    Ag                 405 Zh F2IV
 EKR           2405 D638ABB-9    Hi In              302 Zh M6V
-Zdietlie      2406 A455688-D  Y Ag Ni              221 Zh K2III M3D
+Zdietlie      2406 A455688-D  Y Ag Ni              221 Zh K2III M3V
 Stia          2408 B999224-A    Lo Ni              814 Zh F7V
-Jdezhdle      2409 C974785-8    Ag                 714 Zh G3V M1D
+Jdezhdle      2409 C974785-8    Ag                 714 Zh G3V M1V
 Ozdleietsba   2410 B753264-7    Lo Ni Po           204 Zh M7V
 
 @SUB-SECTOR D: Driaflzha SECTOR: Tsadra
@@ -158,12 +158,12 @@ IDETIDLER     2501 C8A5ADE-C    Fl Hi In           715 Zh G2V
 Piprebia      2502 C120359-B    De Lo Ni Po        301 Zh F3III
 JDE           2503 D411AC9-9    Hi Ic In Na        304 Zh M1IV
 Intsdients    2504 B588324-8    Lo Ni              111 Zh G7V
-Zhdrvie       2505 E579637-5    Ni                 420 Zh M9V M7D
+Zhdrvie       2505 E579637-5    Ni                 420 Zh M7V M9V
 Brimedr       2508 E98746B-2    Ni                 213 Zh G4V
 PLI           2604 B3459ED-A  Z Hi In              401 Zh M7V
 Tsiadle       2606 C520413-8    De Ni              814 Zh M6V
 Fezhdrejlep   2609 B200766-B    Na Va              921 Zh K3IV
-Chtamiesdle   2610 C585742-3    Ag Ri              903 Zh F8V M2D
+Chtamiesdle   2610 C585742-3    Ag Ri              903 Zh F8V M2V
 Chamediet     2703 C7595AB-5    Ni                 511 Zh M2III
 Basaidients   2705 C6862C3-6    Lo Ni              414 Zh M4IV
 Tiazhdr       2707 C110537-B    Ni                 203 Zh M3V
@@ -177,7 +177,7 @@ Bazhed        2910 C84857A-6    Ag Ni              905 Zh F6V
 SIEDLESI      3003 AA99966-C  Z Hi In Wa           700 Zh G4V
 Ozhdr         3101 D546466-5    Ni                 303 Zh K2III
 Vle           3102 A593410-D  Z Ni                 702 Zh M5V
-SHITA         3103 C4839A6-A    Hi In              812 Zh F3V M2IV
+SHITA         3103 C4839A6-A    Hi In              812 Zh M2IV F3V
 Stiedle       3105 B311483-9    Ic Ni              602 Zh K7V
 DRIAFLZHA     3108 A987999-D  Y Hi In Ri Cp        114 Zh F6V
 FLEBASI       3203 D5A6956-A    Fl Hi In           500 Zh M7V
@@ -202,7 +202,7 @@ Sizhdriet     3209 A000775-F  r As Na              204 Zh K4V
               0415 X343000-0    Ba Ni Po           323 Na M1v
               0417 X696000-0    Ba Ni              213 Na G2V
               0419 X687000-0    Ba Ni              413 Na M3II
-              0511 X635000-0    Ba Ni              402 Na M8V M1D
+              0511 X635000-0    Ba Ni              402 Na M1V M8V
               0512 X799000-0    Ba Ni Wa           502 Na M7v
               0516 X8A7000-0    Ba Fl Ni           802 Na G2IV
               0518 X630000-0    Ba De Ni           713 Na M1V M3V
@@ -245,9 +245,9 @@ EJIEK         1415 C546988-5    Hi In              803 Tn M4V
 Bramez        1418 B53278B-7    Na Po              513 Tn K3V
 Staaluncri    1515 B400310-8    Lo Ni Va           822 Tn M3V
 Kedrellie     1517 C748303-8    Lo Ni              504 Tn F1V
-Pipequal      1520 A876624-C  N Ag Ni              713 Tn M7V M2D
+Pipequal      1520 A876624-C  N Ag Ni              713 Tn M2V M7V
 Chantseria    1611 C243300-A    Lo Ni Po           802 Tn K0V
-Serenesan     1614 A630878-B  N De Na Po           201 Tn M6V F1V
+Serenesan     1614 A630878-B  N De Na Po           201 Tn F1V M6V
 Altiea        1618 C948554-9    Ag Ni              313 Tn M2III
 
 @SUB-SECTOR G: Lisheen SECTOR: Tsadra
@@ -300,7 +300,7 @@ FREZHDR       2512 C6E696E-5    Hi In              113 Zh M6IV
 Plensfozh     2513 B797653-B  Z Ag Ni              914 Zh F9v
 Vlel          2515 E1103A7-A    Lo Ni              523 Zh M7V
 Chadzhebl     2517 B6766A7-9    Ag Ni              413 Zh M3V
-Iplmiek       2611 B100223-D  r Lo Ni Va           902 Zh M8V F1V
+Iplmiek       2611 B100223-D  r Lo Ni Va           902 Zh F1V M8V
 Bridapabr     2612 B463466-7    Ni                 812 Zh K3V
 Fletzlich     2613 B275658-B    Ag Ni              524 Zh M3V M3V
 ZHEDEBRIL     2618 A787ABC-C  Z Hi In              214 Zh G3V
@@ -312,12 +312,12 @@ Flestal       2714 E3378B8-8    Ni                 220 Zh F8V M7V
 Qiemisod      2716 E693336-5    Lo Ni              924 Zh M2V
 Dlebla        2717 E986340-5    Lo Ni              812 Zh F6V
 Chtolshte     2719 B4485A7-C  Z Ag Ni              904 Zh M5V
-Kretsevli     2811 C5A0578-A    De Fl Ni           223 Zh M0V K1V
+Kretsevli     2811 C5A0578-A    De Fl Ni           223 Zh K1V M0V
 Beshpri       2813 B456213-9    Lo Ni Po           323 Zh K5V
 BATSBEVEL     2815 C422965-9    Hi In Na Po        203 Zh M8V
 Vladrkrie     2818 B331444-9    Ni Po              915 Zh M9V
 Itlieflat     2820 A68A467-C  Z Ni Wa              400 Zh G9V
-Ezchta        2915 B200783-A    Na Va              212 Zh M7V M0V
+Ezchta        2915 B200783-A    Na Va              212 Zh M0V M7V
 IPLZHDR       2916 A86A986-D  Z Hi In Wa Cp        101 Zh G4V
 Krienzh       3011 B525413-8    Ni                 204 Zh K3V
 Ietla         3013 B545362-7    Lo Ni              505 Zh M2V
@@ -349,11 +349,11 @@ Tsialsier     3220 A230553-D  Y De Lo Ni Po        604 Zh M3V
               0224 X400000-0    Ba Ni Va           204 Na F2III
               0226 X300000-0    Ba Ni Va           911 Na K2V
               0227 X596000-0    Ba Ni              804 Na M2V M2V
-              0324 X446000-0    Ba Ni              111 Na F5V M2D
+              0324 X446000-0    Ba Ni              111 Na F5V M2V
               0326 X236000-0    Ba Ni              404 Na F8V
               0330 X381000-0    Ba Ni              603 Na F3V M1V
               0427 X411000-0    Ba Ni              314 Na K2V
-              0429 X649000-0    Ba Ni              502 Na F7V M3D
+              0429 X649000-0    Ba Ni              502 Na F7V M3V
               0521 X532000-0    Ba Ni              805 Na M7V
               0523 X000000-0    As Ni An           624 Na K3III
 ADRSIDLE      0525 A8679B5-C  N Hi In              123 Na G8V
@@ -384,9 +384,9 @@ Ismlz         1324 A423398-B  N Lo Ni Po           314 Tn M2V
 Ozh           1421 A1008AA-C  N Na Va              522 Tn F7V
 JDIBLA        1425 A876954-C  A Hi In Cp           222 Na M4V
 Ezianzh       1523 C20067A-A    Na Ni Va           501 Tn F2V
-              1527 X000000-0    As Ni              202 Na M4V M1V
+              1527 X000000-0    As Ni              202 Na M1V M4V
 Chta'Inch     1622 AA67958-B  N Lo Ni              322 Tn G3V
-              1628 X798000-0    Ba Na              915 Na F7v M1D
+              1628 X798000-0    Ba Na              915 Na F7V M1V
 
 @SUB-SECTOR K: Chazhdar SECTOR: Tsadra
 #
@@ -408,7 +408,7 @@ Rathaus       2222 A100559-D  r Ni Va              513 Fj M5V
 Sazhefr       2321 E100300-8    Lo Ni Va           321 Na M7V
 Norrway       2322 CAA7652-7    Fl Ni              513 Fj F8V
 Fynlan        2324 A764637-A  N Ag Ni              902 Fj M4V
-              2327 X511000-0    Ba Ni Po           603 Na M2V K4V
+              2327 X511000-0    Ba Ni Po           603 Na K4V M2V
               2426 X544000-0    Ba Ni              322 Na G3IV
 
 
@@ -424,11 +424,11 @@ Faroe         2625 B200588-C  N Ni Va              513 Fj M4V
 Leidham       2627 B351354-D  r Lo Ni Po           714 Na F3V
 Karlsberg     2722 C687213-9  N Lo Ni              911 Fj M2V M2V
 Narke         2724 CA8A675-B  N Ni Ri Wa           920 Fj M6V
-Lappland      2726 C675331-6    Lo Ni              303 Fj M7V M3D
+Lappland      2726 C675331-6    Lo Ni              303 Fj M3V M7V
 Eriksborg     2823 C7A8856-9  N Fl                 115 Fj F2IV
 NORDICA       2825 AAA7AA7-D  A Fl Hi In           402 Fj G6V
-SCANIA        2827 C220AA5-C  N De Hi In Na Po     125 Fj F3v M2D
-Noerwald      2830 E857352-5    Lo Ni              201 Na M3v
+SCANIA        2827 C220AA5-C  N De Hi In Na Po     125 Fj F3V M2V
+Noerwald      2830 E857352-5    Lo Ni              201 Na M3V
 Iceland       2922 B41379C-C  N Ni Ic Po           401 Fj M2V
 Olafshold     2924 C555766-9  N Ag Ni              114 Fj F6V
 Gottoland     2927 A363735-B  N Ni Ri              212 Fj M2III
@@ -501,7 +501,7 @@ Afar          3230 D6A7501-2    Fl Ni              622 Tc G2V
               1735 X696000-0    Ba Ni              210 Na M3V M3V
               1740 X255000-0    Ba Ni              322 Na K4V
               1837 X704000-0    Ba Ic Ni Va        613 Na M6V
-              1931 X333000-0    Ba Ni Po           104 Na M5V M8V M2V
+              1931 X333000-0    Ba Ni Po           104 Na M2V M8V M5V
               1935 XAB7000-0    Ba Fl Ni           503 Na F5V
               2031 X548000-0    Ba Ni              203 Na F2V
               2037 X000000-0    As Ni              921 Na F7IV
@@ -526,7 +526,7 @@ Afar          3230 D6A7501-2    Fl Ni              622 Tc G2V
               2732 X566000-0    Ba Ni              312 Na F6V
               2833 X000000-0    As Ni              501 Na M2III
               2835 X777000-0    Ba Ni              622 Na G3V
-              2838 X445000-0    Ba Ni An           224 Na F7V M3D
+              2838 X445000-0    Ba Ni An           224 Na F7V M3V
               2839 X234000-0    Ba Ni Po           912 Na M1V
               2933 X430000-0    Ba De Ni Po        602 Na F3IV
               2937 X325000-0    Ba Ni              404 Na K2III


### PR DESCRIPTION
@inexorabletash asked me to, when submitting bulk sector-data fixen, break up said fixen PRs into different classes of sectors, so here goes with squaring up the stellar data in the Zhodani-dominated sectors, Tsadra, Sidiadl and Eiaplial.
I'm not making any deliberate attempt to canonicalise star sizes as per T5.10 Book 3 p 28.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is _swapped_ into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).