### PR TITLE
Fix Kruse sector stellar data

### DIFF
--- a/res/Sectors/M1105/Kruse.txt
+++ b/res/Sectors/M1105/Kruse.txt
@@ -10,7 +10,7 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 0609 Adams 0609           XADA???-? Oc                                          031   Na K0 V                 
 0610 Adams 0610           X21????-?                                             001   Na G8 V M3 V K2 V       
 0709 Adams 0709           X344???-?                                             001   Na M6 V                 
-0707 Hoydell’s Gate       D8BA367-D Fl Ht Lo                                    722   So M7 V BD M2 V         
+0707 Hoydell’s Gate       D8BA367-D Fl Ht Lo                                    722   So M2 V BD M7 V         
 0704 Hoydell’s Watchtower D533267-D Ht Lo Po                                  A 601   So M0 V                 
 1206 Always               X5A5000-0 Ba Fl                                     A 011   Na K8 V                 
 1001 Barnett 0201         X??????-?                                           A 013   Na K4 V                 
@@ -23,7 +23,7 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 1303 Barnett 0503         X1A0000-0 Ba                                        A 023   Na K0 III K6 V          
 1310 Barnett 0510         X101000-0 Ba Ic Va                                    004   Na K9 V                 
 1401 Barnett 0601         X??????-?                                           A 011   Na K5 V                 
-1505 Barnett 0705         X??????-?                                           A 010   Na M7 V M6 V            
+1505 Barnett 0705         X??????-?                                           A 010   Na M6 V M7 V            
 1507 Barnett 0707         X??????-?                                           A 021   Na K1 V                 
 1508 Barnett 0708         X698000-0 Ba                                          020   Na K6 V M8 V M3 V       
 1509 Barnett 0709         X859000-0 Ba                                          001   Na G2 V                 
@@ -34,7 +34,7 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 1207 Sometimes            D524267-D Ht Lo                                     A 202   So K0 V                 
 1702 Chase 0102           X??????-?                                           A 001   Na K1 V                 
 1705 Chase 0105           X876000-0 Ba                                        A 013   Na M7 V                 
-1802 Chase 0203           X??????-?                                           A 030   Na K6 V K1 V            
+1802 Chase 0203           X??????-?                                           A 030   Na K1 V K6 V            
 1908 Chase 0308           X101000-0 Ba Ic Va                                    030   Na K6 III M0 V          
 1910 Chase 0310           X547000-0 Ba                                          012   Na G4 V M5 V            
 2004 Chase 0404           X??????-?                                           A 003   Na M1 V                 
@@ -45,7 +45,7 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 2303 Chase 0703           X100000-0 Ba Va                                     A 013   Na M3 V                 
 2401 Chase 0801           X??????-?                                           A 001   Na K0 V M2 V M9 V       
 2407 Discovery            C78A485-9 Ni Wa                                       703   RM G4 V K2 V            
-2207 Emblem               X000000-0 As Ba Va                                    001   Na K9 V K3 V            
+2207 Emblem               X000000-0 As Ba Va                                    001   Na K3 V K9 V            
 2308 Mosaic               C587585-9 Ag Ni                                       221   RM M6 V                 
 2306 Trophy               A765785-9 Ag Ga Ri Cp                                 603   RM M9 V                 
 2209 Velvet               D888585-9 Ag Ni                                       223   RM F4 V                 
@@ -56,7 +56,7 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 2608 Drower 0208          X656000-0 Ba Ga                                       002   Na M0 V                 
 2703 Drower 0303          X??????-?                                             032   Na G3 V M2 V            
 2707 Drower 0307          X955000-0 Ba                                          024   Na K1 V                 
-2708 Drower 0308          X361000-0 Ba                                          003   Na M6 V M4 V            
+2708 Drower 0308          X361000-0 Ba                                          003   Na M4 V M6 V            
 2709 Drower 0309          X222000-0 Ba Po                                       012   Na F2 V                 
 2801 Drower 0401          X??????-?                                             001   Na M2 V                 
 2806 Drower 0406          X537000-0 Ba                                          011   Na M3 V                 
