### PR TITLE
Update Spinward Marches.tab

### DIFF
--- a/res/t5ss/data/Spinward Marches.tab
+++ b/res/t5ss/data/Spinward Marches.tab
@@ -181,7 +181,7 @@ Spin	J	1429	Gunn	E544110-8		Lo Da	A	602	ImDd	M3 V	{ -3 }	(500-5)	[1113]	B	9	-25
 Spin	J	1430	Caliburn	E000514-A		As Ni Va		914	ImDd	M2 V	{ -1 }	(C43-3)	[3438]	B	13	-432
 Spin	N	1433	Noctocol	E7A5747-8		Fl		602	NaHu	F5 V M2 V	{ -2 }	(B66-2)	[7558]		15	-792
 Spin	N	1434	Tarkine	C566662-7	S	Ag Ni Ri Da O:1435	A	310	CsIm	M0 V M2 V	{ 0 }	(854-4)	[2613]		9	-640
-Spin	N	1435	Dallia	B885883-9		Ga Ri Pa Ph		610	CsIm	F2 V	{ 2 }	(B7B-1)	[5A26]		9	-847
+Spin	N	1435	Dallia	B8B5883-9		Fl Ph		610	CsIm	F2 V	{ 2 }	(B7B-1)	[5A26]		9	-847
 Spin	N	1436	Talos	E433532-9		Ni Po		820	NaHu	F9 V M1 V	{ -2 }	(942-5)	[1315]		9	-360
 Spin	B	1510	871-438	E722000-0		Ba He Po		001	NaXX	M3 V M8 V	{ -3 }	(200-5)	[0000]		7	-10
 Spin	F	1511	Tionale	C674321-8		Lo Da (minor)	A	910	CsIm	M2 V M5 V	{ -2 }	(620-5)	[1114]		11	-60


### PR DESCRIPTION
Doing a deep dive into District 268 subsector, I have found what I believe to be a mistake in the sector data: Dallia has always had an atmospheric code of 'B', all the way from Supplement 3, to MegaTraveller Journal 3, to GURPS Behind the Claw, up to and including Mongoose 1st 'Spinward Marches'.

The 2019 Behind the Claw for Mongoose 2nd Edition, however, gives its atmospheric code as '8', which was then propagated into the T5SS data. I believe this to have been an error at time of publication by Mongoose's part – no information is given in the book text itself about this world besides the one instance of the UWP, and it seems to me like someone might have confused a 'B' for an '8' somewhere along the way.

I'm not sure which takes precedence here. Technically the Mg2nd Edition Behind the Claw would 'trump' older sources, but the corpus of material from previous editions is substantial enough that it gives me pause. How can we resolve this conundrum? Should we?