### PR TITLE
Fix Katoonah sector stellar data

### DIFF
--- a/res/Sectors/M1105/Katoonah.sec
+++ b/res/Sectors/M1105/Katoonah.sec
@@ -252,9 +252,9 @@ TORONAGA                  1628 A857956-E N Ag Hi In Ri                 202 De F8
 Jyell                     1707 A312457-E r Ba Ic Lo Ni                 310 -- K3 III
 Blodi                     1711 B435656-B   Na Ni Po                    804 -- K6 V
 Aitia                     1712 X000000-0   As Ba Lo Ni                 010 -- M3 V
-Razmar                    1716 C683554-A   Na Lo Ni                    624 Hl K3 V F4 V
+Razmar                    1716 C683554-A   Na Lo Ni                    624 Hl F4 V K3 V
 Sayardal                  1720 A662626-C N Na Ni Po                    913 Sa M2 V M5 V
-Mileaki                   1721 C454531-C   Na Lo Ni                    104 Sa G8 V G3 V
+Mileaki                   1721 C454531-C   Na Lo Ni                    104 Sa G3 V G8 V
 Brea                      1726 A7A78A7-C   Ag In Ri                    126 -- G5 V M2 V
 Fraxys                    1732 C223322-C C Na Lo Ni Po                 313 -- M3 V
 Zanemahon                 1733 A77869A-7   Ag Ni Ri                    510 -- K3 IV M3 V
@@ -442,7 +442,7 @@ Nojacks                   3034 XAC4000-0   Ba Fl Lo Ni                 422 -- G2
                           3116 X668000-0   Ba Lo Ni                    103 -- F9 V
                           3120 X000000-0   As Ba Lo Ni                 104 -- K8 V M1 V
 OLYBRIUS                  3123 A888959-D A Ag Hi In Ri                 413 -- F3 V M4 V
-Barter                    3124 B557850-B   Ba Lo Ni                    723 -- M3 V F9 V
+Barter                    3124 B557850-B   Ba Lo Ni                    723 -- F9 V M3 V
 Delta                     3125 A8A7653-D N Ag In Ri                    612 -- F4 V M6 V
 Kybarak                   3126 B2226AE-B N Na De Ni Po                 503 -- M4 V
 Hostage                   3127 C35066A-B   Ba Lo Ni Po                 720 -- K3 V


### PR DESCRIPTION
Clean up stellar data in M1105 Katoonah.

First, any main-sequence "dwarfs" (eg `G3 D`) are promoted to size V (`G3 V`).
Second, following TravellerMap's own stellar-data checker, the biggest, then breaking ties by earliest, star (eg `M5 V M8 V M2 V`) is swapped into the first star (`M2 V M8 V M5 V`).

For cases such as `M6 V M1 D`, if a promoted "dwarf" is now the best primary candidate, so be it (`M1 V M6 V`).