@@ -71,11 +71,11 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 0516 Bedazzled            D341416-A Ni                                          701   Ec G4 V                 
 0618 Bewitched            E545471-6 Ni                                          133   Ec K5 V                 
 0515 Captivated           X321000-0 Ba Po                                       031   Na K7 V                 
-0114 Eberhardt 0104       X9D8000-0 Ba Fl                                       002   Na M7 V M0 V M9 V       
+0114 Eberhardt 0104       X9D8000-0 Ba Fl                                       002   Na M0 V M7 V M9 V       
 0117 Eberhardt 0107       X66A000-0 Ba Wa                                       002   Na K4 V M1 V K8 V       
 0215 Eberhardt 0205       X777000-0 Ba                                          021   Na G3 V M4 V M2 V       
 0218 Eberhardt 0208       X622000-0 Ba Po                                       003   Na G2 V                 
-0319 Eberhardt 0309       XA99000-0 Ba                                          010   Na M8 V M8 V M6 V       
+0319 Eberhardt 0309       XA99000-0 Ba                                          010   Na M6 V M8 V M8 V       
 0413 Eberhardt 0403       X998000-0 Ba                                          033   Na G8 IV                
 0612 Eberhardt 0602       X100000-0 Ba Va                                       031   Na M4 V BD              
 0712 Eberhardt 0702       X422000-0 Ba Po                                       004   Na K4 V M4 V M1 V K4 V  
@@ -87,7 +87,7 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 0817 Entranced            EA8A316-B Lo Wa                                       533   Ec K6 V                 
 0717 Mesmerised           E589416-C Ht Ni                                       200   Ec K0 V M2 V            
 0216 Misfeasance          X7A3000-0 Ba Fl                                       034   Na G4 V                 
-0317 Nonchalance          B5497C8-C Ht                                          322   So M2 V BD M0 V         
+0317 Nonchalance          B5497C8-C Ht                                          322   So M0 V BD M2 V         
 0615 Spellbound           D543572-7 Po Ni                                       502   Ec M5 V                 
 1516 Clarity              C520467-D De Ht Ni O:1416                             600   So K0 V M3 V            
 1417 Fadeout              C9AA367-D Fl Ht Lo O:1416                             201   So M0 V M9 V            
@@ -119,7 +119,7 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 2115 Gower 0505           X8AA000-0 Ba Fl                                       001   Na K4 V M5 V            
 2119 Gower 0509           X832000-0 Ba Po                                       031   Na M0 V BD              
 2212 Gower 0602           X521000-0 Ba Po                                       001   Na M9 V                 
-2219 Gower 0609           X876000-0 Ba                                          000   Na M3 V M2 V            
+2219 Gower 0609           X876000-0 Ba                                          000   Na M2 V M3 V            
 2316 Gower 0706           XA95000-0 Ba                                          001   Na M0 V                 
 2413 Gower 0803           X100000-0 Ba Va                                       022   Na M1 V M7 V            
 2414 Gower 0804           X699000-0 Ba                                          002   Na A7 V                 
@@ -135,10 +135,10 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 2916 Covenant             B773745-9                                             610   Ir G6 V                 
 2512 Hagan 0102           X333000-0 Ba Po                                       012   Na K1 V                 
 2520 Hagan 0110           X578000-0 Ba                                          001   Na K3 V                 
-2614 Hagan 0110           X200000-0 Ba Va                                       002   Na M4 V M2 V            
+2614 Hagan 0110           X200000-0 Ba Va                                       002   Na M2 V M4 V            
 2615 Hagan 0205           X231000-0 Ba Po                                       021   Na A0 V                 
 2617 Hagan 0207           X335000-0 Ba                                          001   Na G7 V                 
-2619 Hagan 0209           X534000-0 Ba                                          003   Na M4 V M4 V M0 V       
+2619 Hagan 0209           X534000-0 Ba                                          003   Na M0 V M4 V M4 V       
 2711 Hagan 0301           X310000-0 Ba                                          001   Na K0 V                 
 2714 Hagan 0304           X7B3000-0 Ba Fl                                       002   Na M1 V                 
 2719 Hagan 0309           X995000-0 Ba                                          022   Na G7 V K8 V            
