### PR TITLE
Fix Hkakhaeaw sector stellar data

### DIFF
--- a/res/Sectors/M1105/hkakhaeaw.sec
+++ b/res/Sectors/M1105/hkakhaeaw.sec
@@ -30,52 +30,52 @@ P: Feiko
  61-62: Allegiance
  64-80: Stellar Data
 
-0319               0319 X100000-5   Ba Lo Ni Va       014 Na M3 V M9 D M8 D
-0421               0421 X877003-0   Lo Ni             014 Na F5 V M0 D
+0319               0319 X100000-5   Ba Lo Ni Va       014 Na M3 V M9 V M8 V
+0421               0421 X877003-0   Lo Ni             014 Na F5 V M0 V
 0639               0639 X210003-2   Lo Ni             003 Na M6 V
-0702               0702 X428000-1   Ba Lo Ni          014 Na G6 II M3 D
+0702               0702 X428000-1   Ba Lo Ni          014 Na G6 II M3 V
 0712               0712 X445013-0   Lo Ni             004 Na F7 V
-0913               0913 X8A0000-1   Ba De Lo Ni       003 Na K5 V M7 D
-0920               0920 X370010-0   De Lo Ni          002 Na G0 V M4 D
-1033               1033 X778004-1   Lo Ni             004 Na F0 V M0 D
-1115               1115 X73A012-1   Lo Ni Wa          024 Na G5 V M7 D
-1209               1209 X669002-0   Lo Ni             011 Na G6 V M7 D
+0913               0913 X8A0000-1   Ba De Lo Ni       003 Na K5 V M7 V
+0920               0920 X370010-0   De Lo Ni          002 Na G0 V M4 V
+1033               1033 X778004-1   Lo Ni             004 Na F0 V M0 V
+1115               1115 X73A012-1   Lo Ni Wa          024 Na G5 V M7 V
+1209               1209 X669002-0   Lo Ni             011 Na G6 V M7 V
 1215               1215 X765011-2   Lo Ni             005 Na F5 V
 1311               1311 X698003-3   Lo Ni             014 Na K0 V
 1314               1314 X8D5011-1   Fl Lo Ni          004 Na F4 V
 1334               1334 X797005-0   Lo Ni             004 Na F8 V
-1419               1419 X666000-0   Ba Lo Ni          013 Na F8 V M1 D
+1419               1419 X666000-0   Ba Lo Ni          013 Na F8 V M1 V
 1620               1620 X698002-1   Lo Ni             023 Na F9 V
 2138               2138 X747001-2   Lo Ni             023 Na F2 V M5 V
-2301               2301 X564023-0   Lo Ni             024 Na F1 V M9 D
+2301               2301 X564023-0   Lo Ni             024 Na F1 V M9 V
 2340               2340 X584000-0   Ba Lo Ni          005 Na F5 V
 2406               2406 X140010-0   De Lo Ni Po       001 Na G8 V
-2434               2434 X472023-0   Lo Ni             013 Na G4 V M2 D
-2440               2440 X665000-0   Ba Lo Ni          000 Na F3 V M7 D
+2434               2434 X472023-0   Lo Ni             013 Na G4 V M2 V
+2440               2440 X665000-0   Ba Lo Ni          000 Na F3 V M7 V
 Steaisoaai         2539 X150597-2   De Ni Po          305 As F7 V
 Oika               2633 C400259-9 S Lo Ni Va          204 As K4 IV M8 V
 Stoaewalyese       2634 CA9A476-A S Ni Wa             101 As K0 V
 Feaaearloiea       2638 X678264-0   Lo Ni             402 As F5 V
 2710               2710 X110021-0   Lo Ni             003 Na G0 IV
 2719               2719 X212012-1   Ic Lo Ni          005 Na M8 V
-Yai                2734 CAC67A8-4   Fl                100 As K8 V M8 D
+Yai                2734 CAC67A8-4   Fl                100 As K8 V M8 V
 Yewyuawar          2739 X120264-5   De Lo Ni Po       215 As K3 V
 Riy                2740 C444263-7   Lo Ni             404 As F4 V
-2806               2806 X348000-2   Ba Lo Ni          024 Na G5 V M8 D
+2806               2806 X348000-2   Ba Lo Ni          024 Na G5 V M8 V
 Yeyoauhalr         2830 C231526-8   Ni Po             305 As A8 V
 Hte'eari           2834 C2009CD-B   Hi Na Va          602 As F1 V
-Ealiyakhau         2835 C336699-6   Ni                502 As M6 V M1 V
-Iee                2934 C546474-7 S Ni                904 As F5 V M5 D
-Kiyh               2935 C352255-9 S Lo Ni Po          403 As F7 V M9 D
+Ealiyakhau         2835 C336699-6   Ni                502 As M1 V M6 V
+Iee                2934 C546474-7 S Ni                904 As F5 V M5 V
+Kiyh               2935 C352255-9 S Lo Ni Po          403 As F7 V M9 V
 Hteia              2937 B437677-C   Ni                601 As M2 IV
 Khtaoouwao         2939 X6466A9-0   Ag Ni             521 As G1 V
-Hkyeyu             3034 C685684-7 S Ag Ni Ri          603 As F4 V M0 D
+Hkyeyu             3034 C685684-7 S Ag Ni Ri          603 As F4 V M0 V
 Eyehaol            3039 C367479-A   Ni                824 As G5 V
 Khtafiyraarl       3040 B5739A9-9   Hi In             502 As F1 V
 Asalalre           3131 C65A620-A   Ni Wa             602 As F9 V
-Eaeialea           3133 C74A244-B S Lo Ni Wa          304 As F3 V M6 D
-Uiilrarlyow        3135 C6449B7-6   Hi In             700 As G9 V M0 D
-Aorous             3139 C222034-7 S Lo Ni Po          704 As M4 V M9 D
+Eaeialea           3133 C74A244-B S Lo Ni Wa          304 As F3 V M6 V
+Uiilrarlyow        3135 C6449B7-6   Hi In             700 As G9 V M0 V
+Aorous             3139 C222034-7 S Lo Ni Po          704 As M4 V M9 V
 Yaiiysuiri         3229 C726645-8 S Ni                703 As K4 V
 Yei                3234 C8C6798-8   Fl                100 As A2 III
-Khouhauhyua        3235 C578030-8 S Lo Ni             815 As F1 V M6 D
+Khouhauhyua        3235 C578030-8 S Lo Ni             815 As F1 V M6 V


### PR DESCRIPTION
Clean up stellar data in M1105 Hkakhaeaw.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is swapped into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).