### PR TITLE
Update Trojan Reach.tab

### DIFF
--- a/res/t5ss/data/Trojan Reach.tab
+++ b/res/t5ss/data/Trojan Reach.tab
@@ -149,7 +149,7 @@ Troj	B	1308	Eleson	E541100-8		He Lo Po		323	BlSo	F8 V M2 V	{ -3 }	(800-5)	[1113]
 Troj	F	1317	Caldos	B530879-6		De Na Po Ph		824	NaHu	F2 V	{ 0 }	(A77+1)	[9867]		9	490
 Troj	F	1319	Lacidaeus	D100786-7		Na Va Pi		502	NaHu	M9 V	{ -2 }	(966-3)	[6546]		8	-972
 Troj	J	1322	Hrahraiu	B42068C-C	T	De He Na Ni Po Da	A	800	AsT8	M6 V	{ 1 }	(855+4)	[978F]		7	800
-Troj	J	1323	Hliyh	B200AB7-E	R	Hi In Na Va		102	AsMw	F8 V	{ 4 }	(E9G+4)	[AE5E]		12	8064
+Troj	J	1323	Hliyh	B200AB7-E	R	Hi In Na Va Huma4		102	AsSc	F8 V	{ 4 }	(E9G+4)	[AE5E]		12	8064
 Troj	J	1324	Eilaeah	B863267-B		Lo O:1323		414	AsMw	G6 V	{ 1 }	(911+1)	[235B]		12	9
 Troj	N	1333	Rileakh	C437855-A		Ph		702	AsTv	F7 V M6 V M6 V	{ 1 }	(C7A-1)	[6938]		12	-840
 Troj	N	1334	Eateaw	E423000-0		Ba Po		004	AsXX	M6 V M7 V	{ -3 }	(200-5)	[0000]		12	-10
@@ -188,7 +188,7 @@ Troj	N	1634	Aiuite	B645747-A	R	Ag Pi		223	AsMw	F5 V M3 V	{ 3 }	(E6C+3)	[7A5A]		1
 Troj	N	1637	Awaweaw	E855859-7		Ga Pa Ph (Yont)		121	AsTv	F8 V M9 V	{ -2 }	(A76-1)	[9668]		12	-420
 Troj	G	1715	Homestead	D561250-6		Lo		524	NaHu	F9 V	{ -3 }	(410-5)	[1111]		16	-20
 Troj	G	1719	Ace	E7A08B9-8		He Ph Pz	A	700	NaHu	M0 V D	{ -2 }	(A76-1)	[9669]		7	-420
-Troj	K	1723	Oiwoiieaw	B787897-A		Ga Ri Pa Ph		711	AsVc	F0 V M7 V	{ 3 }	(C7C+3)	[8B5A]		13	3024
+Troj	K	1723	Oiwoiieaw	B787897-A		Ga Ri Pa Ph		711	AsTv	F0 V M7 V	{ 3 }	(C7C+3)	[8B5A]		13	3024
 Troj	K	1728	Asoieteal	B697688-A	R	Ag Ni		604	AsWc	F2 V	{ 2 }	(C56+2)	[685A]		16	720
 Troj	O	1731	Wesiyeah	D641259-8		He Lo Po		823	AsMw	K4 V	{ -3 }	(910-2)	[3169]		16	-18
 Troj	O	1733	Aiwewakh	BA96113-B		Lo		404	AsMw	G4 V M2 V	{ 1 }	(701-2)	[1228]		10	-14
@@ -240,7 +240,7 @@ Troj	K	2227	Iroioah	B530113-C		De Lo Po		823	AsMw	M3 V M4 V	{ 1 }	(801-2)	[1229]
 Troj	K	2229	Hleakhayes	E54348B-7		Ni Po		812	AsMw	F2 V M0 V	{ -3 }	(631-1)	[6179]		9	-18
 Troj	K	2230	Akoaft	E898000-0		Ba		031	AsXX	F3 V	{ -3 }	(200-5)	[0000]		17	-10
 Troj	O	2232	Khtiyrlo	DA887CA-6		Ag Ri Pz	A	222	AsMw	M2 V M6 V	{ 0 }	(967+2)	[9778]		10	756
-Troj	O	2233	Eaohfose	B6736A7-A	T	Ni		105	AsT1	K6 V D	{ 1 }	(D55+1)	[675A]		17	325
+Troj	O	2233	Eaohfose	B6736A7-A	T	Ni		105	AsTv	K6 V D	{ 1 }	(D55+1)	[675A]		17	325
 Troj	O	2234	Gikarlum	B310587-9		Ni		714	NaHu	F0 IV	{ 0 }	(C44+1)	[5559]		11	192
 Troj	C	2304	Rhysk	X413730-7		Ic Na Pi Fo	R	613	ImDd	M1 V M4 V	{ -2 }	(966-5)	[2512]		16	-1620
 Troj	C	2306	Caraz	E311959-A	N	Hi Ic In Na Pz	A	222	ImDd	F7 V M5 V	{ 2 }	(F8C+3)	[AB6B]	BE	13	4320


### PR DESCRIPTION
- Change **Oiwoiieaw** allegiance from AsVc to AsTv to reflect _Pirates of Drinax_ 1: “There is an Aslan world called Oiwoiiea, ruled by the Ahroay’if trading clan [a Tlaukhu vassal]" p. 266.
- Change **Eaohfose** allegiance from AsT1 to AsTv to reflect _Pirates of Drinax_ 2: “the Ahroah’if and their Tlaiowaha backers attacked the Tiykhisto and conquered the world of Eaohfose. Adding insult to injury, the Tlaiowaha established a naval base at Eaohfose specifically to watch for Tiykhisto raiders” p.  201.
- Change **Hliyh** allegiance from AsMw to AsSc to reflect _The Glorious Empire_: “Despite their diametrically opposed views, the Ahroay’if and Hrakoea clans fought together against the Empire and both clans acquired land holdings on metal-rich Hliyh. When territories on the airless world were being carved up for distribution after the war, the peace council were careful not to assign adjacent lands to the two opposing clans. To ensure the peace, the Ryoauae clan were given many of the lands located between the two” p. 130.  Add Huma4 to remarks per _Pirates of Drinax_ 2: “The economy of the Glorious Empire is founded on slavery – between 30% to 60% of its population are humans” p. 126.
