### PR TITLE
Fix Nuughe sector stellar data

### DIFF
--- a/res/Sectors/M1105/Nuughe.tab
+++ b/res/Sectors/M1105/Nuughe.tab
@@ -319,7 +319,7 @@ Hex	Name	UWP	Remarks	{ Ix }	( Ex )	[ Cx ]	N	B	Z	PBG	W	A	Stellar
 2812		?785???-?	Ga Tz				-	-	-	130	B	Na	K9 V M3 V
 2818		?598???-?	Tz				-	-	-	500	8	Na	M7 V
 2820		?610???-?					-	-	-	200	A	Na	G4 V
-2822		?433???-?	Ho Po Tz				-	-	-	502	B	Na	G9 V M3 V G6 V K0 V
+2822		?433???-?	Ho Po Tz				-	-	-	502	B	Na	G6 V M3 V G9 V K0 V
 2823		?767???-?	Ga				-	-	-	311	F	Na	K7 V
 2832		?530???-?	De Po				-	-	-	301	A	Na	G2 V G3 V G4 V
 2901		?846???-?	 				-	-	-	510	8	Na	G2 IV M9 V


### PR DESCRIPTION
Clean up stellar data in M1105 Nuughe.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is swapped into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).