### PR TITLE
Update sophont_codes.tab

### DIFF
--- a/res/t5ss/sophont_codes.tab
+++ b/res/t5ss/sophont_codes.tab
@@ -72,3 +72,4 @@ Za't	Za'tachk	Wren
 Zhod	Zhodani	Zhodani space
 Ziad	Ziadd	Dagu
 Ramm	Rammak	Krus
+Murr  Murrissi  Hlak


### PR DESCRIPTION
Add Sophont code for Murrissi, an Aslan vassal species native to Atuakhtea.