### PR TITLE
Update Spinward Marches.tab

### DIFF
--- a/res/t5ss/data/Spinward Marches.tab
+++ b/res/t5ss/data/Spinward Marches.tab
@@ -154,7 +154,7 @@ Spin	F	1217	Arkadia	E546845-6		Pa Ph Pi		402	ImDd	G8 V	{ -2 }	(A75-4)	[6634]	BcD
 Spin	J	1221	Gungnir	B544779-8	M	Ag Pi		432	SwCf	G3 IV M4 V	{ 1 }	(E69+2)	[8869]		13	1512
 Spin	J	1223	Gram	A895957-C	KM	Hi In Cx		603	SwCf	F2 V M2 V	{ 5 }	(E8G+5)	[9E5C]		10	8960
 Spin	J	1225	Excalibur	B424755-A	KM	Pi		402	SwCf	K5 V	{ 3 }	(B6C+1)	[5A38]		10	792
-Spin	N	1232	Walston	C544338-8	S	Lo Varg7		302	CsIm	M2 V	{ -2 }	(720-2)	[3158]		8	-28
+Spin	N	1232	Walston	C544338-8	S	Lo Varg7		302	CsIm	M2 V	{ -2 }	(720-2)	[3158]		7	-28
 Spin	N	1233	Flexos	E5A1422-8		Fl He Ni		610	NaHu	M1 V M2 V	{ -3 }	(731-5)	[1114]		8	-105
 Spin	N	1237	Collace	B628943-D	S	Hi In		101	CsIm	F1 V M3 V	{ 4 }	(C8G+1)	[6D2A]		5	1536
 Spin	N	1238	Pavabid	C6678D8-6		Ga Ri Pa Ph Pz	A	701	NaHu	K7 V	{ 0 }	(A77+1)	[8856]		14	490


### PR DESCRIPTION
As showcased on pages 11-12 of the Mongoose 2nd Edition product '_Spinward Marches 1: The Bowman Arm_' (see: https://www.mongoosepublishing.com/products/spinward-marches-1-the-bowman-arm-ebook) the Walston system contains a total of 7 worlds: Mainworld, two Gas Giants, and 4 terrestrial worlds.
Suggested edit brings T5SS entry in accordance to above.