@@ -161,8 +161,8 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 0222 Ivy 0202             X647000-0 Ba                                          012   Na M8 V                 
 0223 Ivy 0203             X334000-0 Ba                                          031   Na A7 V                 
 0224 Ivy 0204             X646000-0 Ba                                          033   Na M7 V                 
-0226 Ivy 0206             X244000-0 Ba                                          001   Na M8 V M2 V            
-0228 Ivy 0208             X141000-0 Ba Po                                       000   Na K9 V K4 V M6 V M4 V  
+0226 Ivy 0206             X244000-0 Ba                                          001   Na M2 V M8 V            
+0228 Ivy 0208             X141000-0 Ba Po                                       000   Na K4 V K9 V M6 V M4 V  
 0229 Ivy 0209             X110000-0 Ba                                          012   Na G0 V                 
 0323 Ivy 0303             XA9A000-0 Ba Oc                                       021   Na M2 V                 
 0325 Ivy 0305             X646000-0 Ba                                          022   Na K4 V                 
@@ -180,10 +180,10 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 0830 Ivy 0810             X425000-0 Ba Po                                       011   Na K2 V                 
 0725 Rammak Claim         E431000-0 Ba Po                                       010   Rm M4 V M8 V            
 0827 Rammak Claim         D210206-8 Lo RammW                                    202   Rm K3 V                 
-0426 Rammak Colony        C687506-8 Ga Ni RammW                                 321   Rm M9 V M7 V            
+0426 Rammak Colony        C687506-8 Ga Ni RammW                                 321   Rm M7 V M9 V            
 0626 Rammak Colony        C675606-8 Ni RammW                                    601   Rm K6 V M1 V K8 V       
 0727 Rammak Home          A655A06-8 Ga Hi Cp (Rammak)                           212   Rm F3 V D               
-0527 Rammak Outpost       D321306-8 Lo Po RammW                                 932   Rm M8 V M3 V            
+0527 Rammak Outpost       D321306-8 Lo Po RammW                                 932   Rm M3 V M8 V            
 0627 Rammak Outpost       D400306-8 Lo Va RammW                                 310   Rm M8 V BD              
 0628 Rammak Outpost       C510406-8 Ni RammW                                    602   Rm G5 V                 
 1325 Antunder             E98A776-2 Lt Ri Wa                                    201   Na F2 V M9 V            
@@ -197,9 +197,9 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 1023 Jain 1023            X455000-0 Ba                                          001   Na M2 V                 
 1122 Jain 1122            X463000-0 Ba                                          012   Na M2 III               
 1126 Jain 1126            X100000-0 Ba Va                                       031   Na M0 V M2 V M2 V       
-1229 Jain 1229            X78A000-0 Ba Wa                                       002   Na M7 V M1 V            
+1229 Jain 1229            X78A000-0 Ba Wa                                       002   Na M1 V M7 V            
 1230 Jain 1230            X565000-0 Ba                                          002   Na K2 V                 
-1323 Jain 1323            X955000-0 Ba                                          002   Na G2 V G1 V            
+1323 Jain 1323            X955000-0 Ba                                          002   Na G1 V G2 V            
 1522 Jain 1522            X420000-0 Ba De Po                                    011   Na M9 V BD M9 V         
 1530 Jain 1530            X365000-0 Ba                                          002   Na M3 V                 
 1626 Jain 1626            X377000-0 Ba                                          001   Na M5 V                 
@@ -219,7 +219,7 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 2230 Kane 0610            X563400-0 Lt                                          130   Na F7 V M3 V D          
 2323 Kane 0703            X100000-0 Ba Va                                       023   Na K3 V M7 V            
 2330 Kane 0710            X5A6000-0 Ba Fl                                       030   Na G6 IV                
-2426 Kane 0806            X588000-0 Ba                                          001   Na G5 V G0 IV K5 V      
+2426 Kane 0806            X588000-0 Ba                                          001   Na G0 IV G5 V K5 V      
 2429 Kane 0809            X300000-0 Ba Va                                       022   Na K7 V M6 V K9 V M6 V  
 1723 Legishnai            E457874-2 Lt                                          110   Na K5 V                 
 2023 Oeprea               E557872-3 Lt                                          412   Na G8 IV K9 V G5 V      
