### PR TITLE
Update to Hiver sectors Spica & Langere

### DIFF
--- a/res/Sectors/M1105/Langere.tab
+++ b/res/Sectors/M1105/Langere.tab
@@ -46,7 +46,7 @@ Lang	A	0708	Khalil	A784441-A		Ni Pa Tr		200	NaHu	G4 V	{ 1 }	(A36-3)	[6587]		10	-
 Lang	A	0710	Mysuru	C53047B-A		De Ni Po Co Sa		101	SoHn	K4 V	{ 0 }	(832+1)	[149C]		7	48
 Lang	E	0711	Akkadevi	A763A7A-C	M	Hi Cp Tr Tz		110	SoHn	K2 V	{ 3 }	(89C-1)	[BD8B]		12	-864
 Lang	E	0716	Cor Hydræ	E200000-0		Ba Va Co Tz		022	HvFd	K3 III	{ -3 }	(B00-5)	[0000]		9	-55
-Lang	E	0717	Monwran	A53056C-6		De Ni Po Da (Ditha) O:0720 Tz	A	214	HvFd	M3 V	{ -1 }	(640-5)	[441A]		11	-120
+Lang	E	0717	Monwran	A53056C-6		De Ni Po Da (Ditha) O:0720 Tz	A	214	Hf	M3 V	{ -1 }	(640-5)	[441A]		11	-120
 Lang	E	0719	Yaga	E876000-0		Ba		001	NaHu	A2 III	{ -3 }	(B00-5)	[0000]		7	-55
 Lang	E	0720	Wyee	A400658-9	E	Na Ni Va Co Tz		122	HvFd	M0 V	{ 0 }	(D52-4)	[5637]		10	-520
 Lang	A	0801	Zalman	D974400-6		Ni Pa		330	SoCf	G9 V M5 V	{ -3 }	(633-1)	[213B]		13	-54
@@ -94,7 +94,7 @@ Lang	B	1602	Farming Moon	D668766-6		Ag Ri O:1804 Sa		401	HvFd	G9 V	{ 0 }	(364-3)
 Lang	B	1607	Guhng	C9A4304-5		Fl Lo Tz		102	HvFd	F6 V M3 V	{ -2 }	(820+4)	[1153]		6	64
 Lang	F	1611	Kee	E000000-0		As Ba Va		032	HvFd	M2 V	{ -3 }	(700-5)	[0000]		10	-35
 Lang	F	1614	Quch	C555536-8		Ag Ni Za'tW Ho		933	HvFd	G8 V	{ -1 }	(E43+1)	[944A]		16	168
-Lang	J	1623	Gyuu	X8A7632-3		Fl Ni Fo (Kiki)	R	102	HvFd	G0 V	{ -3 }	(A50+1)	[83A1]		10	50
+Lang	J	1623	Gyuu	X8A7632-3		Fl Ni Fo (Kiki)	R	102	Hf	G0 V	{ -3 }	(A50+1)	[83A1]		10	50
 Lang	J	1624	Ohcii	A68A522-B		Ni Wa Pr Co Tz		231	HvFd	M1 V	{ 1 }	(843-2)	[567C]		8	-192
 Lang	J	1628	Phlaun	B000204-A		As Lo Va		100	HvFd	B7 V	{ 1 }	(711+3)	[5355]		8	21
 Lang	N	1636	Slough	X8BA448-A		Fl Ni Fo Tz	R	511	NaHu	M3 V	{ -1 }	(E30-1)	[23AE]		5	-42
@@ -107,10 +107,10 @@ Lang	K	1722	Yefaa	E876000-0		Ba		001	NaHu	G5 V	{ -3 }	(B00-5)	[0000]		7	-55
 Lang	K	1725	Zojaa	B967841-9		Cp Ri Pa Ph GurvW Tr		913	HvFd	G6 V	{ 2 }	(D7B+1)	[CA5A]		9	1001
 Lang	K	1727	Yoteagaa	B656406-9		Ni Ga Pa Tr		223	HvFd	G2 V	{ 0 }	(D34+1)	[4465]		15	156
 Lang	C	1802	Ajihe	B316305-8		Ic Lo Tz		412	HvFd	M0 V	{ -1 }	(D20+3)	[1267]		11	78
-Lang	C	1803	Yaiz	D410755-5		Na Pi Pz (Uhnuphe) Co	A	331	HvFd	A5 V K1 V M0 V	{ -2 }	(360-5)	[2514]		10	-90
+Lang	C	1803	Yaiz	D410755-5		Na Pi Pz (Uhnuphe) Co	A	331	Hf	A5 V K1 V M0 V	{ -2 }	(360-5)	[2514]		10	-90
 Lang	C	1804	Kwaal	B588835-D		Ri Pa Ph Ho		402	HvFd	K3 V M9 V	{ 3 }	(E79+1)	[7B6D]		6	882
 Lang	C	1809	Aanage	A410543-C		Ni Tz		402	HvFd	M3 V M5 V	{ 1 }	(842+3)	[767D]		13	192
-Lang	G	1811	Ihn	D530264-3		De Lo Po Da (Tothpre) O:2313 Tz	A	801	HvFd	M1 V M3 V	{ -3 }	(710-1)	[4131]		5	-7
+Lang	G	1811	Ihn	D530264-3		De Lo Po Da (Tothpre) O:2313 Tz	A	801	Hf	M1 V M3 V	{ -3 }	(710-1)	[4131]		5	-7
 Lang	G	1817	Aziyyo	A655403-B	E	Ni Ga Pa Lk		123	HvFd	F6 V	{ 1 }	(933+1)	[155B]		14	81
 Lang	K	1821	Fehaa	B310844-B	KM	Na Ph Pi Tz		320	HvFd	M2 V	{ 3 }	(675-5)	[AB1E]		13	-1050
 Lang	K	1822	Cold World	B575531-C	K	Ag Ni Co		912	HvFd	F6 V	{ 2 }	(B45-1)	[671D]		16	-220
@@ -144,7 +144,7 @@ Lang	G	2118	Phleluel	D4A6204-8		Fl Lo Tz		312	HvFd	M0 V	{ -3 }	(E10-5)	[511C]		1
 Lang	G	2120	Unpleasant	B4A4201-A		Fl Lo Co Tz		100	HvFd	K7 V M0 V	{ 1 }	(311+1)	[433A]		8	3
 Lang	K	2121	Nablaq	C300214-7		Lo Va		602	HvFd	G6 V	{ -2 }	(310+3)	[5112]		7	9
 Lang	K	2122	Tyoeh	C654405-A		Ni Pa		222	HvFd	F6 V	{ 0 }	(834-1)	[146E]		9	-96
-Lang	K	2123	Eeg	B630265-6		De Lo Po Da (Nightshade) O:1821	A	112	HvFd	A2 V	{ -1 }	(610+5)	[1154]		9	30
+Lang	K	2123	Eeg	E646355-6		Lo Da (Seoesse) O:1821	A	112	Hf	A2 V	{ -3 }	(620+5)	[1154]		9	60
 Lang	K	2124	Seh	D100302-7		Lo Va		312	HvFd	F0 V K6 V	{ -3 }	(720+4)	[5185]		12	56
 Lang	K	2129	Phyeaa	C667875-C		Ga Ri Pa Ph Tr		101	HvFd	K8 V M9 V	{ 2 }	(874+1)	[7A7D]		9	224
 Lang	O	2136	Lyekla	A68769C-8		Ag Ni Ga Ri Da Tu	A	223	NaHu	F5 V	{ 1 }	(G57+1)	[7789]		8	560
@@ -152,7 +152,7 @@ Lang	C	2201	Ihjoch	A577423-A	E	Ni Pa		101	HvFd	M3 V	{ 1 }	(933-3)	[1549]		7	-243
 Lang	C	2203	Qissilu	B888525-7		Ag Ni Pr		602	HvFd	M0 V M4 V	{ 0 }	(542-1)	[554A]		7	-40
 Lang	C	2209	Tah	C698203-5		Lo		404	HvFd	M4 II F6 V	{ -2 }	(710+1)	[3187]		14	7
 Lang	K	2225	Tez	B544506-9		Ag Ni		131	HvFd	G8 V	{ 1 }	(E47-3)	[163C]		10	-1176
-Lang	O	2231	Ckiic	B530267-6		De Lo Po Da (Iasza) O:2631 Ho Tz	A	430	HvFd	K1 V M9 V	{ -1 }	(610-4)	[2177]		13	-24
+Lang	O	2231	Ckiic	B553787-9		Po Pz (Iasza)8 Ho Tz	A	430	HvFd	K1 V M9 V	{ 1 }	(66C+1)	[2877]		13	432
 Lang	O	2236	7B5-177	E7B5000-0		Ba Fl Tz		000	NaXX	M2 V	{ -3 }	(500-5)	[0000]		9	-25
 Lang	O	2240	Melantha III	X699123-6		Lo Fo Lk	R	711	NaHu	F6 V	{ -3 }	(500+1)	[1187]		7	5
 Lang	C	2305	Veea	A884A55-F	K	Cp Hi		121	HvFd	K1 IV F7 V	{ 3 }	(C9B-4)	[9D4H]		8	-4752
@@ -191,12 +191,12 @@ Lang	D	2805	Yanuh	B569A84-9		Hi Co Lk		804	HvFd	M7 II K8 V	{ 2 }	(D96+1)	[DC5A]	
 Lang	H	2811	Waap	D866A51-A		Hi Ga		502	HvFd	F7 V	{ 1 }	(794+1)	[7B3E]		9	252
 Lang	H	2813	Optimum	A565955-A	K	Cp Hi Pr		101	HvFd	G9 V M6 V	{ 3 }	(48D+1)	[BC78]		9	416
 Lang	H	2815	Three Stars	B672611-B		He Ni		302	HvFd	F8 V G8 V M3 V	{ 1 }	(A57+1)	[A7AE]		9	350
-Lang	H	2816	Gohi	X620564-3		De He Ni Po Fo (Kedaoud) O:2813 Ho	R	402	HvFd	F9 V M5 V	{ -3 }	(342-4)	[8251]		8	-96
+Lang	H	2816	Gohi	X620564-3		De He Ni Po Fo (Kedaoud) O:2813 Ho	R	402	Hf	F9 V M5 V	{ -3 }	(342-4)	[8251]		8	-96
 Lang	H	2819	Wrul	E100000-0		Ba Va Tz		001	HvFd	M2 V M6 V	{ -3 }	(900-5)	[0000]		10	-45
-Lang	L	2823	Ochzyu	C4A4666-5		Fl Ni Da (Kingrua) O:2519 Co Lk Px	A	102	HvFd	K8 V M9 V	{ -2 }	(651+1)	[5454]		10	30
+Lang	L	2823	Ochzyu	C4A4666-5		Fl Ni Da (Kingrua) O:2519 Co Lk Px	A	102	Hf	K8 V M9 V	{ -2 }	(651+1)	[5454]		10	30
 Lang	L	2830	Dohj	D410404-7		Ni		402	HvFd	G3 V	{ -3 }	(632+5)	[511C]		9	180
 Lang	P	2839	410-359	X410000-0		Ba		003	NaXX	F8 V	{ -3 }	(200-5)	[0000]		14	-10
-Lang	D	2910	Va Lat	XAB8505-5		Fl Ni Fo (Alktatre)	R	103	HvFd	A4 IV G3 V	{ -3 }	(540-5)	[6215]		10	-100
+Lang	D	2910	Va Lat	XAB8505-5		Fl Ni Fo (Alktatre)	R	103	Hf	A4 IV G3 V	{ -3 }	(540-5)	[6215]		10	-100
 Lang	H	2919	Ziiping	C546756-6		Ag Pi Pz HumaW Co	A	933	HvFd	K6 V M3 V	{ 0 }	(86C+2)	[8786]		14	1152
 Lang	L	2924	Yeeng	E500000-0		Ba Va Lk		002	HvFd	M0 V	{ -3 }	(900-5)	[0000]		12	-45
 Lang	L	2927	Cuulyang	C410205-7		Lo Co Tz		121	HvFd	M1 V	{ -2 }	(710+2)	[2139]		13	14

