### PR TITLE
Fix Kilong sector stellar data

### DIFF
--- a/res/Sectors/M1105/Kilong.tab
+++ b/res/Sectors/M1105/Kilong.tab
@@ -132,7 +132,7 @@ Hex	Name	UWP	Bases	Remarks	Zone	PBG	Allegiance	Stars	{Ix}	(Ex)	[Cx]	Nobility	W
 0733	Toorragaa	A552ARK-F	K	Hi Po		712	Kk	A6 V F9 V	{ 3 }	(C9F-3)	[8D9E]		12
 0735	Xa!prar	E430000-0		De Ba Po		003	Kk	A8 V F6 V	{ -3 }	(600-1)	[0000]		12
 0738	Ghargragi	C6485QK-B	K	Ni Ag		923	Kk	M5 V BD M9 V	{ 1 }	(D44+2)	[468B]		12
-0802	Kraak'lu	E100000-0	K	Va Ba		012	Kk	M4 V M1 V	{ -3 }	(500-1)	[0000]		9
+0802	Kraak'lu	E100000-0	K	Va Ba		012	Kk	M1 V M4 V	{ -3 }	(500-1)	[0000]		9
 0806	Tinuukax	E3775QK-9	K	Ni Ag		112	Kk	M9 V	{ -1 }	(A42+2)	[8469]		12
 0808	Rakeir	C7859RK-E		Ga Hi Pr		101	Kk	G1 V	{ 2 }	(A88-1)	[9B5F]		14
 0809	Eearroo	D8868RK-D	K	Ga Ph Pa Ri		825	Kk	F0 V	{ 1 }	(B77-1)	[6B8F]		18


### PR DESCRIPTION
Clean up stellar data in M1105 Kilong.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is swapped into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).