### PR TITLE
fix: incorrect parsing of stellar data

### DIFF
--- a/server/RenderUtil.cs
+++ b/server/RenderUtil.cs
@@ -632,7 +632,8 @@ namespace Maps.Rendering
                 { "II", 3 },
                 { "III", 2 },
                 { "IV", 1 },
-                { "V", 0 }
+                { "V", 0 },
+                { "VI", 0 }
             });
 
         // Base radius for spectral class.

--- a/server/RenderUtil.cs
+++ b/server/RenderUtil.cs
@@ -633,7 +633,7 @@ namespace Maps.Rendering
                 { "III", 2 },
                 { "IV", 1 },
                 { "V", 0 },
-                { "VI", 0 }
+                { "VI", -0.1f }
             });
 
         // Base radius for spectral class.

--- a/server/StellarData.cs
+++ b/server/StellarData.cs
@@ -21,7 +21,7 @@ namespace Maps
             public string? luminosity; // Ia, Ib, II, III, IV, V, VI, VII
         }
 
-        private static readonly Regex STELLAR_REGEX = new Regex(@"([OBAFGKM][0-9] ?(?:Ia|Ib|II|III|IV|V|VI|VII|D)|D|NS|PSR|BH|BD)",
+        private static readonly Regex STELLAR_REGEX = new Regex(@"([OBAFGKM][0-9] ?(?:Ia|Ib|III|II|IV|VII|VI|V|D)|D|NS|PSR|BH|BD)",
             RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         private static Regex STAR_REGEX = new Regex(@"^([OBAFGKM])([0-9]) ?(Ia|Ib|II|III|IV|V|VI)$",

--- a/server/StellarData.cs
+++ b/server/StellarData.cs
@@ -21,7 +21,7 @@ namespace Maps
             public string? luminosity; // Ia, Ib, II, III, IV, V, VI, VII
         }
 
-        private static readonly Regex STELLAR_REGEX = new Regex(@"([OBAFGKM][0-9] ?(?:Ia|Ib|III|II|IV|VII|VI|V|D)|D|NS|PSR|BH|BD)",
+        private static readonly Regex STELLAR_REGEX = new Regex(@"([OBAFGKM][0-9] ?(?:Ia|Ib|II|III|IV|V|VI|VII|D)|D|NS|PSR|BH|BD)\b",
             RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         private static Regex STAR_REGEX = new Regex(@"^([OBAFGKM])([0-9]) ?(Ia|Ib|II|III|IV|V|VI)$",


### PR DESCRIPTION
This fixes parsing of luminosity in stellar data. The old regex ordering meant it would parse "M6 III" as "M6 II".