### PR TITLE
feat: add sector label to exported metadata

### DIFF
--- a/server/api/SectorMetaDataHandler.cs
+++ b/server/api/SectorMetaDataHandler.cs
@@ -91,6 +91,8 @@ namespace Maps.API.Results
         public string Tags { get => sector.TagString; set { } }
         [XmlAttribute]
         public string Abbreviation { get => sector.Abbreviation; set { } }
+        [XmlAttribute]
+        public string Label { get => sector.Label; set { } }
         [XmlElement("Name")]
         public List<Name> Names => sector.Names;
         public XmlCDataSection Credits { get => new XmlDocument().CreateCDataSection(sector.Credits); set { } }


### PR DESCRIPTION
This adds the sector label to exported metadata for sectors that have one.

For XML format metadata it's added as an attribute on the Sector element
`<Sector xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Tags="Apocryphal Faraway" Abbreviation="JGCM" Label="Crucis Margin">`

For JSON format metadata it's added as a top level element
`
   ...
    "Tags": "Apocryphal Faraway",
    "Abbreviation": "JGCM",
    "Label": "Crucis Margin",
    "Names": [
   ...
`

Testing
- Verified label is included in JSON and XML metadata for sectors that have one
   /api/metadata?milieu=M1105&sector=Crucis Margin (Judges Guild)
- Verified label is not included in JSON and XML metadata for sectors that don't have one
  /api/metadata?milieu=M1105&sector=Vanguard Reaches