### PR TITLE
Fix: unnecessary api calls with undefined coords (#537)

### DIFF
--- a/index.js
+++ b/index.js
@@ -731,9 +731,7 @@
   }, EVENT_DEBOUNCE_MS);
 
   map.OnPositionChanged = Util.debounce(() => {
-    if(map.worldX !== undefined && map.worldY !== undefined) {
-      updateContext(map.worldX, map.worldY);
-    }
+    updateContext(map.worldX, map.worldY);
     updatePermalink();
     savePreferences();
   }, EVENT_DEBOUNCE_MS);

--- a/map.js
+++ b/map.js
@@ -1731,7 +1731,7 @@ const Util = {
 
     get worldX() { return Astrometrics.mapToWorld(this.x, this.y).x; }
 
-    get world() { return Astrometrics.mapToWorld(this.x, this.y).y; }
+    get worldY() { return Astrometrics.mapToWorld(this.x, this.y).y; }
 
     // This places the specified Sector, Hex coordinates (parsec)
     // at the center of the viewport.


### PR DESCRIPTION
This fixes the extra API calls being made that return default data, while leaving other functionality. Note that the undefined coords may be the symptom of a larger problem.

Using a touch screen is much snappier with this change; the subtle touch movements seemed to trigger this invalid API call which would block the touch tap from selecting a sector.

See #537