### PR TITLE
Update Spinward Marches.tab

### DIFF
--- a/res/t5ss/data/Spinward Marches.tab
+++ b/res/t5ss/data/Spinward Marches.tab
@@ -241,7 +241,7 @@ Spin	O	1836	Callia	E550852-6		De Po Ph		810	ImDd	M3 V	{ -2 }	(A75-5)	[4612]	Be	1
 Spin	C	1903	Pixie	A100103-D	N	Lo Va An Px		901	ImDd	K1 V M0 V	{ 1 }	(401-2)	[122A]	B	14	-8
 Spin	C	1904	Boughene	A8B3531-D	S	Fl Ni An		601	ImDd	M1 V	{ 1 }	(845-3)	[1619]	B	13	-480
 Spin	C	1909	Hefry	C200423-7	S	Ni Va		320	ImDd	K6 II M2 V	{ -2 }	(631-5)	[1224]	B	13	-90
-Spin	C	1910	Regina	A788899-C	NS	Ri Pa Ph An Cp (Amindii)2 Varg0 Asla0 Sa		703	ImDd	F7 V BD M3 V	{ 4 }	(D7E+5)	[9C6D]	BcCeF	8	6370
+Spin	C	1910	Regina	A788899-C	NS	Ri Pa Ph An Cp (Amindii)2 Varg0 Asla0 Sa		703	ImDd	F7 V BD M3 V	{ 4 }	(D7E+5)	[9C6D]	BcCeF	9	6370
 Spin	G	1912	Dinomn	B674632-9	S	Ag Ni		204	ImDd	G8 V	{ 1 }	(C55-3)	[2715]	BC	11	-900
 Spin	G	1916	Ylaven	X587552-4		Ag Ni Pr Fo	R	922	ImDd	F9 V	{ -2 }	(742-5)	[1311]		11	-280
 Spin	G	1918	Sonthert	D6266AB-7		Ni Da	A	314	ImDd	K6 V M0 V	{ -3 }	(851-1)	[8379]	B	8	-40


### PR DESCRIPTION
The Regina System, as shown in the original Book 6: Scouts (Page 55, Classic Traveller) and following materials, has a total of 8 planets between its three (two-and-a-brown-dwarf) stars (Lusor + Speck) and Darida; 3 of them being gas giants.

The 'Worlds' value of the UWP, however, also includes the mainworld — in this case, a Satellite of one of the gas giants. This means that, by having the Worlds entry as '8', one rocky planet is being omitted from the system; the correct value would be 9:

3 Gas Giants + 5 Terrestrial Worlds + 1 'Sa' Mainworld = 9