### PR TITLE
Update M1105.xml

### DIFF
--- a/res/Sectors/M1105/M1105.xml
+++ b/res/Sectors/M1105/M1105.xml
@@ -2130,6 +2130,24 @@ Left:   0041 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030 0029 0028 00
     <X>-8</X>
     <Name Lang="as">Yahehwe</Name>
     <DataFile Source="Solomani and Aslan" Ref="https://travellermap.com/data/yahehwe">yahehwe.sec</DataFile>
+    <Subsectors>
+      <Subsector Index="A">Aloiui</Subsector>
+      <Subsector Index="B">Ouei'ya</Subsector>
+      <Subsector Index="C">Iyrua</Subsector>
+      <Subsector Index="D">Ohlaohyo</Subsector>
+      <Subsector Index="E">Aitaliy</Subsector>
+      <Subsector Index="F">Auaokhih</Subsector>
+      <Subsector Index="G">Iyyeahewaw</Subsector>
+      <Subsector Index="H">Iyail</Subsector>
+      <Subsector Index="I">Yehotyo</Subsector>
+      <Subsector Index="J">Hlya</Subsector>
+      <Subsector Index="K">Oahustokhao</Subsector>
+      <Subsector Index="L">Aohikteaeas</Subsector>
+      <Subsector Index="M">Ktaaoher</Subsector>
+      <Subsector Index="N">Kiy'yeao</Subsector>
+      <Subsector Index="O">Fuh</Subsector>
+      <Subsector Index="P">Eeayeyeh</Subsector>
+    </Subsectors>
     <Borders>
       <Border Allegiance="As">0611 0712 0812 0912 1011 1012 0913 0914 0915 0916 0917 1017 1018 1119 1219 1320 1321 1322 1222 1123 1023 0924 0925 0926 0825 0824 0724 0723 0722 0721 0720 0719 0718 0717 0716 0715 0714 0713 0712 0611</Border>
       <Border Allegiance="As" LabelPosition="1806">1406 1506 1605 1604 1704 1803 1802 1903 2003 2104 2204 2305 2405 2505 2504 2503 2502 2501 2500 2600 2700 2800 2900 3000 3100 3200 3300 3301 3302 3303 3304 3305 3306 3307 3308 3309 3310 3311 3312 3313 3314 3315 3316 3317 3318 3319 3320 3321 3322 3323 3324 3325 3224 3124 3123 3022 2922 2821 2721 2620 2520 2519 2518 2517 2516 2515 2514 2513 2512 2511 2510 2409 2509 2608 2607 2606 2506 2405 2305 2205 2106 2006 2007 1908 1909 1910 1911 1912 1911 1810 1809 1709 1608 1508 1507 1406</Border>
@@ -2453,6 +2471,24 @@ Left:   0041 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030 0029 0028 00
     <X>-8</X>
     <Name Lang="as">Ohieraoi</Name>
     <DataFile Source="Solomani and Aslan" Ref="https://travellermap.com/data/ohieraoi">ohieraoi.sec</DataFile>
+    <Subsectors>
+      <Subsector Index="A">Ol</Subsector>
+      <Subsector Index="B">Irluikaei</Subsector>
+      <Subsector Index="C">Easuawyorl</Subsector>
+      <Subsector Index="D">Yakteatoheh</Subsector>
+      <Subsector Index="E">Trelr</Subsector>
+      <Subsector Index="F">Ya'yesahta</Subsector>
+      <Subsector Index="G">Earl</Subsector>
+      <Subsector Index="H">Khaaoehlaeh</Subsector>
+      <Subsector Index="I">Eyu</Subsector>
+      <Subsector Index="J">Aokeira</Subsector>
+      <Subsector Index="K">Aolah</Subsector>
+      <Subsector Index="L">Ouafi</Subsector>
+      <Subsector Index="M">Ehla</Subsector>
+      <Subsector Index="N">Yohaoekhes</Subsector>
+      <Subsector Index="O">Ueahtelr</Subsector>
+      <Subsector Index="P">Eakau</Subsector>
+    </Subsectors>
     <Borders>
       <Border Allegiance="As">1434 1534 1533 1532 1531 1630 1629 1628 1627 1626 1625 1725 1724 1824 1924 2023 2123 2124 2224 2225 2326 2327 2227 2228 2129 2130 2030 2031 1932 1832 1733 1633 1534 1434</Border>
       <Border Allegiance="As">2311 2410 2510 2509 2609 2709 2808 2908 3007 3107 3206 3306 3305 3306 3307 3308 3309 3310 3311 3312 3313 3314 3315 3316 3317 3318 3319 3320 3321 3220 3120 3020 2920 2819 2719 2718 2717 2716 2615 2515 2514 2513 2512 2411 2311</Border>