--- a/res/Sectors/M1105/Langere.tab
+++ b/res/Sectors/M1105/Langere.tab
@@ -46,7 +46,7 @@ Lang	A	0708	Khalil	A784441-A		Ni Pa Tr		200	NaHu	G4 V	{ 1 }	(A36-3)	[6587]		10	-
 Lang	A	0710	Mysuru	C53047B-A		De Ni Po Co Sa		101	SoHn	K4 V	{ 0 }	(832+1)	[149C]		7	48
 Lang	E	0711	Akkadevi	A763A7A-C	M	Hi Cp Tr Tz		110	SoHn	K2 V	{ 3 }	(89C-1)	[BD8B]		12	-864
 Lang	E	0716	Cor Hydræ	E200000-0		Ba Va Co Tz		022	HvFd	K3 III	{ -3 }	(B00-5)	[0000]		9	-55
-Lang	E	0717	Monwran	A53056C-6		De Ni Po Da (minor) O:0720 Tz	A	214	HvFd	M3 V	{ -1 }	(640-5)	[441A]		11	-120
+Lang	E	0717	Monwran	A53056C-6		De Ni Po Da (Ditha) O:0720 Tz	A	214	HvFd	M3 V	{ -1 }	(640-5)	[441A]		11	-120
 Lang	E	0719	Yaga	E876000-0		Ba		001	NaHu	A2 III	{ -3 }	(B00-5)	[0000]		7	-55
 Lang	E	0720	Wyee	A400658-9	E	Na Ni Va Co Tz		122	HvFd	M0 V	{ 0 }	(D52-4)	[5637]		10	-520
 Lang	A	0801	Zalman	D974400-6		Ni Pa		330	SoCf	G9 V M5 V	{ -3 }	(633-1)	[213B]		13	-54
