### PR TITLE
Update Spinward Marches.tab

### DIFF
--- a/res/t5ss/data/Spinward Marches.tab
+++ b/res/t5ss/data/Spinward Marches.tab
@@ -228,7 +228,7 @@ Spin	C	1805	Uakye	B439598-D		Ni		320	ImDd	M3 V	{ 1 }	(945+1)	[565D]	B	12	180
 Spin	C	1806	Whanga	E676126-7		Lo		224	ImDd	G1 V M1 V	{ -3 }	(300-4)	[1146]	B	14	-12
 Spin	C	1807	Knorbes	E888765-2		Ag Ri An Re		834	ImDd	G3 V	{ 0 }	(965-2)	[5731]	BC	15	-540
 Spin	C	1808	Forboldn	D893614-5		Ni		312	ImDd	G0 V	{ -3 }	(851-5)	[4333]	B	14	-200
-Spin	C	1809	Ruie	C776977-7		Hi In Pz Di(Daccamites)	A	701	NaHu	G5 V	{ 1 }	(B8A+1)	[9A57]		9	880
+Spin	C	1809	Ruie	C776977-7		Hi In Pz Di(Daccamites)	A	701	NaHu	G5 V	{ 1 }	(B8A+1)	[9A57]		8	880
 Spin	C	1810	Jenghe	C799663-9	S	Ni O:1910		323	ImDd	M0 V	{ -1 }	(D53-4)	[3526]	B	11	-780
 Spin	G	1811	Dinom	D300535-A		Ni Va Sa		201	ImDd	A4 V	{ -1 }	(843-3)	[3438]	B	14	-288
 Spin	G	1815	Ghandi	B311455-A	N	Ic Ni		303	ImDd	F8 V M3 V	{ 1 }	(934-1)	[2538]	B	13	-108


### PR DESCRIPTION
The system description for Ruie in the Mongoose 1st Edition publication _Compendium 2_ (see page 115) lists 8 planets in the system, including in that count the single Gas Giant and the Mainworld itself.

This count is also consistent with that given in the JTAS Online article "_Ruie_", by Hans Rancke-Madsen and published in 2001. Relevant excerpt: _"Ruie is the second planet of the system. There are six other terrestrial planets and one gas giant (Reinlich, at 10 AUs); there are no asteroid belts."_

Though the specific details about the system's arrangement vary between the two publications, both agree the total number of worlds in the system is 8.