@@ -2482,11 +2518,11 @@ Left:   0041 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030 0029 0028 00
       <Subsector Index="P">Khiyrl</Subsector>
     </Subsectors>
     <Borders>
-      <Border Allegiance="As">0006 0106 0105 0205 0305 0306 0307 0407 0408 0409 0410 0311 0211 0112 0113 0114 0115 0215 0316 0216 0217 0218 0219 0120 0121 0020 0019 0018 0017 0016 0015 0014 0013 0012 0011 0010 0009 0008 0007 0006</Border>
-      <Border Allegiance="As">2216 2316 2315 2314 2313 2312 2311 2310 2309 2308 2307 2306 2406 2507 2606 2706 2805 2905 2904 2903 3003 3104 3203 3104 3105 3106 3107 3108 3109 3009 3010 3011 2912 2913 2914 2915 2916 3016 2916 2816 2717 2617 2517 2416 2316 2216</Border>
-      <Border Allegiance="Hy" Color="khaki">0428 0528 0527 0526 0527 0627 0728 0828 0829 0730 0731 0732 0731 0730 0629 0529 0428</Border>
-      <Border Allegiance="Kt" Color="goldenrod">2536 2635 2735 2834 2833 2832 2932 3031 3030 3029 3028 3027 3128 3228 3229 3230 3231 3232 3233 3234 3135 3035 3036 2937 2837 2738 2739 2738 2637 2537 2536</Border>
-      <Border Allegiance="Sa" Color="orange">0313 0412 0513 0613 0713 0714 0814 0915 1015 1116 1215 1216 1317 1217 1218 1219 1120 1020 0921 0821 0822 0723 0622 0522 0521 0520 0519 0518 0417 0416 0415 0414 0314 0313</Border>
+      <Border Allegiance="As" LabelPosition="0411">0006 0106 0105 0205 0305 0306 0307 0407 0408 0409 0410 0311 0211 0112 0113 0114 0115 0215 0316 0216 0217 0218 0219 0120 0121 0020 0019 0018 0017 0016 0015 0014 0013 0012 0011 0010 0009 0008 0007 0006</Border>
+      <Border Allegiance="As" LabelPosition="2712">2216 2316 2315 2314 2313 2312 2311 2310 2309 2308 2307 2306 2406 2507 2606 2706 2805 2905 2904 2903 3003 3104 3203 3104 3105 3106 3107 3108 3109 3009 3010 3011 2912 2913 2914 2915 2916 3016 2916 2816 2717 2617 2517 2416 2316 2216</Border>
+      <Border Allegiance="Hy" Color="khaki" LabelPosition="0726">0428 0528 0527 0526 0527 0627 0728 0828 0829 0730 0731 0732 0731 0730 0629 0529 0428</Border>
+      <Border Allegiance="Kt" Color="red" LabelPosition="2935">2536 2635 2735 2834 2833 2832 2932 3031 3030 3029 3028 3027 3128 3228 3229 3230 3231 3232 3233 3234 3135 3035 3036 2937 2837 2738 2739 2738 2637 2537 2536</Border>
+      <Border Allegiance="Sa" Color="orange" LabelPosition="1117">0313 0412 0513 0613 0713 0714 0814 0915 1015 1116 1215 1216 1317 1217 1218 1219 1120 1020 0921 0821 0822 0723 0622 0522 0521 0520 0519 0518 0417 0416 0415 0414 0314 0313</Border>
     </Borders>
     <Allegiances Source="Solomani and Aslan">
       <Allegiance Code="Hy">Hreahiyouea</Allegiance>
@@ -2511,12 +2547,30 @@ Left:   0041 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030 0029 0028 00
       ]]>
     </Credits>
     <DataFile Author="WG Zeist" Source="explorerbase" Ref="https://explorerbase.wordpress.com/sector-data/" Type="SecondSurvey">Hfiywitir.txt</DataFile>