@@ -256,7 +256,7 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 0333 Abitorra             C657418-8 Ga Ni (Sappil)9                             632   Na K0 V                 
 0840 HBD                  X??????-?                                             001   Na G0 V                 
 0139 Mullings 0109        X454000-0 Ba                                          011   Na M0 V                 
-0231 Mullings 0201        X000000-0 As Ba Va                                    002   Na F9 V F0 V            
+0231 Mullings 0201        X000000-0 As Ba Va                                    002   Na F0 V F9 V            
 0234 Mullings 0204        X540000-0 Ba De Po                                    001   Na M0 V                 
 0331 Mullings 0301        X773000-0 Ba                                          002   Na G7 V M9 V            
 0335 Mullings 0305        X553000-0 Ba Po                                       024   Na M0 III M8 V BD       
@@ -265,7 +265,7 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 0633 Mullings 0603        X585000-0 Ba                                          020   Na K4 V                 
 0732 Mullings 0702        X210000-0 Ba                                          034   Na M9 V                 
 0133 Tummuldt             E577774-2 Ag                                        A 400   Na K8 V                 
-1233 Affirmation          D850268-7 De Lo Po                                    801   Sv M7 V M2 V            
+1233 Affirmation          D850268-7 De Lo Po                                    801   Sv M2 V M7 V            
 1631 Boundary             C230368-7 De Lo Po                                    932   Sv K4 V                 
 1532 Gravitatie Puternica D988468-7                                             604   Sv M0 V                 
 1432 Insula Suverana      A6649F9-B Hi Cp                                       632   Sv M5 V                 
@@ -297,15 +297,15 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 2035 Osthoff 0405         X7A8???-? Fl                                          031   Na G0 V M7 V            
 2036 Osthoff 0406         X658???-?                                             022   Na M8 V BD              
 2039 Osthoff 0409         X??????-?                                             000   Na M0 V M0 V            
-2134 Osthoff 0504         X300000-0 Ba Va                                       021   Na F3 V G3 V F1 V       
+2134 Osthoff 0504         X300000-0 Ba Va                                       021   Na F1 V G3 V F3 V       
 2136 Osthoff 0506         X442???-? Po                                          014   Na M9 V                 
 2137 Osthoff 0507         X553???-? Po                                          002   Na G9 V                 
 2139 Osthoff 0509         X??????-?                                             011   Na K2 III               
-2140 Osthoff 0510         X??????-?                                             034   Na M7 V M0 V            
+2140 Osthoff 0510         X??????-?                                             034   Na M0 V M7 V            
 2233 Osthoff 0603         X6B0000-0 Ba                                          031   Na M5 V                 
 2238 Osthoff 0608         X??????-?                                             004   Na K7 V M2 V M0 V       
 2239 Osthoff 0608         X??????-?                                             000   Na K4 V M5 V M1 V       
-2333 Osthoff 0703         X541???-? Po                                          000   Na K8 V M1 V M9 V K4 V  
+2333 Osthoff 0703         X541???-? Po                                          000   Na K4 V M1 V M9 V K8 V  
 2334 Osthoff 0704         X2A0???-?                                             020   Na G6 V K6 V K9 V       
 2335 Osthoff 0705         XA5A???-? Wa                                          022   Na M6 III               
 2337 Osthoff 0707         X??????-?                                             034   Na K1 V M8 V            
@@ -317,7 +317,7 @@ Hex  Name                 UWP       Remarks                {Ix} (Ex) [Cx] N B Z 
 3133 Encounter            X887000-0 Ba                                        A 031   Na F9 V                 
 2734 Pletneva             X100000-0 Ba Va                                       000   Na M5 V M7 V            
 2539 Pletneva 0109        X??????-?                                             001   Na K1 V                 
-2540 Pletneva 0110        X??????-?                                             001   Na M9 V M0 V            
+2540 Pletneva 0110        X??????-?                                             001   Na M0 V M9 V            
 2631 Pletneva 0201        X111000-0 Ba Ic                                       002   Na G1 V M4 V            
 2639 Pletneva 0209        X??????-?                                             011   Na M0 V M1 V            
 2932 Pletneva 0502        X200000-0 Ba Va                                       002   Na K6 V                 


### PR DESCRIPTION
Clean up stellar data in M1105 Kruse.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is swapped into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).