### PR TITLE
Fix Folgore sector stellar data

### DIFF
--- a/res/Sectors/M1105/Folgore.txt
+++ b/res/Sectors/M1105/Folgore.txt
@@ -378,7 +378,7 @@ Hex  Name                 UWP       Remarks                      {Ix}   (Ex)    
 2234                      D431622-7 Na Ni Po                     { -3 } (550+3) [4316] - N  - 800  5 CsHv G6 V M3 V
 2331                      A9A5426-B Fl Ni IthkW Pz               {  1 } (A37+1) [157B] - E  A 104 14 HvFd M3 V M7 V 
 2332                      E7A5226-8 Lo Fl IthkW Pz               { -3 } (C11-3) [2147] - -  A 704 13 HvFd M5 V M5 V
-2431                      B796416-8 Ni Pa                        { -1 } (D33-3) [43A7] - -  - 504 16 HvFd M9 V K0 V
+2431                      B796416-8 Ni Pa                        { -1 } (D33-3) [43A7] - -  - 504 16 HvFd K0 V M9 V
 2536                      D120126-7 De Lo Po                     { -3 } (401-1) [1156] - N  - 824  9 NaXX M6 V
 2640 Sixex                E685836-5 Ga Ph Pa Ri (Sixex)          { -1 } (87B-5) [8758] - N  - 823 11 NaXX F7 V M5 V
 2831                      C211110-7 Ic Lo                        { -2 } (701-1) [1125] - M  - 902 12 HvFd G6 V


### PR DESCRIPTION
Clean up stellar data in M1105 Folgore.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is swapped into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).