+    <Subsectors>
+      <Subsector Index="A">Staisirehar</Subsector>
+      <Subsector Index="B">Hrekea</Subsector>
+      <Subsector Index="C">Ouwoulea</Subsector>
+      <Subsector Index="D">Hleiakh</Subsector>
+      <Subsector Index="E">Eakhaohtoa</Subsector>
+      <Subsector Index="F">Efai</Subsector>
+      <Subsector Index="G">Ktiyawaahe</Subsector>
+      <Subsector Index="H">Wuirah</Subsector>
+      <Subsector Index="I">Eaaoel</Subsector>
+      <Subsector Index="J">Teoaoul</Subsector>
+      <Subsector Index="K">Ahoiewui</Subsector>
+      <Subsector Index="L">Aooalaoftyeo</Subsector>
+      <Subsector Index="M">Oihae</Subsector>
+      <Subsector Index="N">Aia</Subsector>
+      <Subsector Index="O">Iheierealr</Subsector>
+      <Subsector Index="P">Oihareiy</Subsector>
+    </Subsectors>
     <Borders>
-      <Border Allegiance="As">1306 1405 1404 1505 1605 1705 1804 1904 1903 1904 2004 2005 2006 2107 2207 2308 2408 2509 2608 2708 2709 2809 2910 2810 2811 2712 2612 2613 2614 2615 2616 2517 2518 2417 2318 2218 2217 2117 2016 1916 1915 1914 2013 2012 2011 2010 2009 2008 1908 1807 1708 1608 1509 1408 1407 1406 1306</Border>
+      <Border Allegiance="As" LabelPosition="2011">1306 1405 1404 1505 1605 1705 1804 1904 1903 1904 2004 2005 2006 2107 2207 2308 2408 2509 2608 2708 2709 2809 2910 2810 2811 2712 2612 2613 2614 2615 2616 2517 2518 2417 2318 2218 2217 2117 2016 1916 1915 1914 2013 2012 2011 2010 2009 2008 1908 1807 1708 1608 1509 1408 1407 1406 1306</Border>
       <Border Allegiance="Et" Color="burlywood" LabelPosition="1014">0416 0516 0515 0614 0613 0713 0712 0713 0813 0914 1014 1114 1213 1214 1215 1116 1117 1017 0917 0817 0718 0617 0517 0417 0416</Border>
       <Border Allegiance="Ko" Color="orange">1629 1729 1828 1928 2027 2127 2126 2226 2326 2425 2525 2624 2725 2824 2925 3024 3025 3126 3127 3128 3129 3029 3030 2931 2932 2933 2934 2935 2936 2937 2837 2737 2636 2537 2437 2338 2238 2139 2039 1939 1839 1739 1838 1837 1836 1835 1834 1734 1633 1632 1631 1630 1629</Border>
-      <Border Allegiance="Se" Color="khaki">3035 3135 3134 3133 3132 3131 3230 3330 3329 3328 3327 3328 3329 3330 3331 3332 3333 3334 3335 3336 3337 3338 3339 3340 3239 3238 3237 3137 3036 3035</Border>
-      <Border Allegiance="Sy" Color="goldenrod">0629 0730 0830 0730 0630 0629</Border>
+      <Border Allegiance="Se" Color="khaki" LabelPosition="3133">3035 3135 3134 3133 3132 3131 3230 3330 3329 3328 3327 3328 3329 3330 3331 3332 3333 3334 3335 3336 3337 3338 3339 3340 3239 3238 3237 3137 3036 3035</Border>
+      <Border Allegiance="Sy" Color="goldenrod" LabelPosition="0631">0629 0730 0830 0730 0630 0629</Border>
     </Borders>
     <Allegiances Source="Solomani and Aslan">
       <Allegiance Code="Et">Etra</Allegiance>
@@ -2562,6 +2616,24 @@ Left:   0041 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030 0029 0028 00
     <Name Lang="as">Teahloarifu</Name>
     <Name Lang="as" Source="GURPS Traveller: Alien Races 2">Tahloarifu</Name>
     <DataFile Source="Solomani and Aslan" Ref="https://travellermap.com/data/teahloarifu">teahloarifu.sec</DataFile>