@@ -74,9 +74,9 @@ Lang	J	1121	Oojaa	B400104-7	K	Lo Va Co Tz		113	HvFd	M2 V M8 V	{ -1 }	(700-1)	[11
 Lang	N	1140	310-736	X310000-0		Ba Tz		002	NaXX	M0 V M0 V	{ -3 }	(900-5)	[0000]		10	-45
 Lang	B	1201	Iitrejjii	C985652-9	M	Ag Ni Ri Ithk7 Tu		303	HvFd	G5 V	{ 1 }	(B52+3)	[6759]		8	330
 Lang	F	1214	Big Sea	C79A406-8		Ni Wa		201	HvFd	F1 V K0 V	{ -2 }	(530+1)	[4236]		4	15
-Lang	F	1216	Angee	C7B8934-9		Fl Hi In		200	HvFd	K6 V	{ 2 }	(984+1)	[6B38]		9	288
+Lang	F	1216	Angee	C7B8984-9		Fl Hi In		200	HvFd	K6 V	{ 2 }	(984+1)	[6B38]		9	288
 Lang	N	1231	675-465	E675000-0		Ba		021	NaXX	G0 V	{ -3 }	(600-5)	[0000]		14	-30
-Lang	B	1304	Fehde	A599623-C	K	Ni Ho Tz		712	HvFd	K7 V	{ 1 }	(A52+5)	[873C]		10	500
+Lang	B	1304	Fehde	A599623-C	K	Cp Ni Ho Tz		712	HvFd	K7 V	{ 1 }	(A52+5)	[873C]		10	500
 Lang	F	1311	Ossi	D998652-7		Ag Ni IthkW		232	HvFd	G4 V	{ -2 }	(550-2)	[244A]		15	-50
 Lang	F	1315	Idjzuu'uxuu	B887656-9	M	Ag Ni Ga Ri IthkW		221	HvFd	G7 V	{ 2 }	(F53+1)	[3816]		9	225
 Lang	F	1317	Geet	E310305-7	M	Lo Ho		601	HvFd	K1 IV	{ -3 }	(320+2)	[4169]		11	12
@@ -87,14 +87,14 @@ Lang	N	1440	Moxi	C300320-A	K	Lo Va Co Lk		412	NaHu	K8 V M1 V	{ 0 }	(920+1)	[836C
 Lang	B	1505	Ote	B410403-7		Ni Co Tz		613	HvFd	M1 II M0 V	{ -1 }	(C32+1)	[3328]		12	72
 Lang	F	1515	Avoid	E620204-7		De He Lo Po Tz		203	HvFd	M1 V	{ -3 }	(810+1)	[2169]		14	8
 Lang	F	1518	Gochaawea	B76A614-C	K	Ni Ri Wa		630	HvFd	K2 V	{ 2 }	(C54+1)	[686E]		12	240
-Lang	F	1519	Feayava	B687601-B		Ag Ni Ga Ri Tu		602	HvFd	F9 V K0 V	{ 3 }	(958-4)	[897E]		12	-1440
+Lang	F	1519	Feayava	B687621-B		Ag Ni Ga Ri Tu		602	HvFd	F9 V K0 V	{ 3 }	(958-4)	[897E]		12	-1440
 Lang	J	1526	Baax	C669876-A		Ri Ph		801	HvFd	K4 V	{ 2 }	(97C+2)	[BA65]		7	1512
 Lang	N	1539	Brenna	B9A9779-A		Fl		514	NaHu	G1 V	{ 2 }	(G6C+1)	[5917]		13	1152
 Lang	B	1602	Farming Moon	D668766-6		Ag Ri O:1804 Sa		401	HvFd	G9 V	{ 0 }	(364-3)	[5739]		10	-216
 Lang	B	1607	Guhng	C9A4304-5		Fl Lo Tz		102	HvFd	F6 V M3 V	{ -2 }	(820+4)	[1153]		6	64
 Lang	F	1611	Kee	E000000-0		As Ba Va		032	HvFd	M2 V	{ -3 }	(700-5)	[0000]		10	-35
 Lang	F	1614	Quch	C555536-8		Ag Ni Za'tW Ho		933	HvFd	G8 V	{ -1 }	(E43+1)	[944A]		16	168
-Lang	J	1623	Gyuu	X8A7632-3		Fl Ni Fo (minor)	R	102	HvFd	G0 V	{ -3 }	(A50+1)	[83A1]		10	50
+Lang	J	1623	Gyuu	X8A7632-3		Fl Ni Fo (Kiki)	R	102	HvFd	G0 V	{ -3 }	(A50+1)	[83A1]		10	50
 Lang	J	1624	Ohcii	A68A522-B		Ni Wa Pr Co Tz		231	HvFd	M1 V	{ 1 }	(843-2)	[567C]		8	-192
 Lang	J	1628	Phlaun	B000204-A		As Lo Va		100	HvFd	B7 V	{ 1 }	(711+3)	[5355]		8	21
 Lang	N	1636	Slough	X8BA448-A		Fl Ni Fo Tz	R	511	NaHu	M3 V	{ -1 }	(E30-1)	[23AE]		5	-42
@@ -104,15 +104,15 @@ Lang	G	1711	Noxeh	B5AA405-9		Fl Ni Fr Sa		901	HvFd	M0 V M6 V	{ 0 }	(435-2)	[1488
 Lang	G	1714	Lehpep	E876000-0		Ba		001	NaHu	G5 V	{ -3 }	(B00-5)	[0000]		7	-55
 Lang	G	1717	Gihvehze	E4A2642-8		Fl He Ni		204	HvFd	G1 V M4 V	{ -3 }	(D50+5)	[B35B]		11	325
 Lang	K	1722	Yefaa	E876000-0		Ba		001	NaHu	G5 V	{ -3 }	(B00-5)	[0000]		7	-55
-Lang	K	1725	Zojaa	B967841-9		Ri Pa Ph GurvW Tr		913	HvFd	G6 V	{ 2 }	(D7B+1)	[CA5A]		9	1001
+Lang	K	1725	Zojaa	B967841-9		Cp Ri Pa Ph GurvW Tr		913	HvFd	G6 V	{ 2 }	(D7B+1)	[CA5A]		9	1001
 Lang	K	1727	Yoteagaa	B656406-9		Ni Ga Pa Tr		223	HvFd	G2 V	{ 0 }	(D34+1)	[4465]		15	156
 Lang	C	1802	Ajihe	B316305-8		Ic Lo Tz		412	HvFd	M0 V	{ -1 }	(D20+3)	[1267]		11	78
-Lang	C	1803	Yaiz	D410755-5		Na Pi Pz (minor) Co	A	331	HvFd	A5 V K1 V M0 V	{ -2 }	(360-5)	[2514]		10	-90
+Lang	C	1803	Yaiz	D410755-5		Na Pi Pz (Uhnuphe) Co	A	331	HvFd	A5 V K1 V M0 V	{ -2 }	(360-5)	[2514]		10	-90
 Lang	C	1804	Kwaal	B588835-D		Ri Pa Ph Ho		402	HvFd	K3 V M9 V	{ 3 }	(E79+1)	[7B6D]		6	882
 Lang	C	1809	Aanage	A410543-C		Ni Tz		402	HvFd	M3 V M5 V	{ 1 }	(842+3)	[767D]		13	192
-Lang	G	1811	Ihn	D530264-3		De Lo Po Da (minor) O:2313 Tz	A	801	HvFd	M1 V M3 V	{ -3 }	(710-1)	[4131]		5	-7
+Lang	G	1811	Ihn	D530264-3		De Lo Po Da (Tothpre) O:2313 Tz	A	801	HvFd	M1 V M3 V	{ -3 }	(710-1)	[4131]		5	-7
 Lang	G	1817	Aziyyo	A655403-B	E	Ni Ga Pa Lk		123	HvFd	F6 V	{ 1 }	(933+1)	[155B]		14	81
-Lang	K	1821	Fehaa	B310824-B	KM	Na Ph Pi Tz		320	HvFd	M2 V	{ 3 }	(675-5)	[AB1E]		13	-1050
+Lang	K	1821	Fehaa	B310844-B	KM	Na Ph Pi Tz		320	HvFd	M2 V	{ 3 }	(675-5)	[AB1E]		13	-1050
 Lang	K	1822	Cold World	B575531-C	K	Ag Ni Co		912	HvFd	F6 V	{ 2 }	(B45-1)	[671D]		16	-220
 Lang	K	1823	Gyee	D100216-7		Lo Va		302	HvFd	K3 V M4 V	{ -3 }	(A10+1)	[3143]		5	10
 Lang	K	1827	Natrutor	B4A4544-B		Fl Ni Tz		334	HvFd	G4 V M0 V K2 V K9 V	{ 1 }	(946-1)	[764B]		16	-216
@@ -137,14 +137,14 @@ Lang	O	2032	Oryx	A8A3778-C		Fl		103	NaHu	F4 V	{ 2 }	(96B+1)	[594F]		11	594
 Lang	O	2033	Ninoiphl	E310127-9		Lo Co Sa		230	NaHu	K0 V	{ -2 }	(500-2)	[2176]		11	-10
 Lang	O	2035	Genoga	E99A324-9		Lo Wa Tz		222	NaHu	A6 V M0 V	{ -2 }	(B20-4)	[213A]		8	-88
 Lang	O	2039	Andromache	E685552-4		Ag Ni Ga Pr		321	NaHu	K7 V	{ -2 }	(A44+1)	[6351]		7	160
-Lang	G	2111	Fah	A500104-7	K	Lo Va Co Tz		730	HvFd	M3 V	{ -1 }	(600-1)	[1176]		10	-6
+Lang	G	2111	Fah	B500104-7		Lo Va Co Tz		730	HvFd	M3 V	{ -1 }	(600-1)	[1176]		10	-6
 Lang	G	2112	Eeep	E510000-0		Ba		002	HvFd	K1 V M9 V	{ -3 }	(600-5)	[0000]		8	-30
 Lang	G	2117	Phliask	E300000-0		Ba Va Co Tz		002	HvFd	M1 V	{ -3 }	(A00-5)	[0000]		10	-50
 Lang	G	2118	Phleluel	D4A6204-8		Fl Lo Tz		312	HvFd	M0 V	{ -3 }	(E10-5)	[511C]		15	-70
 Lang	G	2120	Unpleasant	B4A4201-A		Fl Lo Co Tz		100	HvFd	K7 V M0 V	{ 1 }	(311+1)	[433A]		8	3
 Lang	K	2121	Nablaq	C300214-7		Lo Va		602	HvFd	G6 V	{ -2 }	(310+3)	[5112]		7	9
 Lang	K	2122	Tyoeh	C654405-A		Ni Pa		222	HvFd	F6 V	{ 0 }	(834-1)	[146E]		9	-96
-Lang	K	2123	Eeg	B630265-6		De Lo Po Da (minor) O:1821	A	112	HvFd	A2 V	{ -1 }	(610+5)	[1154]		9	30
+Lang	K	2123	Eeg	B630265-6		De Lo Po Da (Nightshade) O:1821	A	112	HvFd	A2 V	{ -1 }	(610+5)	[1154]		9	30
 Lang	K	2124	Seh	D100302-7		Lo Va		312	HvFd	F0 V K6 V	{ -3 }	(720+4)	[5185]		12	56
 Lang	K	2129	Phyeaa	C667875-C		Ga Ri Pa Ph Tr		101	HvFd	K8 V M9 V	{ 2 }	(874+1)	[7A7D]		9	224
 Lang	O	2136	Lyekla	A68769C-8		Ag Ni Ga Ri Da Tu	A	223	NaHu	F5 V	{ 1 }	(G57+1)	[7789]		8	560
@@ -152,11 +152,11 @@ Lang	C	2201	Ihjoch	A577423-A	E	Ni Pa		101	HvFd	M3 V	{ 1 }	(933-3)	[1549]		7	-243
 Lang	C	2203	Qissilu	B888525-7		Ag Ni Pr		602	HvFd	M0 V M4 V	{ 0 }	(542-1)	[554A]		7	-40
 Lang	C	2209	Tah	C698203-5		Lo		404	HvFd	M4 II F6 V	{ -2 }	(710+1)	[3187]		14	7
 Lang	K	2225	Tez	B544506-9		Ag Ni		131	HvFd	G8 V	{ 1 }	(E47-3)	[163C]		10	-1176
-Lang	O	2231	Ckiic	B530267-6		De Lo Po Da (minor) O:2631 Ho Tz	A	430	HvFd	K1 V M9 V	{ -1 }	(610-4)	[2177]		13	-24
+Lang	O	2231	Ckiic	B530267-6		De Lo Po Da (Iasza) O:2631 Ho Tz	A	430	HvFd	K1 V M9 V	{ -1 }	(610-4)	[2177]		13	-24
 Lang	O	2236	7B5-177	E7B5000-0		Ba Fl Tz		000	NaXX	M2 V	{ -3 }	(500-5)	[0000]		9	-25
 Lang	O	2240	Melantha III	X699123-6		Lo Fo Lk	R	711	NaHu	F6 V	{ -3 }	(500+1)	[1187]		7	5
-Lang	C	2305	Veea	A884A55-F	K	Hi		121	HvFd	K1 IV F7 V	{ 3 }	(C9B-4)	[9D4H]		8	-4752
-Lang	G	2313	Glyah	B563941-C		Hi Pr Tz		502	HvFd	M2 V M8 V	{ 3 }	(88B+1)	[BC6B]		11	704
+Lang	C	2305	Veea	A884A55-F	K	Cp Hi		121	HvFd	K1 IV F7 V	{ 3 }	(C9B-4)	[9D4H]		8	-4752
+Lang	G	2313	Glyah	A563941-C	K	Cp Hi Pr Tz		502	HvFd	M2 V M8 V	{ 3 }	(88B+1)	[BC6B]		11	704
 Lang	G	2314	Adequate	C559755-6				320	HvFd	G6 V	{ -1 }	(665-5)	[B654]		12	-900
 Lang	K	2321	Xea	B845462-7	K	Ni Pa HumaW Mr		931	HvFd	G5 V	{ -1 }	(932-3)	[7388]		15	-162
 Lang	K	2324	Ahvea	E100104-7		Lo Va Tz		413	HvFd	M1 V	{ -3 }	(600+1)	[1156]		13	6
@@ -170,38 +170,38 @@ Lang	O	2437	7B3-758	X7B3000-0		Ba Fl Co Tz		002	NaXX	M1 V	{ -3 }	(400-5)	[0000]	
 Lang	O	2440	Yemima	C6B8444-9	K	Fl Ni Fr		502	NaHu	M0 V	{ -1 }	(533-3)	[2329]		10	-135
 Lang	D	2503	Fochl	B100102-8		Lo Va Tz		302	HvFd	M0 V	{ -1 }	(A00+1)	[1124]		9	10
 Lang	H	2514	Ackih	C877846-8		Pa Ph Pi GurvW		122	HvFd	K3 V M4 V	{ -1 }	(F76-2)	[877B]		14	-1260
-Lang	H	2519	Nyozee	C865932-C		Hi Ga Pr		100	HvFd	G1 V	{ 2 }	(98D+1)	[9B8B]		4	936
+Lang	H	2519	Nyozee	C865942-C		Hi Ga Pr		100	HvFd	G1 V	{ 2 }	(98D+1)	[9B8B]		4	936
 Lang	L	2527	Saak	B730201-7		De Lo Po Tz		102	HvFd	M2 V	{ -1 }	(710-5)	[1186]		13	-35
 Lang	P	2534	Yekeh	B9B3205-B		Fl Lo		103	HvFd	K0 V	{ 1 }	(511+2)	[232A]		10	10
 Lang	P	2537	Puatacaci	D100210-A		Lo Va		103	NaHu	K0 V	{ -1 }	(710+4)	[318C]		14	28
 Lang	D	2603	Aazyee	A855872-E	E	Ga Pa Ph		732	HvFd	G6 V	{ 2 }	(97B-1)	[6A4E]		11	-693
 Lang	D	2610	Kkiik	A200214-8		Lo Va		104	HvFd	K0 V	{ -1 }	(B10-1)	[217B]		9	-11
 Lang	H	2620	Gea	B410313-8		Lo		111	HvFd	G1 IV	{ -1 }	(B20-2)	[3243]		14	-44
-Lang	P	2631	Pah	A66AA84-F	K	Hi Wa		204	HvFd	F8 V M7 V	{ 3 }	(A96-1)	[7D3D]		12	-540
-Lang	P	2635	Xadee	C642605-9		He Ni Po HumaW		213	HvFd	G7 V	{ -1 }	(754+2)	[5536]		11	280
+Lang	P	2631	Pah	A66AA84-F	K	Cp Hi Wa		204	HvFd	F8 V M7 V	{ 3 }	(A96-1)	[7D3D]		12	-540
+Lang	P	2635	Xadee	C642625-9		He Ni Po HumaW		213	HvFd	G7 V	{ -1 }	(754+2)	[5536]		11	280
 Lang	P	2640	Pris	C8C4437-9		Fl Ni Co Tz		302	NaHu	M2 V	{ -1 }	(C30+1)	[536C]		6	36
-Lang	H	2711	Urzxxyysso	A88A653-7		Ni Ri Wa IthkW		402	HvFd	G4 V	{ 0 }	(951-2)	[4622]		12	-90
+Lang	H	2711	Urzxxyysso	B88A653-7		Ni Ri Wa IthkW		402	HvFd	G4 V	{ 0 }	(951-2)	[4622]		12	-90
 Lang	H	2714	Nyaeh	B400202-A		Lo Va		420	HvFd	K3 V M8 V	{ 1 }	(811-1)	[134B]		15	-8
 Lang	L	2721	Duu	A4A7513-9	E	Fl Ni Co		134	HvFd	A2 V	{ 0 }	(C42-2)	[356E]		15	-192
-Lang	L	2727	Siyza	B542204-A		He Lo Po Ho Sa		822	HvFd	G2 V	{ 1 }	(E11-1)	[2398]		14	-14
+Lang	L	2727	Siyza	B542204-A		Cp He Lo Po Ho Sa		822	HvFd	G2 V	{ 1 }	(E11-1)	[2398]		14	-14
 Lang	L	2728	Eangea	B310212-7	K	Lo Tz		402	HvFd	M4 V	{ -1 }	(B10+1)	[2195]		7	11
 Lang	D	2801	Very Hot	E678501-5		Ag Ni HumaW Ho		214	HvFd	G1 V	{ -2 }	(841+1)	[6378]		17	32
 Lang	D	2803	Veaou	B300102-A		Lo Va Co		820	HvFd	F8 V	{ 1 }	(B01+1)	[125B]		7	11
 Lang	D	2805	Yanuh	B569A84-9		Hi Co Lk		804	HvFd	M7 II K8 V	{ 2 }	(D96+1)	[DC5A]		9	702
 Lang	H	2811	Waap	D866A51-A		Hi Ga		502	HvFd	F7 V	{ 1 }	(794+1)	[7B3E]		9	252
-Lang	H	2813	Optimum	B565955-A	K	Hi Pr		101	HvFd	G9 V M6 V	{ 3 }	(48D+1)	[BC78]		9	416
+Lang	H	2813	Optimum	A565955-A	K	Cp Hi Pr		101	HvFd	G9 V M6 V	{ 3 }	(48D+1)	[BC78]		9	416
 Lang	H	2815	Three Stars	B672611-B		He Ni		302	HvFd	F8 V G8 V M3 V	{ 1 }	(A57+1)	[A7AE]		9	350
-Lang	H	2816	Gohi	X620564-3		De He Ni Po Fo (minor) O:2813 Ho	R	402	HvFd	F9 V M5 V	{ -3 }	(342-4)	[8251]		8	-96
+Lang	H	2816	Gohi	X620564-3		De He Ni Po Fo (Kedaoud) O:2813 Ho	R	402	HvFd	F9 V M5 V	{ -3 }	(342-4)	[8251]		8	-96
 Lang	H	2819	Wrul	E100000-0		Ba Va Tz		001	HvFd	M2 V M6 V	{ -3 }	(900-5)	[0000]		10	-45
-Lang	L	2823	Ochzyu	C4A4666-5		Fl Ni Da (minor) O:2519 Co Lk Px	A	102	HvFd	K8 V M9 V	{ -2 }	(651+1)	[5454]		10	30
+Lang	L	2823	Ochzyu	C4A4666-5		Fl Ni Da (Kingrua) O:2519 Co Lk Px	A	102	HvFd	K8 V M9 V	{ -2 }	(651+1)	[5454]		10	30
 Lang	L	2830	Dohj	D410404-7		Ni		402	HvFd	G3 V	{ -3 }	(632+5)	[511C]		9	180
 Lang	P	2839	410-359	X410000-0		Ba		003	NaXX	F8 V	{ -3 }	(200-5)	[0000]		14	-10
-Lang	D	2910	Va Lat	XAB8505-5		Fl Ni Fo (minor)	R	103	HvFd	A4 IV G3 V	{ -3 }	(540-5)	[6215]		10	-100
+Lang	D	2910	Va Lat	XAB8505-5		Fl Ni Fo (Alktatre)	R	103	HvFd	A4 IV G3 V	{ -3 }	(540-5)	[6215]		10	-100
 Lang	H	2919	Ziiping	C546756-6		Ag Pi Pz HumaW Co	A	933	HvFd	K6 V M3 V	{ 0 }	(86C+2)	[8786]		14	1152
 Lang	L	2924	Yeeng	E500000-0		Ba Va Lk		002	HvFd	M0 V	{ -3 }	(900-5)	[0000]		12	-45
 Lang	L	2927	Cuulyang	C410205-7		Lo Co Tz		121	HvFd	M1 V	{ -2 }	(710+2)	[2139]		13	14
 Lang	P	2936	Raapuy	C65A741-9		Wa Co		123	HvFd	G8 V K8 V	{ 0 }	(E63+1)	[479B]		12	252
-Lang	D	3002	Dax	A655754-C	KM	Ag Ga		611	HvFd	F2 V	{ 4 }	(D6B+1)	[9B6E]		12	858
+Lang	D	3002	Dax	A655754-C	KM	Ag Cp Ga		611	HvFd	F2 V	{ 4 }	(D6B+1)	[9B6E]		12	858
 Lang	D	3010	Unsuitable	A621544-9	E	He Ni Po Tz		302	HvFd	M0 V	{ 0 }	(A45-1)	[258B]		7	-200
 Lang	H	3018	Vuth	B676301-8		Lo Tu		222	HvFd	G4 V K6 V	{ -1 }	(920+2)	[4297]		14	36
 Lang	L	3024	Geyipyy	C100403-8		Ni Va Ho Tz		202	HvFd	K6 V M3 V	{ -2 }	(930+1)	[6236]		10	27
@@ -216,6 +216,6 @@ Lang	P	3134	Vazoi	C750764-7		De Po O:2631 Ho Tz		600	HvFd	K3 V M6 V	{ -1 }	(766-
 Lang	P	3138	Goold	C777376-9	KM	Lo Tz		123	NaHu	M0 V	{ 0 }	(E20-1)	[836A]		11	-28
 Lang	P	3139	Palantir	C665999-8		Hi Ga Pr Sa		221	NaHu	G5 V M9 V	{ 0 }	(989+3)	[A957]		11	1944
 Lang	D	3205	Limited	D300211-8		Lo Va Ho		201	HvFd	G4 V	{ -3 }	(B10-1)	[3137]		9	-11
-Lang	P	3233	Geaeeraa	E8A6603-7		Fl Ni		130	HvFd	G7 V	{ -3 }	(A50-1)	[3397]		10	-50
+Lang	P	3233	Geaeeraa	E8A6503-7		Fl Ni		130	HvFd	G7 V	{ -3 }	(A40-1)	[3397]		10	-40
 Lang	P	3236	Gloxcontat	C410444-7		Ni Ho Tz		420	NaHu	K4 V M1 V	{ -2 }	(733+1)	[1297]		14	63
 Lang	P	3237	Maghreb	A730744-B		De Na Po		431	NaHu	M3 V D	{ 2 }	(A67+1)	[895C]		15	420

--- a/res/Sectors/M1105/Langere.xml
+++ b/res/Sectors/M1105/Langere.xml
@@ -31,12 +31,52 @@
     <Subsector Index="O">Oryx</Subsector>
     <Subsector Index="P">Palantir</Subsector>
   </Subsectors>
+  <Allegiances>
+    <Allegiance Code="Hf">Hive FDA Uplift/Observation Site</Allegiance>
+    <Allegiance Code="CsHv">Client state, Hive Federation</Allegiance>
+    <Allegiance Code="Xh">Hive FDA extra-Federation operation</Allegiance>
+  </Allegiances>
   <Borders>
-   <Border Allegiance="HvFd" LabelPosition="2118">0716 0815 0915 1014 1013 1113 1112 1111 1110 1109 1108 1207 1206 1306 1305 1304 1303 1302 1201 1101 1000 1100 1200 1300 1400 1500 1600 1700 1800 1900 2000 2100 2200 2300 2400 2500 2600 2700 2800 2900 3000 3100 3200 3300 3301 3302 3303 3304 3305 3306 3307 3308 3309 3310 3311 3312 3313 3314 3315 3316 3317 3318 3319 3320 3321 3322 3323 3324 3325 3326 3327 3328 3329 3330 3331 3332 3333 3334 3233 3134 3034 2935 2936 2835 2735 2635 2634 2534 2533 2432 2332 2231 2230 2229 2129 2028 1928 1827 1728 1628 1627 1527 1426 1326 1425 1525 1624 1623 1723 1822 1821 1820 1720 1619 1519 1419 1320 1220 1121 1020 0920 0819 0720 0819 0919 0918 0817 0717 0716 </Border>
+   <Border Allegiance="HvFd" LabelPosition="2116">0716 0815 0915 1014 1013 1113 1112 1111 1110 1109 1108 1207 1206 1306 1305 1304 1303 1302 1201 1101 1000 1100 1200 1300 1400 1500 1600 1700 1800 1900 2000 2100 2200 2300 2400 2500 2600 2700 2800 2900 3000 3100 3200 3300 3301 3302 3303 3304 3305 3306 3307 3308 3309 3310 3311 3312 3313 3314 3315 3316 3317 3318 3319 3320 3321 3322 3323 3324 3325 3326 3327 3328 3329 3330 3331 3332 3333 3334 3233 3134 3034 2935 2936 2835 2735 2635 2634 2534 2533 2432 2332 2231 2230 2229 2129 2028 1928 1827 1728 1628 1627 1527 1426 1326 1425 1525 1624 1623 1723 1822 1821 1820 1720 1619 1519 1419 1320 1220 1121 1020 0920 0819 0720 0819 0919 0918 0817 0717 0716 </Border>
     <Border Allegiance="SoCf" LabelPosition="0404">0000 0100 0200 0300 0400 0500 0600 0700 0800 0900 0800 0801 0701 0601 0502 0402 0303 0304 0305 0306 0206 0107 0108 0109 0009 0010 0011 0012 0113 0114 0214 0215 0316 0416 0317 0217 0218 0119 0019 0018 0017 0016 0015 0014 0013 0012 0011 0010 0009 0008 0007 0006 0005 0004 0003 0002 0001 0000 </Border>
     <Border Allegiance="SoHn" WrapLabel="true" Color="Blue" LabelPosition="0311" Label="Hanuman Systems">0308 0408 0509 0609 0710 0809 0710 0711 0610 0510 0409 0408 0308 </Border>
   </Borders>
   <Routes>
+    <Route Start="3002" End="2940" EndOffsetY="-1" Type="Trade" />
+    <Route Start="2803" End="3002" Type="Trade" />
+    <Route Start="2603" End="2803" Type="Trade" />
+    <Route Start="2305" End="2603" Type="Trade" />
+    <Route Start="2201" End="2240" EndOffsetY="-1" Type="Trade" />
+    <Route Start="2203" End="2201" Type="Trade" />
+    <Route Start="2305" End="2203" Type="Trade" />
+    <Route Start="2005" End="2305" Type="Trade" />
+    <Route Start="1804" End="2005" Type="Trade" />
+    <Route Start="1505" End="1804" Type="Trade" />
+    <Route Start="1304" End="1505" Type="Trade" />
+    <Route Start="2007" End="2005" Type="Trade" />
+    <Route Start="1809" End="2007" Type="Trade" />
+    <Route Start="2111" End="1809" Type="Trade" />
+    <Route Start="2313" End="2111" Type="Trade" />
+    <Route Start="2514" End="2313" Type="Trade" />
+    <Route Start="2813" End="2514" Type="Trade" />
+    <Route Start="2815" End="2813" Type="Trade" />
+    <Route Start="3018" End="2815" Type="Trade" />
+    <Route Start="3018" End="0217" EndOffsetX="1" Type="Trade" />
+    <Route Start="2721" End="3018" Type="Trade" />
+    <Route Start="2519" End="2721" Type="Trade" />
+    <Route Start="2321" End="2519" Type="Trade" />
+    <Route Start="2019" End="2321" Type="Trade" />
+    <Route Start="1817" End="2019" Type="Trade" />
+    <Route Start="1518" End="1817" Type="Trade" />
+    <Route Start="1216" End="1518" Type="Trade" />
+    <Route Start="1013" End="1216" Type="Trade" />
+    <Route Start="1821" End="2019" Type="Trade" />
+    <Route Start="1725" End="1821" Type="Trade" />
+    <Route Start="3025" End="0125" EndOffsetX="1" Type="Trade" />
+    <Route Start="2727" End="3025" Type="Trade" />
+    <Route Start="2728" End="2727" Type="Trade" />
+    <Route Start="2830" End="2728" Type="Trade" />
+    <Route Start="2631" End="2830" Type="Trade" />
     <Route Start="0109" End="0509" Allegiance="SoCf" />
     <Route Start="0509" End="0711" Allegiance="SoCf" />
     <Route Start="0214" End="3013" EndOffsetX="-1" Allegiance="SoCf" />

--- a/res/Sectors/M1105/Phlask.xml
+++ b/res/Sectors/M1105/Phlask.xml
@@ -23,17 +23,20 @@
   </Subsectors>
   <Allegiances>
     <Allegiance Code="Ia">Ithklur Aexzz</Allegiance>
+    <Allegiance Code="Hf">Hive FDA Uplift/Observation Site</Allegiance>
+    <Allegiance Code="CsHv">Client state, Hive Federation</Allegiance>
+    <Allegiance Code="Xh">Hive FDA extra-Federation operation</Allegiance>
   </Allegiances>
 
   <Regions>
-    <Region Color="Aquamarine" Label="Nainur Regime" WrapLabel="true">
+    <Region Color="Aquamarine" Label="Nainur Regime" LabelPosition="2014" WrapLabel="true">
       1916 2015 2115 2114 2115 2215 2116 2015 1916
     </Region>
   </Regions>
 
   <Borders>
-    <Border Allegiance="HvFd">0017 0117 0217 0317 0417 0517 0616 0716 0815 0915 1014 1114 1213 1313 1412 1512 1612 1713 1813 1913 2012 2112 2212 2312 2411 2511 2611 2712 2811 2912 3011 3112 3211 3312 3313 3314 3315 3316 3317 3318 3319 3320 3321 3322 3323 3324 3325 3326 3327 3328 3329 3330 3331 3332 3333 3334 3335 3336 3337 3338 3339 3340 3341 3241 3141 3041 2941 2841 2741 2641 2541 2441 2341 2241 2141 2041 1941 1841 1741 1641 1541 1441 1341 1241 1141 1041 0941 0841 0741 0641 0541 0441 0341 0241 0141 0041 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030 0029 0028 0027 0026 0025 0024 0023 0022 0021 0020 0019 0018 0017</Border>
-    <Border Allegiance="Ia" Color="pink" WrapLabel="true">2200 2300 2400 2500 2600 2700 2800 2900 3000 3100 3200 3300 3301 3201 3102 3103 3102 3001 2901 2800 2701 2601 2602 2603 2504 2403 2402 2302 2301 2200</Border>
+    <Border Allegiance="HvFd" LabelPosition="1525">0017 0117 0217 0317 0417 0517 0616 0716 0815 0915 1014 1114 1213 1313 1412 1512 1612 1713 1813 1913 2012 2112 2212 2312 2411 2511 2611 2712 2811 2912 3011 3112 3211 3312 3313 3314 3315 3316 3317 3318 3319 3320 3321 3322 3323 3324 3325 3326 3327 3328 3329 3330 3331 3332 3333 3334 3335 3336 3337 3338 3339 3340 3341 3241 3141 3041 2941 2841 2741 2641 2541 2441 2341 2241 2141 2041 1941 1841 1741 1641 1541 1441 1341 1241 1141 1041 0941 0841 0741 0641 0541 0441 0341 0241 0141 0041 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030 0029 0028 0027 0026 0025 0024 0023 0022 0021 0020 0019 0018 0017</Border>
+    <Border Allegiance="Ia" Color="pink" LabelPosition="2502" WrapLabel="true">2200 2300 2400 2500 2600 2700 2800 2900 3000 3100 3200 3300 3301 3201 3102 3103 3102 3001 2901 2800 2701 2601 2602 2603 2504 2403 2402 2302 2301 2200</Border>
   </Borders>
 
   <Routes>
@@ -57,10 +60,11 @@
     <Route Start="0720" End="0820" Type="Trade"/>
     <Route Start="1021" End="0820" Type="Trade"/>
     <Route Start="1021" End="1122" Type="Trade"/>
+    <Route Start="1122" End="1222" Type="Trade"/>
     <Route Start="1222" End="1120" Type="Trade"/>
     <Route Start="1222" End="1323" Type="Trade"/>
     <Route Start="1624" End="1323" Type="Trade"/>
-    <Route Start="1325" End="1323" Type="Trade" />
+    <Route Start="1325" End="1323" Type="Trade"/>
     <Route Start="1325" End="1226" Type="Trade"/>
     <Route Start="1818" End="2118" Type="Trade"/>
     <Route Start="2215" End="2118" Type="Trade"/>
@@ -79,6 +83,8 @@
     <Route Start="0737" End="0539" Type="Trade"/>
     <Route Start="0834" End="0434" Type="Trade"/>
     <Route Start="0434" End="0332" Type="Trade"/>
+    <Route Start="0332" End="0431" Type="Trade"/>
+    <Route Start="0332" End="3230" EndOffsetX="-1" Type="Trade" />
     <Route Start="0431" End="0531" Type="Trade"/>
     <Route Start="0531" End="0732" Type="Trade"/>
     <Route Start="2631" End="2931" Type="Trade"/>
@@ -90,9 +96,9 @@
     <Route Start="3020" End="2619" Type="Trade"/>
     <Route Start="3020" End="3121" Type="Trade"/>
     <Route Start="2512" End="2516" Type="Trade"/>
-    <Route Start="0332" End="0434" Type="Trade"/>
     <Route Start="1430" End="1632" Type="Trade"/>
     <Route Start="1330" End="1630" Type="Trade"/>
+    <Route Start="1330" End="1430" Type="Trade"/>
     <Route Start="1934" End="1632" Type="Trade"/>
     <Route Start="1433" End="1632" Type="Trade"/>
     <Route Start="1433" End="1434" Type="Trade"/>
@@ -124,11 +130,15 @@
     <Route Start="1234" End="0935" Type="Trade"/>
     <Route Start="0935" End="0834" Type="Trade"/>
     <Route Start="0539" End="0238" Type="Trade"/>
+    <Route Start="0238" End="3238" EndOffsetX="-1" Type="Trade" />
     <Route Start="2828" End="2927" Type="Trade"/>
     <Route Start="2927" End="3224" Type="Trade"/>
     <Route Start="2931" End="3133" Type="Trade"/>
     <Route Start="2937" End="3135" Type="Trade"/>
     <Route Start="3135" End="3133" Type="Trade"/>
     <Route Start="0625" End="1026" Type="Trade"/>
+    <Route Start="0625" End="0423" Type="Trade"/>
+    <Route Start="0423" End="0125" Type="Trade"/>
+    <Route Start="0125" End="3225" EndOffsetX="-1" Type="Trade" />
   </Routes>
 </Sector>

--- a/res/Sectors/M1105/Spica.tab
+++ b/res/Sectors/M1105/Spica.tab
@@ -174,7 +174,7 @@ Spic	B	1303	Icestop	C201447-9		Ic Ni Va		520	NaHu	M2 V	{ -1 }	(832-1)	[4359]		9	
 Spic	B	1307	Gomez	C550778-6		De Po		803	NaHu	M2 V M6 V	{ -1 }	(966-1)	[7656]		14	-324
 Spic	F	1311	Sephor	C544336-9		Lo		402	NaHu	G4 V M6 V	{ -1 }	(720-2)	[2248]		8	-28
 Spic	F	1318	Lucullan	B7975AB-A		Ag Ni Da	A	400	NaHu	K2 V	{ 2 }	(746+4)	[777C]		13	672
-Spic	F	1319	Quatre	B421565-A		He Ni Po (minor) O:1522		914	HvFd	G5 IV M2 V M9 V	{ 1 }	(C45-1)	[3638]		15	-240
+Spic	F	1319	Quatre	B421565-A		He Ni Po (Rahnha) O:1522		914	HvFd	G5 IV M2 V M9 V	{ 1 }	(C45-1)	[3638]		15	-240
 Spic	J	1322	Gropie	C799313-7		Lo		305	HvFd	M0 V	{ -2 }	(520-5)	[1124]		9	-50
 Spic	J	1323	Nax'Hah'Nor	C7B877B-8		Fl Pz	A	804	SoCf	M0 V	{ -1 }	(D67+1)	[967A]		7	546
 Spic	J	1324	Border	BA9A734-C		Oc Pi		523	HvFd	M0 V	{ 2 }	(E6C+1)	[593A]		11	1008
@@ -194,12 +194,12 @@ Spic	B	1410	Larellum	C535587-6		Ni		503	NaHu	M2 V	{ -2 }	(742-2)	[5356]		14	-112
 Spic	F	1416	Distal	B541223-8		He Lo Po		720	NaHu	A8 V	{ -1 }	(610-4)	[1125]		10	-24
 Spic	F	1417	Duomo	D5328DE-6		Na Po Ph Pz	A	903	NaHu	M0 V M0 V	{ -2 }	(A75+2)	[C69A]		11	700
 Spic	J	1423	Xezelfarb	D544723-6		Ag Pi Pz	A	610	HvFd	K2 V M9 V	{ -1 }	(966-4)	[4623]		13	-1296
-Spic	J	1427	Aow'Post	E7B4000-0		Ba Fl (minor)		010	HvFd	M2 V	{ -3 }	(200-5)	[0000]		12	-10
+Spic	J	1427	Aow'Post	E7B4000-0		Ba Fl Di(Ulkatrac)		010	HvFd	M2 V	{ -3 }	(200-5)	[0000]		12	-10
 Spic	N	1431	Lyihtar	D423752-9		Na Po Pi		100	HvFd	M1 V M5 V	{ -1 }	(968-5)	[3615]		10	-2160
 Spic	N	1432	Peris	B545876-6	KM	Pa Ph Pi Pz	A	913	SoCf	A3 V	{ 1 }	(A78+1)	[7945]		13	560
 Spic	N	1433	Tongariro	E568557-6		Ag Ni Pr		420	SoCf	M2 V	{ -2 }	(742-2)	[5356]		5	-112
 Spic	N	1436	Kasur	E521876-7		He Na Po Ph Pi		614	HvFd	M2 V M3 V	{ -2 }	(A76-3)	[7646]		8	-1260
-Spic	N	1438	Cairgax	C531833-6		Na Po Ph (minor)		810	HvFd	G3 V M8 V	{ -1 }	(A76-4)	[5723]		14	-1680
+Spic	N	1438	Cairgax	C531833-6		Na Po Ph (Qizzuekzi)		810	HvFd	G3 V M8 V	{ -1 }	(A76-4)	[5723]		14	-1680
 Spic	N	1439	Royran	C532836-9		Na Po Ph		710	HvFd	M2 V M9 V	{ 0 }	(B79-1)	[7848]		14	-693
 Spic	N	1440	Denher IV	A557445-D	KM	Ni Pa		324	HvFd	G6 IV	{ 2 }	(C35+1)	[263B]		9	180
 Spic	B	1502	Foster	C426522-B		Ni		314	NaHu	M2 V	{ 0 }	(C44-4)	[1517]		9	-768
@@ -236,7 +236,7 @@ Spic	K	1722	Star Hub	A401434-E	KM	Ic Ni Va		514	HvFd	G4 V M1 V	{ 2 }	(B35+1)	[26
 Spic	K	1729	Yengilz	E550305-8		De Lo Po		611	HvFd	K1 V	{ -3 }	(720-5)	[1136]		10	-70
 Spic	O	1731	Mihne	B430353-9	K	De Lo Po		504	HvFd	F8 V	{ 0 }	(920-3)	[1326]		11	-54
 Spic	O	1736	Buron	E688422-7		Ni Pa		510	HvFd	M0 V M3 V	{ -3 }	(631-5)	[1113]		14	-90
-Spic	O	1738	Waxatha	C8C6567-9		Fl Ni (minor) O:1638		413	HvFd	K7 V M3 V	{ -1 }	(B43-1)	[5459]		16	-132
+Spic	O	1738	Waxatha	C8C6567-9		Fl Ni (Duiars) O:1638		413	HvFd	K7 V M3 V	{ -1 }	(B43-1)	[5459]		16	-132
 Spic	O	1740	Doduk	A663104-E		Lo		304	HvFd	M0 V	{ 1 }	(701-1)	[123C]		10	-7
 Spic	C	1802	Storewell	C5208AA-7		De He Na Po Ph Pi Pz	A	803	NaHu	M7 II	{ -1 }	(A77+1)	[A779]		13	490
 Spic	C	1805	Xoar Beta	E310332-7		Lo Da	A	600	NaHu	G8 III M8 V	{ -3 }	(520-5)	[1113]		10	-50
@@ -262,14 +262,14 @@ Spic	C	1910	Ceril	C200222-A		Lo Va Da	A	610	NaHu	K1 V M2 V	{ 0 }	(510-4)	[1216]	
 Spic	G	1913	Delea I	C431675-9		Na Ni Po		600	NaHu	K2 V	{ -1 }	(853-3)	[4537]		11	-360
 Spic	G	1914	Caldor	C577587-5		Ag Ni		214	NaHu	K1 V	{ -1 }	(743-1)	[5455]		10	-84
 Spic	G	1919	Sorgho	B6A8852-C		Fl Ph An		803	NaHu	K0 V M0 V	{ 2 }	(D7C-2)	[4A18]		11	-2184
-Spic	K	1921	Xoarax	D311859-7		Ic Na Ph Pi (minor)		400	HvFd	G4 V M3 V	{ -2 }	(A76-1)	[9668]		11	-420
+Spic	K	1921	Xoarax	D311859-7		Ic Na Ph Pi (Wuiche)		400	HvFd	G4 V M3 V	{ -2 }	(A76-1)	[9668]		11	-420
 Spic	K	1922	Pilza	B78A635-C	KM	Ni Ri Wa		104	HvFd	M1 V	{ 3 }	(C57+1)	[493A]		9	420
 Spic	K	1923	Naros	E599855-8		Ph Pi		810	HvFd	K2 V	{ -2 }	(B76-4)	[6636]		5	-1848
 Spic	K	1925	Zinam	D69A345-9		Lo Wa		313	HvFd	M0 V	{ -2 }	(920-4)	[1137]		13	-72
-Spic	K	1926	Particulately	A743267-A	E	Lo Po (minor) O:2026		200	HvFd	M1 V M3 V	{ 1 }	(411+1)	[235A]		8	4
+Spic	K	1926	Particulately	A743267-A	E	Lo Po (Kanuwail) O:2026		200	HvFd	M1 V M3 V	{ 1 }	(411+1)	[235A]		8	4
 Spic	K	1927	Wrengex IV	B789265-C		Lo O:2026		500	HvFd	A7 V	{ 1 }	(411-1)	[133A]		13	-4
 Spic	K	1930	Kurzon Dax	D798656-7		Ag Ni		503	HvFd	G1 V	{ -2 }	(852-3)	[5446]		9	-240
-Spic	O	1934	Sealene	XA7A501-6		Ni Oc Fo (minor)	R	415	HvFd	K1 V M2 V	{ -3 }	(741-5)	[1212]		10	-140
+Spic	O	1934	Sealene	XA7A501-6		Ni Oc Fo (Oetkle)	R	415	HvFd	K1 V M2 V	{ -3 }	(741-5)	[1212]		10	-140
 Spic	O	1938	Danan	B677556-B		Ag Ni		335	HvFd	M0 V	{ 2 }	(F46+1)	[474A]		11	360
 Spic	C	2002	Liam	E899000-0		Ba		002	NaHu	M2 V M3 V	{ -3 }	(200-5)	[0000]		14	-10
 Spic	C	2003	Tyrolia	A41199B-C		Hi Ic In Na Pz	A	703	NaHu	K3 V	{ 4 }	(E8F+5)	[BD7E]		10	8400
@@ -278,14 +278,14 @@ Spic	G	2015	Aesop	C895356-7		Lo		600	NaHu	M0 V M6 V	{ -2 }	(520-3)	[2146]		11	-3
 Spic	K	2026	Nelyo	B532836-B		Na Po Ph		205	HvFd	M1 V	{ 2 }	(F7C+1)	[7A4A]		10	1260
 Spic	K	2030	Splosh	EA9A412-9		Ni Oc		905	HvFd	G5 IV	{ -2 }	(B31-5)	[1215]		11	-165
 Spic	O	2033	Gorong	CAEA855-B		Oc Ph		704	HvFd	M1 V	{ 1 }	(E7B-1)	[6939]		9	-1078
-Spic	O	2034	Amrad	C423364-8		Lo Po (minor) O:2235		200	HvFd	M7 III	{ -2 }	(520-4)	[1136]		9	-40
+Spic	O	2034	Amrad	C423364-8		Lo Po (Mitrai) O:2235		200	HvFd	M7 III	{ -2 }	(520-4)	[1136]		9	-40
 Spic	O	2037	Baral	C550656-9		De Ni Po		803	HvFd	K1 V	{ -1 }	(B53-2)	[5548]		11	-330
 Spic	C	2103	Strictland	B550676-7	M	De Ni Po		603	NaHu	M3 V M5 V	{ -1 }	(853-2)	[5546]		11	-240
 Spic	C	2105	Malley	C6A98AA-8		Fl Ph Pz	A	802	NaHu	M2 V M7 V	{ -1 }	(C77+1)	[A77A]		8	588
 Spic	C	2109	Good Place	C6A9731-8		Fl		314	NaHu	M2 V	{ -1 }	(E67-5)	[3614]		8	-2940
 Spic	G	2113	Adamantium	A101354-D		Ic Lo Va		300	NaHu	K8 V M8 V	{ 1 }	(521-1)	[143B]		5	-10
 Spic	G	2117	Rasomb	B564202-C		Lo		602	HvFd	K4 V M2 V	{ 1 }	(611-3)	[1318]		12	-18
-Spic	G	2118	Deru Nooq	A8638A5-C		Ri Ph		210	HvFd	M6 III	{ 3 }	(B7D+1)	[6B3A]		6	1001
+Spic	G	2118	Deru Nooq	A8638A5-C		Cp Ri Ph		210	HvFd	M6 III	{ 3 }	(B7D+1)	[6B3A]		6	1001
 Spic	G	2120	Zokel	C634853-A		Ph		534	HvFd	K2 V	{ 1 }	(H7A-2)	[5927]		10	-2380
 Spic	K	2122	Bolehlz	E7BA000-0		Ba Fl		000	HvFd	K7 V M1 V	{ -3 }	(200-5)	[0000]		10	-10
 Spic	K	2124	Delf III	C6A4432-8		Fl Ni		402	HvFd	G1 III D	{ -2 }	(831-5)	[1214]		10	-120
@@ -294,18 +294,18 @@ Spic	K	2127	Pekihr	E6A7463-8		Fl Ni O:2026		610	HvFd	M0 V	{ -3 }	(731-5)	[1125]	
 Spic	K	2129	Ubreyukask	X596404-5		Ni Pa Fo	R	504	HvFd	K2 V	{ -3 }	(631-5)	[2133]		11	-90
 Spic	O	2133	Zeldar	B898864-A		Pa Ph Pi O:2532		804	HvFd	M2 V M6 V	{ 2 }	(E7B+1)	[6A38]		12	1078
 Spic	O	2134	Bingon	C867614-8		Ag Ni Ga Ri An		724	HvFd	A3 V	{ 0 }	(E54-2)	[4636]		9	-560
-Spic	O	2136	Tharal	A541566-A	E	He Ni Po (minor) O:2235		713	HvFd	G2 V M4 V M1 V	{ 1 }	(B45+1)	[4649]		13	220
+Spic	O	2136	Tharal	A541566-A	E	He Ni Po (Drangka) O:2235		713	HvFd	G2 V M4 V M1 V	{ 1 }	(B45+1)	[4649]		13	220
 Spic	O	2137	Dari	B766532-B	K	Ag Ni Ga Pr		824	HvFd	F0 V	{ 2 }	(D46-2)	[1717]		10	-624
 Spic	C	2205	Spica	C755684-5		Ag Ni Ga		704	NaHu	K4 II M7 V	{ -1 }	(853-3)	[4533]		11	-360
 Spic	C	2207	Faller	C557663-4		Ag Ni O:2307		513	NaHu	G4 V	{ -1 }	(853-4)	[3521]		7	-480
 Spic	G	2218	Nandan	B540264-B		De He Lo Po O:2118		614	HvFd	M3 V	{ 1 }	(911-1)	[1339]		12	-9
 Spic	G	2219	Dapan	C411156-9		Ic Lo		320	HvFd	M0 V	{ -1 }	(500-2)	[1148]		13	-10
-Spic	K	2224	Pezal	AAC9467-A	E	Fl Ni (minor) O:2524		804	HvFd	F2 III	{ 1 }	(A34+1)	[455A]		15	120
+Spic	K	2224	Pezal	AAC9647-A	E	Cp Fl Ni (Koatra)8		804	HvFd	F2 III	{ 1 }	(A54+1)	[455A]		15	120
 Spic	K	2230	Cap Subsidiary	B101614-D		Ic Na Ni Va		104	HvFd	M0 V	{ 1 }	(C55-1)	[473B]		13	-300
 Spic	O	2231	Mehlang	C655952-B		Hi Ga		314	HvFd	M0 V M5 V	{ 2 }	(G8D-2)	[5B17]		13	-3328
 Spic	O	2232	Pendar Hai	D555275-7		Lo		212	HvFd	M2 V	{ -3 }	(410-5)	[1135]		14	-20
 Spic	O	2233	Banihld	A89A552-B		Ni Wa		510	HvFd	M3 V	{ 1 }	(845-3)	[1617]		8	-480
-Spic	O	2235	Mehndong	A897683-C	K	Ag Ni		412	HvFd	M2 V	{ 2 }	(B56-1)	[3829]		13	-330
+Spic	O	2235	Mehndong	A897683-C	K	Cp Ag Ni		412	HvFd	M2 V	{ 2 }	(B56-1)	[3829]		13	-330
 Spic	O	2240	Dosos	A6A2541-E		Fl He Ni		600	HvFd	K2 V M2 V	{ 1 }	(745-3)	[161A]		9	-420
 Spic	C	2306	Stewart	A59A855-B		Wa Ph Pi		211	NaHu	K0 V	{ 2 }	(C7C+1)	[6A39]		12	1008
 Spic	C	2307	Spyral	B556730-A	KM	Ag		703	NaHu	K2 V	{ 4 }	(C6D+1)	[2B15]		9	936
@@ -318,7 +318,7 @@ Spic	G	2318	Baren	A651464-B	E	Ni Po O:2118		400	HvFd	G3 V M7 V	{ 1 }	(634-1)	[25
 Spic	G	2320	Piyrul	E530554-8		De Ni Po		700	HvFd	K3 V M0 V M1 V	{ -3 }	(741-5)	[3236]		8	-140
 Spic	K	2321	Thinel	B552865-A		Po Ph O:2621		114	HvFd	M3 V	{ 2 }	(F7B+1)	[6A38]		11	1155
 Spic	K	2323	Nethok	C541356-A		He Lo Po		500	HvFd	K7 V M5 V	{ 0 }	(520-1)	[2349]		9	-10
-Spic	K	2328	Lihnor	A54526A-9	KM	Lo (minor) Mr		100	HvFd	M2 V	{ 1 }	(411+3)	[437B]		13	12
+Spic	K	2328	Lihnor	A54526A-9	KM	Lo (Loubau) Mr		100	HvFd	M2 V	{ 1 }	(411+3)	[437B]		13	12
 Spic	K	2329	Kasal	C89A833-A		Wa Ph Pi Pz	A	410	HvFd	M1 V	{ 1 }	(B7A-2)	[5927]		9	-1540
 Spic	O	2331	Dehlzo	C859453-B		Ni		215	HvFd	M1 V M5 V M2 V	{ 0 }	(C33-3)	[1428]		12	-324
 Spic	O	2334	Ff	B540464-B	K	De He Ni Po Mr		804	HvFd	M3 V	{ 1 }	(A34-1)	[2539]		15	-120
@@ -338,12 +338,12 @@ Spic	K	2422	Nihtehl	B431303-C		Lo Po		914	HvFd	M1 V M4 V	{ 1 }	(A21-2)	[1429]		8
 Spic	K	2423	Tehyehl	D89A123-8		Lo Wa Da	A	200	HvFd	M0 V	{ -3 }	(300-5)	[1125]		13	-15
 Spic	K	2424	Benong IV	A8CA663-C		Fl Ni O:2524		510	HvFd	G4 IV M4 V	{ 1 }	(955-2)	[3729]		12	-450
 Spic	K	2427	Zeko	E568722-6		Ag Ri		404	HvFd	M0 V M8 V	{ 0 }	(967-4)	[3712]		8	-1512
-Spic	O	2431	Ordva	D63466B-6		Ni (minor) O:2532		500	HvFd	G1 V	{ -3 }	(851-1)	[8378]		10	-40
+Spic	O	2431	Ordva	D63466B-6		Ni (Icham) O:2532		500	HvFd	G1 V	{ -3 }	(851-1)	[8378]		10	-40
 Spic	O	2432	Birak	E646552-6		Ag Ni		302	HvFd	M0 III D	{ -2 }	(742-5)	[1312]		12	-280
 Spic	O	2433	Zalehs	A853656-A		Ni Po		905	HvFd	G4 V	{ 1 }	(D55+1)	[5749]		11	325
 Spic	O	2435	Lonibh	C674851-9		Pa Ph Pi		724	HvFd	K3 V	{ 0 }	(G79-4)	[4815]		9	-4032
 Spic	O	2437	Rehndol	B550451-B		De Ni Po		803	HvFd	M2 V M9 V	{ 1 }	(934-3)	[1517]		12	-324
-Spic	H	2518	Star Harvest	A78A464-A	KM	Ni Wa O:2621		203	HvFd	K3 V	{ 2 }	(935+1)	[2638]		12	135
+Spic	H	2518	Star Harvest	A78A464-A	KM	Cp Ni Wa O:2621		203	HvFd	K3 V	{ 2 }	(935+1)	[2638]		12	135
 Spic	H	2520	Lucubratious	E000243-7		As Lo Va		514	NaHu	G3 V M7 V	{ -3 }	(410-5)	[1124]		8	-20
 Spic	L	2522	Zlaleld	C798501-A		Ag Ni		804	HvFd	M1 V M7 V	{ 1 }	(B45-3)	[1616]		10	-660
 Spic	L	2523	Rebang	C896455-7		Ni Pa		914	HvFd	M1 V M9 V	{ -2 }	(631-4)	[2235]		8	-72
@@ -351,7 +351,7 @@ Spic	L	2524	Deso	B655734-A		Ag Ga		220	HvFd	K1 V	{ 3 }	(B6C+1)	[5A38]		6	792
 Spic	L	2525	Bendus	D100656-A		Na Ni Va		305	HvFd	G3 V	{ -1 }	(D53-2)	[5549]		11	-390
 Spic	L	2529	Erest	A695723-C		Ag Pi		424	HvFd	M0 V M0 V	{ 3 }	(F6D+1)	[4A29]		11	1170
 Spic	L	2530	Nehron	E699000-0		Ba		000	HvFd	M3 V	{ -3 }	(200-5)	[0000]		8	-10
-Spic	P	2532	Shipsboat	B668942-C	KM	Hi Pr		503	HvFd	F4 V M6 V	{ 4 }	(E8F+1)	[5D18]		9	1680
+Spic	P	2532	Shipsboat	A668942-C	KM	Cs Hi Pr		503	HvFd	F4 V M6 V	{ 4 }	(E8F+1)	[5D18]		9	1680
 Spic	P	2536	Nehlar	A843755-D		Po Pi		400	HvFd	G1 V M3 V	{ 2 }	(96D+1)	[593B]		9	702
 Spic	P	2537	Raghehk	A956563-D		Ag Ni O:2536		424	HvFd	F4 V	{ 2 }	(D46-1)	[272A]		12	-312
 Spic	P	2539	Kinyar VI	B57A754-D		Wa Pi		904	HvFd	K4 II M6 V	{ 2 }	(D6D+1)	[593B]		14	1014
@@ -362,11 +362,11 @@ Spic	D	2610	Crescendo	E559559-7		Ni		905	NaHu	K0 V	{ -3 }	(741-2)	[6268]		11	-56
 Spic	H	2612	Slater	B887765-A	KM	Ag Ga Ri Mr		921	NaHu	K0 V M6 V	{ 5 }	(C6E+3)	[5C38]		15	3024
 Spic	H	2613	Deseret	E674747-5		Ag Pi		704	NaHu	K1 V	{ -1 }	(966-1)	[7655]		10	-324
 Spic	H	2619	Tritran	E432554-A		Ni Po		523	HvFd	M2 V M2 V	{ -1 }	(C43-3)	[3438]		8	-432
-Spic	L	2621	Pihras	A554953-D		Hi		200	HvFd	G2 V	{ 3 }	(B8F+1)	[6C2A]		11	1320
+Spic	L	2621	Pihras	A554953-D		Cp Hi		200	HvFd	G2 V	{ 3 }	(B8F+1)	[6C2A]		11	1320
 Spic	L	2624	Ryabhan	B311755-D	KM	Ic Na Pi		801	HvFd	M0 V M2 V	{ 3 }	(A6E+1)	[5A3B]		10	840
 Spic	L	2628	Lyalop	B8C5456-D	KM	Fl Ni		803	HvFd	K3 V M4 V	{ 2 }	(935+1)	[364C]		7	135
 Spic	L	2630	Rasup	B679555-D	KM	Ni An		903	HvFd	M2 V M2 V	{ 2 }	(A46+1)	[373B]		11	240
-Spic	P	2632	Momentory	A584154-9		Lo		400	HvFd	K7 V M2 V	{ 0 }	(300-2)	[1137]		7	-6
+Spic	P	2632	Momentory	B584154-9		Lo		400	HvFd	K7 V M2 V	{ 0 }	(300-2)	[1137]		7	-6
 Spic	P	2637	Rekar	E101155-A		Ic Lo Va		105	HvFd	F1 V	{ -1 }	(800-3)	[1138]		8	-24
 Spic	P	2639	Stez Flotz	C423231-B		Lo Po		702	HvFd	M1 V M6 V	{ 0 }	(610-4)	[1217]		11	-24
 Spic	P	2640	Namek	B434A75-F		Hi		724	HvFd	M0 V	{ 3 }	(J9F+1)	[8D3D]		9	2430
@@ -393,7 +393,7 @@ Spic	H	2820	History Club	E577264-7		Lo O:3020		200	HvFd	G0 V	{ -3 }	(410-5)	[113
 Spic	L	2823	Untion	C562554-A		Ni Pr		500	HvFd	M0 V M6 V	{ 0 }	(744-2)	[3538]		10	-224
 Spic	L	2828	Item	D7A6356-9		Fl Lo		300	HvFd	M0 V	{ -2 }	(520-3)	[2148]		8	-30
 Spic	P	2833	Pehnon	D556254-8		Lo Da	A	513	HvFd	K4 V	{ -3 }	(810-5)	[1136]		10	-40
-Spic	P	2834	Hrilll	X9DA734-5		Wa Fo	R	815	HvFd	K4 V M2 V	{ -2 }	(965-4)	[5533]		9	-1080
+Spic	P	2834	Hrilll	X9DA734-5		Wa Fo DolpW	R	815	NaXX	K4 V M2 V	{ -2 }	(965-4)	[5533]		9	-1080
 Spic	D	2906	Marginal	B7547CC-5		Ag Pz	A	400	NaHu	K4 V M4 V	{ 1 }	(968+4)	[A888]		9	1728
 Spic	H	2914	Paros	C6898CD-4		Ri Ph Pz	A	900	NaHu	K4 V M4 V M7 V	{ 0 }	(A76+4)	[C898]		5	1680
 Spic	H	2917	Nggele	D550764-6		De Po O:2716		400	HvFd	K1 V M4 V	{ -2 }	(965-4)	[5534]		13	-1080
@@ -406,7 +406,7 @@ Spic	L	2930	Danim	DA9A302-A		Lo Oc		915	HvFd	M2 V	{ -1 }	(B20-5)	[1216]		9	-110
 Spic	P	2934	Roror	B799161-C	KM	Lo Mr		913	HvFd	A2 V	{ 2 }	(702-2)	[1318]		13	-28
 Spic	P	2936	Bilda	C57A154-C		Lo Wa		403	HvFd	F4 V M1 V	{ 0 }	(600-2)	[113A]		12	-12
 Spic	P	2938	Yard Explorer	A8CA561-F		Fl Ni O:2640		404	HvFd	G3 V	{ 1 }	(B45-3)	[161B]		8	-660
-Spic	P	2940	Pixhemp	B7B8465-8	KM	Fl Ni (minor) Mr		411	HvFd	K2 V M9 V	{ 0 }	(833-2)	[2436]		11	-144
+Spic	P	2940	Pixhemp	B7B8465-8	KM	Fl Ni (Hzille) Mr		411	HvFd	K2 V M9 V	{ 0 }	(833-2)	[2436]		11	-144
 Spic	D	3001	Feral	B6A48BD-9	KM	Fl Ph Pz	A	604	NaHu	M1 V	{ 2 }	(E7B+5)	[CA9D]		8	5390
 Spic	D	3004	Bountiful	C6678AA-7		Ga Ri Pa Ph Pz	A	105	NaHu	M0 V M8 V	{ 0 }	(A78+2)	[A879]		8	1120
 Spic	D	3010	Jumpers	B7B4544-8		Fl Ni		620	NaHu	M1 V	{ -1 }	(943-3)	[3436]		13	-324
@@ -430,7 +430,7 @@ Spic	H	3113	Montevideo	A4307A6-B		De Na Po		604	NaHu	M3 V	{ 2 }	(D6C+1)	[694A]		
 Spic	H	3116	Zongehl	C433651-B		Na Ni Po		401	HvFd	M2 V	{ 0 }	(954-4)	[2617]		8	-720
 Spic	H	3119	Bombir II	E421752-9		He Na Po Pi		300	HvFd	G0 IV	{ -1 }	(968-5)	[3615]		6	-2160
 Spic	H	3120	Filterpool	C674541-9		Ag Ni		404	HvFd	M3 V M3 V	{ 0 }	(B44-4)	[1515]		9	-704
-Spic	L	3127	Panen	A6A8564-9	E	Fl Ni (minor) O:3225		113	HvFd	M2 V	{ 0 }	(B44-2)	[3537]		10	-352
+Spic	L	3127	Panen	A6A8564-9	E	Fl Ni (Oiskee) O:3225		113	HvFd	M2 V	{ 0 }	(B44-2)	[3537]		10	-352
 Spic	L	3130	Atsalan	XAEA504-7		Ni Oc Fo	R	601	HvFd	M0 V	{ -3 }	(741-5)	[3235]		14	-140
 Spic	P	3134	Ridhi	D638752-7				300	HvFd	K1 V M3 V M2 V	{ -2 }	(966-5)	[3513]		13	-1620
 Spic	P	3138	Zonggand	C795261-9		Lo O:3238		420	HvFd	M2 V M7 V	{ -1 }	(610-5)	[1115]		11	-30

--- a/res/Sectors/M1105/Spica.tab
+++ b/res/Sectors/M1105/Spica.tab
@@ -163,7 +163,7 @@ Spic	B	1209	Nathrop	B58A886-A		Ri Wa Ph		604	NaHu	K1 V	{ 3 }	(E7C+2)	[7B49]		13	
 Spic	F	1211	Holy Place	C6A9321-8		Fl Lo		103	NaHu	M1 II M4 V	{ -2 }	(820-5)	[1114]		7	-80
 Spic	F	1212	Hale	C796852-6		Pa Ph Pi		400	NaHu	M2 V	{ -1 }	(A76-5)	[4712]		7	-2100
 Spic	F	1216	Talmud	C546105-7		Lo		910	NaHu	F5 V M6 V	{ -2 }	(300-4)	[1135]		7	-12
-Spic	F	1219	Lupine	C541442-9		He Ni Po		214	SoCf	G2 V	{ -1 }	(B32-5)	[1315]		11	-330
+Spic	F	1219	Lupine	C541442-9		He Ni Po Rahn1		214	SoCf	G2 V	{ -1 }	(B32-5)	[1315]		11	-330
 Spic	J	1224	Nestlands	B565275-B		Lo		820	HvFd	G6 V M9 V	{ 1 }	(611-1)	[1339]		13	-6
 Spic	J	1225	Drake	E57A444-6		Ni Wa		400	SoCf	G4 V	{ -3 }	(631-5)	[2134]		9	-90
 Spic	J	1230	One World	B568413-8		Ni Pa		600	HvFd	M0 V M3 V	{ -1 }	(632-4)	[1325]		12	-144
@@ -174,7 +174,7 @@ Spic	B	1303	Icestop	C201447-9		Ic Ni Va		520	NaHu	M2 V	{ -1 }	(832-1)	[4359]		9	
 Spic	B	1307	Gomez	C550778-6		De Po		803	NaHu	M2 V M6 V	{ -1 }	(966-1)	[7656]		14	-324
 Spic	F	1311	Sephor	C544336-9		Lo		402	NaHu	G4 V M6 V	{ -1 }	(720-2)	[2248]		8	-28
 Spic	F	1318	Lucullan	B7975AB-A		Ag Ni Da	A	400	NaHu	K2 V	{ 2 }	(746+4)	[777C]		13	672
-Spic	F	1319	Quatre	B421565-A		He Ni Po (Rahnha) O:1522		914	HvFd	G5 IV M2 V M9 V	{ 1 }	(C45-1)	[3638]		15	-240
+Spic	F	1319	Quatre	B543565-A		Ni Po (Rahnha) O:1522		914	HvFd	G5 IV M2 V M9 V	{ 1 }	(C45-1)	[3638]		15	-240
 Spic	J	1322	Gropie	C799313-7		Lo		305	HvFd	M0 V	{ -2 }	(520-5)	[1124]		9	-50
 Spic	J	1323	Nax'Hah'Nor	C7B877B-8		Fl Pz	A	804	SoCf	M0 V	{ -1 }	(D67+1)	[967A]		7	546
 Spic	J	1324	Border	BA9A734-C		Oc Pi		523	HvFd	M0 V	{ 2 }	(E6C+1)	[593A]		11	1008
@@ -206,7 +206,7 @@ Spic	B	1502	Foster	C426522-B		Ni		314	NaHu	M2 V	{ 0 }	(C44-4)	[1517]		9	-768
 Spic	B	1508	Tsusist	E550499-6		De Ni Po Da	A	303	NaHu	A4 V K2 V	{ -3 }	(631-2)	[5167]		7	-36
 Spic	F	1517	Sabbatha	E745500-7		Ag Ni		300	NaHu	M9 II	{ -2 }	(742-5)	[1312]		7	-280
 Spic	F	1519	Diva	E598953-9		Hi In		814	HvFd	M0 V	{ 1 }	(G8B-2)	[6A26]		12	-2816
-Spic	J	1522	Waft	B511835-B	KM	Ic Na Ph Pi		914	HvFd	G0 V M4 V	{ 3 }	(F7D+1)	[6B39]		13	1365
+Spic	J	1522	Waft	B511835-B	KM	Ic Na Ph Pi Wuic2		914	HvFd	G0 V M4 V	{ 3 }	(F7D+1)	[6B39]		13	1365
 Spic	J	1527	House Lu	B301423-D		Ic Ni Va An		800	HvFd	K3 V	{ 1 }	(634-2)	[152A]		13	-144
 Spic	J	1528	Raxt Durb	B000761-D		As Na Va Pi O:1828		412	HvFd	M2 V	{ 2 }	(C6D-2)	[3919]		6	-1872
 Spic	N	1539	Lehkak	D896622-6		Ag Ni		500	HvFd	M2 V M4 V	{ -2 }	(852-5)	[2412]		9	-400
@@ -232,7 +232,7 @@ Spic	G	1714	Xoar Zeta	C3115AB-8		Ic Ni Da	A	402	NaHu	M1 V	{ -2 }	(942+1)	[737A]	
 Spic	G	1717	Nehndil	C550205-A		De Lo Po		105	HvFd	M3 V	{ 0 }	(910-2)	[1238]		11	-18
 Spic	G	1718	Egesta	E7B8386-8		Fl Lo		720	HvFd	K7 V M9 V	{ -3 }	(720-4)	[2147]		9	-56
 Spic	K	1721	Tasimkin	D540323-7		De He Lo Po		710	HvFd	K8 V	{ -3 }	(520-5)	[1124]		11	-50
-Spic	K	1722	Star Hub	A401434-E	KM	Ic Ni Va		514	HvFd	G4 V M1 V	{ 2 }	(B35+1)	[263C]		8	165
+Spic	K	1722	Star Hub	A411434-E	KM	Ic Ni Wuic6		514	HvFd	G4 V M1 V	{ 2 }	(B35+1)	[263C]		8	165
 Spic	K	1729	Yengilz	E550305-8		De Lo Po		611	HvFd	K1 V	{ -3 }	(720-5)	[1136]		10	-70
 Spic	O	1731	Mihne	B430353-9	K	De Lo Po		504	HvFd	F8 V	{ 0 }	(920-3)	[1326]		11	-54
 Spic	O	1736	Buron	E688422-7		Ni Pa		510	HvFd	M0 V M3 V	{ -3 }	(631-5)	[1113]		14	-90
@@ -262,7 +262,7 @@ Spic	C	1910	Ceril	C200222-A		Lo Va Da	A	610	NaHu	K1 V M2 V	{ 0 }	(510-4)	[1216]	
 Spic	G	1913	Delea I	C431675-9		Na Ni Po		600	NaHu	K2 V	{ -1 }	(853-3)	[4537]		11	-360
 Spic	G	1914	Caldor	C577587-5		Ag Ni		214	NaHu	K1 V	{ -1 }	(743-1)	[5455]		10	-84
 Spic	G	1919	Sorgho	B6A8852-C		Fl Ph An		803	NaHu	K0 V M0 V	{ 2 }	(D7C-2)	[4A18]		11	-2184
-Spic	K	1921	Xoarax	D311859-7		Ic Na Ph Pi (Wuiche)		400	HvFd	G4 V M3 V	{ -2 }	(A76-1)	[9668]		11	-420
+Spic	K	1921	Xoarax	D311859-7		Ic Na Ph Pi (Wuiche)8		400	HvFd	G4 V M3 V	{ -2 }	(A76-1)	[9668]		11	-420
 Spic	K	1922	Pilza	B78A635-C	KM	Ni Ri Wa		104	HvFd	M1 V	{ 3 }	(C57+1)	[493A]		9	420
 Spic	K	1923	Naros	E599855-8		Ph Pi		810	HvFd	K2 V	{ -2 }	(B76-4)	[6636]		5	-1848
 Spic	K	1925	Zinam	D69A345-9		Lo Wa		313	HvFd	M0 V	{ -2 }	(920-4)	[1137]		13	-72
@@ -300,7 +300,7 @@ Spic	C	2205	Spica	C755684-5		Ag Ni Ga		704	NaHu	K4 II M7 V	{ -1 }	(853-3)	[4533]
 Spic	C	2207	Faller	C557663-4		Ag Ni O:2307		513	NaHu	G4 V	{ -1 }	(853-4)	[3521]		7	-480
 Spic	G	2218	Nandan	B540264-B		De He Lo Po O:2118		614	HvFd	M3 V	{ 1 }	(911-1)	[1339]		12	-9
 Spic	G	2219	Dapan	C411156-9		Ic Lo		320	HvFd	M0 V	{ -1 }	(500-2)	[1148]		13	-10
-Spic	K	2224	Pezal	AAC9647-A	E	Cp Fl Ni (Koatra)8		804	HvFd	F2 III	{ 1 }	(A54+1)	[455A]		15	120
+Spic	K	2224	Pezal	AAC9647-A	E	Cp Fl Ni (Koatra)8		804	HvFd	F2 III	{ 1 }	(A54+1)	[455A]		15	200
 Spic	K	2230	Cap Subsidiary	B101614-D		Ic Na Ni Va		104	HvFd	M0 V	{ 1 }	(C55-1)	[473B]		13	-300
 Spic	O	2231	Mehlang	C655952-B		Hi Ga		314	HvFd	M0 V M5 V	{ 2 }	(G8D-2)	[5B17]		13	-3328
 Spic	O	2232	Pendar Hai	D555275-7		Lo		212	HvFd	M2 V	{ -3 }	(410-5)	[1135]		14	-20
@@ -338,7 +338,7 @@ Spic	K	2422	Nihtehl	B431303-C		Lo Po		914	HvFd	M1 V M4 V	{ 1 }	(A21-2)	[1429]		8
 Spic	K	2423	Tehyehl	D89A123-8		Lo Wa Da	A	200	HvFd	M0 V	{ -3 }	(300-5)	[1125]		13	-15
 Spic	K	2424	Benong IV	A8CA663-C		Fl Ni O:2524		510	HvFd	G4 IV M4 V	{ 1 }	(955-2)	[3729]		12	-450
 Spic	K	2427	Zeko	E568722-6		Ag Ri		404	HvFd	M0 V M8 V	{ 0 }	(967-4)	[3712]		8	-1512
-Spic	O	2431	Ordva	D63466B-6		Ni (Icham) O:2532		500	HvFd	G1 V	{ -3 }	(851-1)	[8378]		10	-40
+Spic	O	2431	Ordva	D68466B-6		Ni (Icham) O:2532		500	HvFd	G1 V	{ -1 }	(851-1)	[8378]		10	-40
 Spic	O	2432	Birak	E646552-6		Ag Ni		302	HvFd	M0 III D	{ -2 }	(742-5)	[1312]		12	-280
 Spic	O	2433	Zalehs	A853656-A		Ni Po		905	HvFd	G4 V	{ 1 }	(D55+1)	[5749]		11	325
 Spic	O	2435	Lonibh	C674851-9		Pa Ph Pi		724	HvFd	K3 V	{ 0 }	(G79-4)	[4815]		9	-4032
@@ -351,7 +351,7 @@ Spic	L	2524	Deso	B655734-A		Ag Ga		220	HvFd	K1 V	{ 3 }	(B6C+1)	[5A38]		6	792
 Spic	L	2525	Bendus	D100656-A		Na Ni Va		305	HvFd	G3 V	{ -1 }	(D53-2)	[5549]		11	-390
 Spic	L	2529	Erest	A695723-C		Ag Pi		424	HvFd	M0 V M0 V	{ 3 }	(F6D+1)	[4A29]		11	1170
 Spic	L	2530	Nehron	E699000-0		Ba		000	HvFd	M3 V	{ -3 }	(200-5)	[0000]		8	-10
-Spic	P	2532	Shipsboat	A668942-C	KM	Cs Hi Pr		503	HvFd	F4 V M6 V	{ 4 }	(E8F+1)	[5D18]		9	1680
+Spic	P	2532	Shipsboat	A668942-C	KM	Ag Cs Hi Pr Ri		503	HvFd	F4 V M6 V	{ 4 }	(E8F+1)	[5D18]		9	1680
 Spic	P	2536	Nehlar	A843755-D		Po Pi		400	HvFd	G1 V M3 V	{ 2 }	(96D+1)	[593B]		9	702
 Spic	P	2537	Raghehk	A956563-D		Ag Ni O:2536		424	HvFd	F4 V	{ 2 }	(D46-1)	[272A]		12	-312
 Spic	P	2539	Kinyar VI	B57A754-D		Wa Pi		904	HvFd	K4 II M6 V	{ 2 }	(D6D+1)	[593B]		14	1014

--- a/res/Sectors/M1105/Spica.xml
+++ b/res/Sectors/M1105/Spica.xml
@@ -32,7 +32,69 @@
     <Subsector Index="O">Kurfane</Subsector>
     <Subsector Index="P">Syzygy</Subsector>
   </Subsectors>
-
+  <Allegiances>
+    <Allegiance Code="SoCf" Base="So">Solomani Confederation</Allegiance>
+    <Allegiance Code="CsHv">Client state, Hive Federation</Allegiance>
+    <Allegiance Code="NaHu" Base="Na">Non-Aligned, Human-dominated</Allegiance>
+    <Allegiance Code="HvFd" Base="Hv">Hive Federation</Allegiance>
+    <Allegiance Code="Hf">Hive FDA Uplift/Observation Site</Allegiance>
+  </Allegiances>
+  <Routes>
+    <Route Start="3230" End="0332" EndOffsetX="1" Type="Trade" />
+    <Route Start="2930" End="3230" Type="Trade" />
+    <Route Start="2630" End="2930" Type="Trade" />
+    <Route Start="2532" End="2630" Type="Trade" />
+    <Route Start="2529" End="2630" Type="Trade" />
+    <Route Start="2529" End="2328" Type="Trade" />
+    <Route Start="2026" End="1827" Type="Trade" />
+    <Route Start="2026" End="2328" Type="Trade" />
+    <Route Start="1827" End="1528" Type="Trade" />
+    <Route Start="1528" End="1327" Type="Trade" />
+    <Route Start="2026" End="2224" Type="Trade" />
+    <Route Start="2224" End="2524" Type="Trade" />
+    <Route Start="2524" End="2724" Type="Trade" />
+    <Route Start="2524" End="2621" Type="Trade" />
+    <Route Start="2621" End="2724" Type="Trade" />
+    <Route Start="2724" End="2925" Type="Trade" />
+    <Route Start="2925" End="3225" Type="Trade" />
+    <Route Start="3225" End="0125" EndOffsetX="1" Type="Trade" />
+    <Route Start="2621" End="2518" Type="Trade" />
+    <Route Start="2518" End="2318" Type="Trade" />
+    <Route Start="2318" End="2118" Type="Trade" />
+    <Route Start="2118" End="1919" Type="Trade" />
+    <Route Start="1919" End="1921" Type="Trade" />
+    <Route Start="1921" End="1922" Type="Trade" />
+    <Route Start="1922" End="2124" Type="Trade" />
+    <Route Start="2124" End="2224" Type="Trade" />
+    <Route Start="2532" End="2433" Type="Trade" />
+    <Route Start="2433" End="2235" Type="Trade" />
+    <Route Start="2235" End="2137" Type="Trade" />
+    <Route Start="2137" End="2339" Type="Trade" />
+    <Route Start="2339" End="2240" Type="Trade" />
+    <Route Start="2240" End="2201" EndOffsetY="1" Type="Trade" />
+    <Route Start="2339" End="2640" Type="Trade" />
+    <Route Start="2640" End="2940" Type="Trade" />
+    <Route Start="2940" End="3002" EndOffsetY="1" Type="Trade" />
+    <Route Start="2940" End="3238" Type="Trade" />
+    <Route Start="3238" End="0238" EndOffsetX="1" Type="Trade" />
+    <Route Start="0323" End="3124" EndOffsetX="-1" Allegiance="SoCf" />
+    <Route Start="0323" End="0623" Allegiance="SoCf" />
+    <Route Start="0623" End="0824" Allegiance="SoCf" />
+    <Route Start="0824" End="1126" Allegiance="SoCf" />
+    <Route Start="0238" End="3137" EndOffsetX="-1" Allegiance="SoCf" />
+    <Route Start="0238" End="0539" Allegiance="SoCf" />
+    <Route Start="0238" End="0435" Allegiance="SoCf" />
+    <Route Start="0435" End="0634" Allegiance="SoCf" />
+    <Route Start="0634" End="0731" Allegiance="SoCf" />
+    <Route Start="0731" End="0828" Allegiance="SoCf" />
+    <Route Start="0828" End="0824" Allegiance="SoCf" />
+    <Route Start="0113" End="3112" EndOffsetX="-1" Allegiance="SoCf" />
+    <Route Start="0315" End="0113" Allegiance="SoCf" />
+    <Route Start="0317" End="0315" Allegiance="SoCf" />
+    <Route Start="0518" End="0317" Allegiance="SoCf" />
+    <Route Start="0220" End="0317" Allegiance="SoCf" />
+    <Route Start="0323" End="0220" Allegiance="SoCf" />
+  </Routes>
   <Borders>
     <Border Allegiance="SoCf">0001 0102 0202 0302 0401 0502 0601 0602 0503 0403 0404 0405 0406 0507 0607 0708 0808 0909 0809 0710 0610 0511 0512 0513 0514 0614 0715 0815 0916 1016 1116 1117 1118 1119 1219 1220 1221 1222 1323 1223 1124 1125 1225 1325 1225 1126 1127 1128 1129 1028 0929 0930 1030 1131 1132 1133 1233 1334 1433 1432 1433 1434 1435 1336 1337 1237 1238 1239 1238 1138 1037 0938 0939 0940 0941 0841 0741 0641 0541 0441 0341 0241 0141 0041 0040 0039 0038 0037 0036 0035 0034 0033 0032 0031 0030 0029 0028 0027 0026 0025 0024 0023 0022 0021 0020 0019 0018 0017 0016 0015 0014 0013 0012 0011 0010 0009 0008 0007 0006 0005 0004 0003 0002 0001</Border>
     <Border Allegiance="HvFd" LabelPosition="1624" WrapLabel="true">1029 1130 1229 1228 1227 1226 1326 1425 1424 1324 1224 1324 1423 1422 1322 1321 1320 1319 1419 1519 1619 1719 1718 1717 1616 1717 1817 1918 2017 2117 2217 2318 2417 2517 2616 2716 2816 2917 3016 3116 3117 3217 3317 3316 3317 3318 3319 3320 3321 3322 3323 3324 3325 3326 3327 3328 3329 3330 3331 3332 3333 3334 3335 3336 3337 3338 3339 3340 3341 3241 3141 3041 2941 2841 2741 2641 2541 2441 2341 2241 2141 2041 1941 1841 1741 1641 1541 1441 1341 1241 1141 1040 1039 1038 1139 1140 1240 1340 1339 1338 1437 1436 1536 1535 1534 1533 1532 1431 1332 1333 1232 1231 1230 1130 1029</Border>


### PR DESCRIPTION
Updated Hiver parts of Spica & Langere sectors to update minor race homeworlds, add subsector capitals and add trade routes.