### PR TITLE
Update Trojan Reach.tab to reflect Mongoose Traveller books.

### DIFF
--- a/res/t5ss/data/Trojan Reach.tab
+++ b/res/t5ss/data/Trojan Reach.tab
@@ -8,7 +8,7 @@ Troj	I	0126	Ahaikhea	B422423-9	R	He Ni Po		101	AsMw	F7 III M7 V	{ 0 }	(733-3)	[1
 Troj	I	0127	Eawatrye	B8B5756-C	R	Fl		903	AsMw	M1 V M7 V	{ 2 }	(C6C+1)	[694B]		12	864
 Troj	I	0129	Tyea'ih	B548889-A		Pa Ph Pi		705	AsVc	K3 V M5 V	{ 2 }	(F7B+3)	[9A6B]		11	3465
 Troj	I	0130	Oiauh	B1018B8-D		Ic Na Va Ph Pi		802	AsT2	F4 V	{ 2 }	(C7D+2)	[8A5D]		10	2184
-Troj	M	0132	Ftyewirl	B55648A-B	T	Ni Pa		120	AsT5	K4 V	{ 1 }	(834+3)	[657D]		13	288
+Troj	M	0132	Ftyewirl	B55648A-B	T	Ni Pa		120	AsT2	K4 V	{ 1 }	(834+3)	[657D]		13	288
 Troj	M	0134	Elahkoi	C568587-9		Ag Ni Pr		722	AsVc	K2 V	{ 0 }	(B44+1)	[5559]		9	176
 Troj	M	0135	Uiwuar	B101115-E		Ic Lo Va		605	AsMw	F1 V M4 V	{ 1 }	(801-1)	[123C]		11	-8
 Troj	M	0139	Ealea	B576587-9		Ag Ni		200	AsMw	G5 V D	{ 1 }	(745+1)	[5659]		8	140
@@ -26,8 +26,8 @@ Troj	I	0224	Ewoiftoil	B546646-A		Ag Ni		510	AsMw	F3 V	{ 2 }	(956+1)	[5849]		9	27
 Troj	I	0227	H'a	D657449-6		Ni Ga Pa		802	AsMw	F4 V	{ -3 }	(631-2)	[5167]		13	-36
 Troj	I	0229	Hreahrya	B433A79-D		Hi Na Po		924	AsSc	K0 V	{ 3 }	(J9F+4)	[BD6E]		12	9720
 Troj	M	0232	Yekhtia	B423376-B		Lo Po		211	AsSc	G0 V M8 V	{ 1 }	(721+1)	[244A]		11	14
-Troj	M	0234	Aehahr	B100449-C		Ni Va Rs		522	AsVc	M7 V M9 V	{ 1 }	(A34+2)	[556D]		15	240
-Troj	M	0236	Ftoakh	E673A8C-A		Hi In Pz	A	200	AsWc	F4 V M9 V M7 V	{ 2 }	(C9C+5)	[DC8D]		10	6480
+Troj	M	0234	Aehahr	B100449-C		Ni Va Rs		522	AsTv	M7 V M9 V	{ 1 }	(A34+2)	[556D]		15	240
+Troj	M	0236	Ftoakh	E673A8C-A		Hi In Pz	A	200	AsSc	F4 V M9 V M7 V	{ 2 }	(C9C+5)	[DC8D]		10	6480
 Troj	M	0240	Aohfeau	B998784-A		Ag Pi		620	AsVc	F3 V M8 V	{ 3 }	(B6C+1)	[5A38]		14	792
 Troj	A	0307	Crescent	B420778-7		De He Na Po Pi		904	NaHu	M1 V	{ 0 }	(968+1)	[7757]		16	432
 Troj	A	0310	Trossachs	B897A54-C		Hi In FlorW		202	FlLe	F6 V	{ 4 }	(E9F+2)	[8E3A]		7	3780
@@ -95,9 +95,9 @@ Troj	I	0824	Yaeawaokh	B43078B-C	T	De Na Po		400	AsT3	F6 V M8 V	{ 2 }	(96C+4)	[99
 Troj	I	0825	Alirar	A55557A-C	R	Ag Ni		913	GlEm	K4 V M4 V	{ 2 }	(B46+4)	[777E]		17	1056
 Troj	I	0829	Ehaealir	B63657B-9		Ni		210	AsSc	M4 V M8 V	{ 0 }	(844+2)	[757B]		12	256
 Troj	M	0835	Stohyus	A567886-C	R	Ri Pa Ph		902	AsTv	F6 V M2 V	{ 3 }	(C7D+2)	[7B4B]		14	2184
-Troj	M	0837	Hkakh	A424546-E	R	Ni		704	AsWc	K6 V	{ 1 }	(B45+1)	[464D]		12	220
+Troj	M	0837	Hkakh	A424546-E	R	Ni		704	AsMw	K6 V	{ 1 }	(B45+1)	[464D]		12	220
 Troj	M	0839	Ohtae	B665168-9		Lo Ga O:0835		903	AsTv	F8 V M6 V	{ 0 }	(600+1)	[1159]		14	6
-Troj	M	0840	Uitasoayaw	B579687-9	R	Ni		103	AsWc	F3 V D	{ 0 }	(B54+1)	[6659]		12	220
+Troj	M	0840	Uitasoayaw	B579687-9	R	Ni		103	AsMw	F3 V D	{ 0 }	(B54+1)	[6659]		12	220
 Troj	B	0902	Walei	E7B4776-8		Fl		811	NaHu	K3 V M5 V	{ -2 }	(B66-3)	[6547]		10	-1188
 Troj	B	0909	Pa'an	E649333-5		Lo		513	CsZh	F3 V M0 V	{ -3 }	(520-5)	[1122]		15	-50
 Troj	F	0914	Solaria	B665734-8		Ag Ga Ri		614	NaHu	F8 V	{ 2 }	(E6A+1)	[5936]		17	840
@@ -200,19 +200,19 @@ Troj	C	1810	Kydde	B644779-5	S	Ag Pi		804	CsIm	M2 V	{ 1 }	(968+2)	[8866]		14	864
 Troj	G	1816	Salif	A6236A6-A		Na Ni Po		301	NaHu	F9 III M0 V	{ 1 }	(955+1)	[5749]		12	225
 Troj	G	1818	Number One	C9D6778-9				602	NaHu	M3 V	{ 0 }	(B69+1)	[7759]		15	594
 Troj	K	1823	Camoran	A55167A-B		Ni Po		514	CsIm	F9 V	{ 1 }	(D55+3)	[877D]		12	975
-Troj	K	1830	Keaih	CAA5887-9		Fl Ph		202	AsWc	K1 V M3 V	{ 0 }	(C79+1)	[8859]		15	756
+Troj	K	1830	Keaih	CAA5887-9		Fl Ph		202	AsTv	K1 V M3 V	{ 0 }	(C79+1)	[8859]		15	756
 Troj	O	1835	Afeakter	A69A68A-B	RT	Ni Wa		514	AsTv	F2 V	{ 2 }	(D56+4)	[887D]		16	1560
 Troj	C	1906	Bantral	C886589-9	S	Ag Ni Ga Pr		503	CsIm	F5 V	{ 0 }	(A44+1)	[656A]		8	160
 Troj	G	1919	Thebus	B534320-7		Lo		823	NaHu	M3 V	{ -1 }	(520-5)	[1212]		15	-50
 Troj	K	1927	Ohaualr	B422388-B	T	He Lo Po		214	AsTv	M9 V	{ 1 }	(A21+1)	[345B]		11	20
-Troj	K	1928	Tlaiowaha	B420954-E	T	De He Hi In Na Po		411	AsT0	F4 V	{ 4 }	(D8G+2)	[7D3C]		10	3328
+Troj	K	1928	Tlaiowaha	B420954-E	T	De He Hi In Na Po		411	AsT7	F4 V	{ 4 }	(D8G+2)	[7D3C]		10	3328
 Troj	O	1931	Ralaiw	B420534-D		De He Ni Po		422	AsVc	F4 V	{ 1 }	(B45-1)	[363B]		13	-220
 Troj	O	1933	Ereah	B67A369-D		Lo Wa O:1634		531	AsMw	K8 V	{ 1 }	(921+2)	[446E]		10	36
 Troj	C	2002	Kryslion	D583AA9-9		Hi		520	ImDd	F6 V	{ 0 }	(E9A+1)	[BA6A]	BE	11	1260
 Troj	C	2008	Orsasch	E541364-7	M	He Lo Po Mr		223	SeFo	M1 V	{ -3 }	(520-5)	[1135]		13	-50
 Troj	G	2018	Noricum	D8867BB-1		Ag Ga Ri Pz	A	804	NaHu	G2 V M9 V M6 V	{ 0 }	(965+2)	[9773]		14	540
 Troj	G	2020	Oghma	B534754-9				404	NaHu	K5 V M5 V M4 V	{ 1 }	(D6A-1)	[5837]		11	-780
-Troj	K	2023	Khusai	A576655-C	R	Ag Ni		724	AsVc	F7 V	{ 2 }	(E56+1)	[483A]		19	420
+Troj	K	2023	Khusai	A576655-C	R	Ag Ni		724	AsMw	F7 V	{ 2 }	(E56+1)	[483A]		19	420
 Troj	K	2029	Staha	B755486-B	R	Ni Ga Pa		313	AsMw	F3 V D	{ 1 }	(A34+1)	[354A]		13	120
 Troj	C	2102	Cyan	C5689B9-A	W	Hi Pr Pz	A	510	ImDd	F6 V M7 V	{ 3 }	(C8D+4)	[AC6B]	BcE	12	4992
 Troj	C	2105	Berengaria	B566644-7	NS	Ag Ni Ri		304	ImDd	F7 V	{ 2 }	(856+1)	[4835]	BC	12	240


### PR DESCRIPTION
Several Trojan Reach worlds have allegiance codes consistent with late Rebellion data (circa 1122) from MegaTraveller Journal 3, but inconsistent with 1105 data from Mongoose Traveller (MgT1 Aslan, MgT2 Pirates of Drinax and Journal of the Travellers’ Aid Society 3).

Keaih (Trojan Reach 1830 CAA5887-9) - “currently held by the Htyowao, vassals of the Ahroay’if [a Tlaukhu vassal]” (Pirates of Drinax 180). Change allegiance from AsWc to AsTv.

Khusai (Trojan Reach 2023 A576655-C) - “Home to the naval base of the belligerent Hrakoea [a multiworld clan]" (Pirates of Drinax 182). Change allegiance from AsVc to AsMw.

Tlaiowaha (Trojan Reach 1928 B420954-E) - “Tlaiowaha is owned by the Tlaiowaha clan [a/k/a Tlerlearlyo]” (Pirates of Drinax 182). Change allegiance from AsT0 to AsT7.

Aehahr (Trojan Reach 0234 B100449-C) - “This world is owned by a vassal clan of the Khaukhearl, the Khtiatiyeea” (Pirates of Drinax 192). Change allegiance from AsVc to AsTv.

Ftoakh (Trojan Reach 0236 E673A8C-A) - “a planet divided by a dozen distinct cultures and a billion unresolved grudges [that is, split control]” (Pirates of Drinax 192). Change allegiance from AsWc to AsSc.

Ftyewirl (Trojan Reach 0132 B55648A-B) - “The colony is owned by the Syoisuis clan, who value their privacy” (Pirates of Drinax 192). Change allegiance from AsT5 to AsT2.

Uitasoayaw (Trojan Reach 0840 B579687-9) - “the oldest of the [Arhiyao] clan’s planets” (JTAS 3 p. 63). Change allegiance from AsWc to AsMw.

Hkakh (Trojan Reach 0837 A424546-E) - “the seat of the Ekhoaoiarl Corporation . . . the economic engine that drives the [Arhiyao] clan.” (JTAS 3 p. 63). Change allegiance from AsWc to AsMw.