+    <Subsectors>
+      <Subsector Index="A">Ehyaiy</Subsector>
+      <Subsector Index="B">Ekhyefiw</Subsector>
+      <Subsector Index="C">Oilrewiys</Subsector>
+      <Subsector Index="D">Akyawehiyhea</Subsector>
+      <Subsector Index="E">Woitia</Subsector>
+      <Subsector Index="F">Easaw</Subsector>
+      <Subsector Index="G">Aoaol</Subsector>
+      <Subsector Index="H">Hasuw</Subsector>
+      <Subsector Index="I">Hweui</Subsector>
+      <Subsector Index="J">Yara</Subsector>
+      <Subsector Index="K">He'ekheah</Subsector>
+      <Subsector Index="L">Yeieaeiew</Subsector>
+      <Subsector Index="M">Eikheayaeah</Subsector>
+      <Subsector Index="N">Iyehow</Subsector>
+      <Subsector Index="O">Liai</Subsector>
+      <Subsector Index="P">Liy</Subsector>
+    </Subsectors>
     <Borders>
       <Border Allegiance="As">0020 0021 0022 0123 0223 0324 0423 0523 0522 0521 0620 0619 0618 0518 0417 0517 0516 0515 0514 0614 0714 0813 0913 1013 1114 1213 1313 1312 1311 1310 1209 1109 1008 0909 0809 0710 0610 0510 0409 0310 0309 0308 0307 0406 0405 0505 0604 0705 0805 0905 1004 1104 1103 1203 1303 1402 1503 1603 1703 1704 1804 1905 1805 1806 1707 1607 1608 1509 1409 1310 1311 1312 1313 1314 1414 1515 1615 1616 1717 1718 1618 1619 1620 1621 1622 1623 1724 1624 1625 1626 1627 1628 1729 1829 1930 2029 2129 2128 2227 2226 2225 2224 2223 2222 2221 2220 2219 2218 2217 2216 2116 2115 2114 2013 1913 1812 1712 1812 1912 2011 2111 2210 2310 2409 2509 2508 2608 2709 2809 2810 2911 2912 2913 2914 2814 2815 2816 2717 2718 2618 2619 2520 2521 2522 2622 2722 2822 2923 2924 3024 3025 3026 3027 3028 3029 3030 3131 3132 3133 3033 2933 2832 2732 2631 2531 2431 2331 2230 2131 2031 1932 1832 1733 1734 1735 1736 1737 1738 1638 1539 1540 1439 1339 1238 1138 1037 1036 1136 1135 1134 1133 1232 1231 1230 1130 1030 0931 0831 0832 0733 0633 0534 0434 0335 0234 0135 0034 0033 0032 0031 0030 0029 0028 0027 0026 0127 0227 0327 0426 0425 0424 0324 0223 0123 0023 0022 0021 0020</Border>
     </Borders>
@@ -2584,6 +2656,24 @@ Left:   0041 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030 0029 0028 00
       ]]>
     </Credits>
     <DataFile Author="WG Zeist" Source="explorerbase" Ref="https://explorerbase.wordpress.com/sector-data/" Type="SecondSurvey">Ahkiweahi.txt</DataFile>
+    <Subsectors>
+      <Subsector Index="A">Iyiykhiyais</Subsector>
+      <Subsector Index="B">Atehel</Subsector>
+      <Subsector Index="C">Hla</Subsector>
+      <Subsector Index="D">Koeyaleryes</Subsector>
+      <Subsector Index="E">Asaihel</Subsector>
+      <Subsector Index="F">Ahalahea</Subsector>
+      <Subsector Index="G">Eaheh</Subsector>
+      <Subsector Index="H">Weaseih</Subsector>
+      <Subsector Index="I">Ailaroa</Subsector>
+      <Subsector Index="J">Esaowah</Subsector>
+      <Subsector Index="K">Hfouoal</Subsector>
+      <Subsector Index="L">Aiheei</Subsector>
+      <Subsector Index="M">Uisai</Subsector>
+      <Subsector Index="N">Loieiloies</Subsector>
+      <Subsector Index="O">Ayearli</Subsector>
+      <Subsector Index="P">Sihoauiw</Subsector>
+    </Subsectors>
     <Borders>
       <Border Allegiance="As">0406 0506 0605 0705 0804 0904 1003 1104 1203 1303 1402 1503 1603 1504 1505 1405 1306 1206 1107 1007 1008 0909 0910 0911 0811 0712 0611 0512 0511 0510 0409 0408 0407 0406</Border>
       <Border Allegiance="As">0634 0734 0833 0832 0831 0931 1030 1029 1130 1230 1330 1429 1428 1528 1527 1626 1627 1628 1629 1730 1830 1831 1732 1632 1633 1634 1535 1434 1335 1235 1135 1034 0934 0834 0735 0634</Border>


### PR DESCRIPTION
Added missing subsector names to remaining Aslan sectors based on Traveller Wiki. 

Changed location of polity names in Hfiywitir and Fahreahlus sectors to improve readability, also changed colour of Ktouho'as to red to help differentiate from Steaakh Yeasaol.